### PR TITLE
Make template rendering avoid inadvertent data leaks

### DIFF
--- a/backend/renderData_test.go
+++ b/backend/renderData_test.go
@@ -152,7 +152,7 @@ func TestRenderData(t *testing.T) {
 	}
 
 	// Test the render functions directly.
-	rd := dt.NewRenderData(nil, nil)
+	rd := newRenderData(dt, nil, nil)
 
 	// Test ParseUrl - independent of Machine and Env
 	s, e := rd.ParseUrl("scheme", "http://192.168.0.%31:8080/")
@@ -261,7 +261,7 @@ func TestRenderData(t *testing.T) {
 	}
 
 	// Tests with machine and bootenv (has bad BootParams)
-	rd = dt.NewRenderData(machine, badBootEnv)
+	rd = newRenderData(dt, machine, badBootEnv)
 	_, e = rd.Param("bogus")
 	if e == nil {
 		t.Errorf("Param should return an error when machine is not defined in RenderData\n")


### PR DESCRIPTION
This refactors how renderData works to avoid inadvertent leaks between
the environment where the bootenvs, machines, and templates are
created and the time they are rendered.  Now, render time explicitly
reloads all pertinent data, which ensures that it always works with
the most current versions of the objects in question.

All that is left to do at object change time is register and
deregister paths and their associated callbacks in the overlay
filesystem.

Also added appropriate hooks to ensure that all appropriate paths are
rerendered when a bootenv changes