### PR TITLE
Update template handling to allow template inlining.

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -16,7 +16,7 @@ fi
 # Work out the GO version we are working with:
 GO_VERSION=$(go version | awk '{ print $3 }' | sed 's/go//')
 WANTED_VER=(1 8)
-if ! [[ "$GO_VERSION" =~ (.*)\.(.*) ]]; then
+if ! [[ "$GO_VERSION" =~ ([0-9]+)\.([0-9]+) ]]; then
     echo "Cannot figure out what version of Go is installed"
     exit 1
 elif ! (( ${BASH_REMATCH[1]} > ${WANTED_VER[0]} || ${BASH_REMATCH[2]} >= ${WANTED_VER[1]} )); then


### PR DESCRIPTION
Go's {{template "ID" .}} syntax should now work to pull in other templates
during the render process.  The backend has been updated to include the usual safety checks.