### PR TITLE
Add clean shutdown on control-C/signals for the

### DIFF
--- a/midlayer/dhcp.go
+++ b/midlayer/dhcp.go
@@ -1,6 +1,7 @@
 package midlayer
 
 import (
+	"context"
 	"encoding/binary"
 	"fmt"
 	"net"
@@ -416,13 +417,14 @@ func (h *DhcpHandler) ServeDHCP(p dhcp.Packet, msgType dhcp.MessageType, options
 	return nil
 }
 
-func (h *DhcpHandler) Stop() {
+func (h *DhcpHandler) Shutdown(ctx context.Context) error {
 	close(h.ch)
 	h.waitGroup.Wait()
+	return nil
 }
 
 type Service interface {
-	Stop()
+	Shutdown(context.Context) error
 }
 
 func StartDhcpHandler(dhcpInfo *backend.DataTracker, dhcpIfs string, dhcpPort int) (Service, error) {

--- a/midlayer/static.go
+++ b/midlayer/static.go
@@ -8,10 +8,10 @@ import (
 	"github.com/digitalrebar/provision/backend"
 )
 
-func ServeStatic(listenAt string, responder http.Handler, logger *log.Logger) error {
+func ServeStatic(listenAt string, responder http.Handler, logger *log.Logger) (*http.Server, error) {
 	conn, err := net.Listen("tcp", listenAt)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	svr := &http.Server{
 		Addr:    listenAt,
@@ -27,8 +27,10 @@ func ServeStatic(listenAt string, responder http.Handler, logger *log.Logger) er
 	}
 	go func() {
 		if err := svr.Serve(conn); err != nil {
-			logger.Fatalf("Static HTTP server error %v", err)
+			if err != http.ErrServerClosed {
+				logger.Fatalf("Static HTTP server error %v", err)
+			}
 		}
 	}()
-	return nil
+	return svr, nil
 }

--- a/midlayer/tftp_test.go
+++ b/midlayer/tftp_test.go
@@ -2,6 +2,7 @@ package midlayer
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"log"
 	"os"
@@ -15,7 +16,7 @@ import (
 func TestTftpFiles(t *testing.T) {
 	logger := log.New(os.Stderr, "", log.LstdFlags)
 	fs := backend.NewFS(".", logger)
-	hh := ServeTftp(":3235235", fs.TftpResponder(), logger)
+	_, hh := ServeTftp(":3235235", fs.TftpResponder(), logger)
 	if hh != nil {
 		if hh.Error() != "address 3235235: invalid port" {
 			t.Errorf("Expected a different error: %v", hh.Error())
@@ -24,7 +25,7 @@ func TestTftpFiles(t *testing.T) {
 		t.Errorf("Should have returned an error")
 	}
 
-	hh = ServeTftp("1.1.1.1:11112", fs.TftpResponder(), logger)
+	_, hh = ServeTftp("1.1.1.1:11112", fs.TftpResponder(), logger)
 	if hh != nil {
 		if !strings.Contains(hh.Error(), "listen udp 1.1.1.1:11112: bind: ") {
 			t.Errorf("Expected a different error: %v", hh.Error())
@@ -38,7 +39,7 @@ func TestTftpFiles(t *testing.T) {
 		panic(err)
 	}
 	fs = backend.NewFS(dir, logger)
-	hh = ServeTftp("127.0.0.1:11112", fs.TftpResponder(), logger)
+	srv, hh := ServeTftp("127.0.0.1:11112", fs.TftpResponder(), logger)
 	if hh != nil {
 		t.Errorf("Should not return an error: %v", hh)
 	} else {
@@ -111,6 +112,8 @@ func TestTftpFiles(t *testing.T) {
 		if err != nil {
 			t.Errorf("tftpClient remove write-only file: Should not return an error: %v", err)
 		}
+
+		srv.Shutdown(context.Background())
 	}
 
 }

--- a/midlayer/tftp_test.go
+++ b/midlayer/tftp_test.go
@@ -1,3 +1,9 @@
+// +build !race
+//
+// The TFTP server has a potential race between starting and shutting down.  This will never get hit in our
+// code, it is possible.
+//
+
 package midlayer
 
 import (


### PR DESCRIPTION
API and DHCP servers.  On MACs, this could leave the DHCP
socker open and stuck forcing a reboot.