### PR TITLE
This updates the CLI to talk a single string on create operations

### DIFF
--- a/cli/bootenv.go
+++ b/cli/bootenv.go
@@ -82,7 +82,11 @@ func (be BootEnvOps) Get(id string) (interface{}, error) {
 func (be BootEnvOps) Create(obj interface{}) (interface{}, error) {
 	bootenv, ok := obj.(*models.BootEnv)
 	if !ok {
-		return nil, fmt.Errorf("Invalid type passed to bootenv create")
+		name, ok := obj.(string)
+		if !ok {
+			return nil, fmt.Errorf("Invalid type passed to bootenv create")
+		}
+		bootenv = &models.BootEnv{Name: &name}
 	}
 	d, e := session.BootEnvs.CreateBootEnv(bootenvs.NewCreateBootEnvParams().WithBody(bootenv), basicAuth)
 	if e != nil {

--- a/cli/bootenv_test.go
+++ b/cli/bootenv_test.go
@@ -93,8 +93,8 @@ var bootEnvExistsMissingJohnString string = "Error: bootenvs GET: john: Not Foun
 
 var bootEnvCreateNoArgErrorString string = "Error: drpcli bootenvs create [json] requires 1 argument\n"
 var bootEnvCreateTooManyArgErrorString string = "Error: drpcli bootenvs create [json] requires 1 argument\n"
-var bootEnvCreateBadJSONString = "asdgasdg"
-var bootEnvCreateBadJSONErrorString = "Error: Invalid bootenv object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.BootEnv\n\n"
+var bootEnvCreateBadJSONString = "{asdgasdg}"
+var bootEnvCreateBadJSONErrorString = "Error: dataTracker create bootenvs: Empty key not allowed\n\n"
 var bootEnvCreateInputString string = `{
   "name": "john"
 }
@@ -117,6 +117,26 @@ var bootEnvCreateJohnString string = `{
   "Templates": null
 }
 `
+var bootEnvCreateFredInputString string = `fred`
+var bootEnvCreateFredString string = `{
+  "Available": false,
+  "BootParams": "",
+  "Errors": [
+    "bootenv: Missing elilo or pxelinux template"
+  ],
+  "Initrds": null,
+  "Kernel": "",
+  "Name": "fred",
+  "OS": {
+    "Name": ""
+  },
+  "OnlyUnknown": false,
+  "OptionalParams": null,
+  "RequiredParams": null,
+  "Templates": null
+}
+`
+var bootEnvDeleteFredString string = "Deleted bootenv fred\n"
 var bootEnvCreateDuplicateErrorString = "Error: dataTracker create bootenvs: john already exists\n\n"
 
 var bootEnvListBothEnvsString = `[
@@ -386,6 +406,8 @@ func TestBootEnvCli(t *testing.T) {
 		CliTest{true, true, []string{"bootenvs", "create", "john", "john2"}, noStdinString, noContentString, bootEnvCreateTooManyArgErrorString},
 		CliTest{false, true, []string{"bootenvs", "create", bootEnvCreateBadJSONString}, noStdinString, noContentString, bootEnvCreateBadJSONErrorString},
 		CliTest{false, false, []string{"bootenvs", "create", bootEnvCreateInputString}, noStdinString, bootEnvCreateJohnString, noErrorString},
+		CliTest{false, false, []string{"bootenvs", "create", bootEnvCreateFredInputString}, noStdinString, bootEnvCreateFredString, noErrorString},
+		CliTest{false, false, []string{"bootenvs", "destroy", bootEnvCreateFredInputString}, noStdinString, bootEnvDeleteFredString, noErrorString},
 		CliTest{false, true, []string{"bootenvs", "create", bootEnvCreateInputString}, noStdinString, noContentString, bootEnvCreateDuplicateErrorString},
 		CliTest{false, false, []string{"bootenvs", "list"}, noStdinString, bootEnvListBothEnvsString, noErrorString},
 

--- a/cli/lease_test.go
+++ b/cli/lease_test.go
@@ -29,7 +29,7 @@ var leaseExistsMissingJohnString string = "Error: leases GET: C0A8646F: Not Foun
 var leaseCreateNoArgErrorString string = "Error: drpcli leases create [json] requires 1 argument\n"
 var leaseCreateTooManyArgErrorString string = "Error: drpcli leases create [json] requires 1 argument\n"
 var leaseCreateBadJSONString = "asdgasdg"
-var leaseCreateBadJSONErrorString = "Error: Invalid lease object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.Lease\n\n"
+var leaseCreateBadJSONErrorString = "Error: Unable to create new lease: Invalid type passed to lease create\n\n"
 var leaseCreateInputString string = `{
   "Addr": "192.168.100.110",
   "ExpireTime": "2017-03-31T00:11:21.028-05:00",

--- a/cli/machines.go
+++ b/cli/machines.go
@@ -77,7 +77,12 @@ func (be MachineOps) Get(id string) (interface{}, error) {
 func (be MachineOps) Create(obj interface{}) (interface{}, error) {
 	machine, ok := obj.(*models.Machine)
 	if !ok {
-		return nil, fmt.Errorf("Invalid type passed to machine create")
+		name, ok := obj.(string)
+		if !ok {
+			return nil, fmt.Errorf("Invalid type passed to machine create")
+		}
+		hostname := strfmt.Hostname(name)
+		machine = &models.Machine{Name: &hostname}
 	}
 	d, e := session.Machines.CreateMachine(machines.NewCreateMachineParams().WithBody(machine), basicAuth)
 	if e != nil {

--- a/cli/machines_test.go
+++ b/cli/machines_test.go
@@ -37,8 +37,10 @@ var machineExistsMissingJohnString string = "Error: machines GET: john: Not Foun
 
 var machineCreateNoArgErrorString string = "Error: drpcli machines create [json] requires 1 argument\n"
 var machineCreateTooManyArgErrorString string = "Error: drpcli machines create [json] requires 1 argument\n"
-var machineCreateBadJSONString = "asdgasdg"
-var machineCreateBadJSONErrorString = "Error: Invalid machine object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.Machine\n\n"
+var machineCreateBadJSONString = "{asdgasdg"
+var machineCreateBadJSONErrorString = "Error: Invalid machine object: error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}' and error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}'\n\n"
+var machineCreateBadJSON2String = "[asdgasdg]"
+var machineCreateBadJSON2ErrorString = "Error: Unable to create new machine: Invalid type passed to machine create\n\n"
 var machineCreateInputString string = `{
   "Address": "192.168.100.110",
   "name": "john",
@@ -58,6 +60,7 @@ var machineCreateJohnString string = `{
   "Uuid": "3e7031fe-3062-45f1-835c-92541bc9cbd3"
 }
 `
+
 var machineCreateDuplicateErrorString = "Error: dataTracker create machines: 3e7031fe-3062-45f1-835c-92541bc9cbd3 already exists\n\n"
 
 var machineListMachinesString = `[
@@ -280,6 +283,7 @@ func TestMachineCli(t *testing.T) {
 		CliTest{true, true, []string{"machines", "create"}, noStdinString, noContentString, machineCreateNoArgErrorString},
 		CliTest{true, true, []string{"machines", "create", "john", "john2"}, noStdinString, noContentString, machineCreateTooManyArgErrorString},
 		CliTest{false, true, []string{"machines", "create", machineCreateBadJSONString}, noStdinString, noContentString, machineCreateBadJSONErrorString},
+		CliTest{false, true, []string{"machines", "create", machineCreateBadJSON2String}, noStdinString, noContentString, machineCreateBadJSON2ErrorString},
 		CliTest{false, false, []string{"machines", "create", machineCreateInputString}, noStdinString, machineCreateJohnString, noErrorString},
 		CliTest{false, true, []string{"machines", "create", machineCreateInputString}, noStdinString, noContentString, machineCreateDuplicateErrorString},
 		CliTest{false, false, []string{"machines", "list"}, noStdinString, machineListMachinesString, noErrorString},

--- a/cli/profiles.go
+++ b/cli/profiles.go
@@ -67,7 +67,11 @@ func (be ProfileOps) Get(id string) (interface{}, error) {
 func (be ProfileOps) Create(obj interface{}) (interface{}, error) {
 	profile, ok := obj.(*models.Profile)
 	if !ok {
-		return nil, fmt.Errorf("Invalid type passed to profile create")
+		profName, ok := obj.(string)
+		if !ok {
+			return nil, fmt.Errorf("Invalid type passed to profile create")
+		}
+		profile = &models.Profile{Name: &profName}
 	}
 	d, e := session.Profiles.CreateProfile(profiles.NewCreateProfileParams().WithBody(profile), basicAuth)
 	if e != nil {

--- a/cli/profiles_test.go
+++ b/cli/profiles_test.go
@@ -31,8 +31,10 @@ var profileExistsMissingJohnString string = "Error: profiles GET: john2: Not Fou
 
 var profileCreateNoArgErrorString string = "Error: drpcli profiles create [json] requires 1 argument\n"
 var profileCreateTooManyArgErrorString string = "Error: drpcli profiles create [json] requires 1 argument\n"
-var profileCreateBadJSONString = "asdgasdg"
-var profileCreateBadJSONErrorString = "Error: Invalid profile object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.Profile\n\n"
+var profileCreateBadJSONString = "{asdgasdg"
+var profileCreateBadJSONErrorString = "Error: Invalid profile object: error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}' and error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}'\n\n"
+var profileCreateBadJSON2String = "[asdgasdg]"
+var profileCreateBadJSON2ErrorString = "Error: Unable to create new profile: Invalid type passed to profile create\n\n"
 var profileCreateInputString string = `{
   "Name": "john",
   "Params": {
@@ -176,6 +178,7 @@ func TestProfileCli(t *testing.T) {
 		CliTest{true, true, []string{"profiles", "create"}, noStdinString, noContentString, profileCreateNoArgErrorString},
 		CliTest{true, true, []string{"profiles", "create", "john", "john2"}, noStdinString, noContentString, profileCreateTooManyArgErrorString},
 		CliTest{false, true, []string{"profiles", "create", profileCreateBadJSONString}, noStdinString, noContentString, profileCreateBadJSONErrorString},
+		CliTest{false, true, []string{"profiles", "create", profileCreateBadJSON2String}, noStdinString, noContentString, profileCreateBadJSON2ErrorString},
 		CliTest{false, false, []string{"profiles", "create", profileCreateInputString}, noStdinString, profileCreateJohnString, noErrorString},
 		CliTest{false, true, []string{"profiles", "create", profileCreateInputString}, noStdinString, noContentString, profileCreateDuplicateErrorString},
 		CliTest{false, false, []string{"profiles", "list"}, noStdinString, profileListProfilesString, noErrorString},

--- a/cli/reservation_test.go
+++ b/cli/reservation_test.go
@@ -30,7 +30,7 @@ var reservationExistsMissingIgnoreString string = "Error: reservation get: addre
 var reservationCreateNoArgErrorString string = "Error: drpcli reservations create [json] requires 1 argument\n"
 var reservationCreateTooManyArgErrorString string = "Error: drpcli reservations create [json] requires 1 argument\n"
 var reservationCreateBadJSONString = "asdgasdg"
-var reservationCreateBadJSONErrorString = "Error: Invalid reservation object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.Reservation\n\n"
+var reservationCreateBadJSONErrorString = "Error: Unable to create new reservation: Invalid type passed to reservation create\n\n"
 var reservationCreateInputString string = `{
   "Addr": "192.168.100.100",
   "NextServer": "2.2.2.2",

--- a/cli/subnet_test.go
+++ b/cli/subnet_test.go
@@ -49,7 +49,7 @@ var subnetExistsMissingIgnoreString string = "Error: subnets GET: ignore: Not Fo
 var subnetCreateNoArgErrorString string = "Error: drpcli subnets create [json] requires 1 argument\n"
 var subnetCreateTooManyArgErrorString string = "Error: drpcli subnets create [json] requires 1 argument\n"
 var subnetCreateBadJSONString = "asdgasdg"
-var subnetCreateBadJSONErrorString = "Error: Invalid subnet object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.Subnet\n\n"
+var subnetCreateBadJSONErrorString = "Error: Unable to create new subnet: Invalid type passed to subnet create\n\n"
 var subnetCreateInputString string = `{
   "Name": "john",
   "ActiveEnd": "192.168.100.100",

--- a/cli/template_test.go
+++ b/cli/template_test.go
@@ -42,7 +42,7 @@ var templateExistsMissingIgnoreString string = "Error: templates GET: ignore: No
 var templateCreateNoArgErrorString string = "Error: drpcli templates create [json] requires 1 argument\n"
 var templateCreateTooManyArgErrorString string = "Error: drpcli templates create [json] requires 1 argument\n"
 var templateCreateBadJSONString = "asdgasdg"
-var templateCreateBadJSONErrorString = "Error: Invalid template object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.Template\n\n"
+var templateCreateBadJSONErrorString = "Error: Unable to create new template: Invalid type passed to template create\n\n"
 var templateCreateInputString string = `{
   "Contents": "John Rules",
   "ID": "john"

--- a/cli/user.go
+++ b/cli/user.go
@@ -67,7 +67,11 @@ func (be UserOps) Get(id string) (interface{}, error) {
 func (be UserOps) Create(obj interface{}) (interface{}, error) {
 	user, ok := obj.(*models.User)
 	if !ok {
-		return nil, fmt.Errorf("Invalid type passed to user create")
+		name, ok := obj.(string)
+		if !ok {
+			return nil, fmt.Errorf("Invalid type passed to user create")
+		}
+		user = &models.User{Name: &name}
 	}
 	d, e := session.Users.CreateUser(users.NewCreateUserParams().WithBody(user), basicAuth)
 	if e != nil {

--- a/cli/user_test.go
+++ b/cli/user_test.go
@@ -27,8 +27,10 @@ var userExistsMissingIgnoreString string = "Error: users GET: ignore: Not Found\
 
 var userCreateNoArgErrorString string = "Error: drpcli users create [json] requires 1 argument\n"
 var userCreateTooManyArgErrorString string = "Error: drpcli users create [json] requires 1 argument\n"
-var userCreateBadJSONString = "asdgasdg"
-var userCreateBadJSONErrorString = "Error: Invalid user object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.User\n\n"
+var userCreateBadJSONString = "{asdgasdg"
+var userCreateBadJSONErrorString = "Error: Invalid user object: error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}' and error converting YAML to JSON: yaml: line 1: did not find expected ',' or '}'\n\n"
+var userCreateBadJSON2String = "[asdgasdg]"
+var userCreateBadJSON2ErrorString = "Error: Unable to create new user: Invalid type passed to user create\n\n"
 var userCreateInputString string = `{
   "Name": "john"
 }
@@ -37,6 +39,12 @@ var userCreateJohnString string = `{
   "Name": "john"
 }
 `
+var userCreateFredInputString string = `fred`
+var userCreateFredString string = `{
+  "Name": "fred"
+}
+`
+var userDestroyFredString string = "Deleted user fred\n"
 var userCreateDuplicateErrorString = "Error: dataTracker create users: john already exists\n\n"
 
 var userListJohnOnlyString = `[
@@ -118,7 +126,10 @@ func TestUserCli(t *testing.T) {
 		CliTest{true, true, []string{"users", "create"}, noStdinString, noContentString, userCreateNoArgErrorString},
 		CliTest{true, true, []string{"users", "create", "john", "john2"}, noStdinString, noContentString, userCreateTooManyArgErrorString},
 		CliTest{false, true, []string{"users", "create", userCreateBadJSONString}, noStdinString, noContentString, userCreateBadJSONErrorString},
+		CliTest{false, true, []string{"users", "create", userCreateBadJSON2String}, noStdinString, noContentString, userCreateBadJSON2ErrorString},
 		CliTest{false, false, []string{"users", "create", userCreateInputString}, noStdinString, userCreateJohnString, noErrorString},
+		CliTest{false, false, []string{"users", "create", userCreateFredInputString}, noStdinString, userCreateFredString, noErrorString},
+		CliTest{false, false, []string{"users", "destroy", userCreateFredInputString}, noStdinString, userDestroyFredString, noErrorString},
 		CliTest{false, true, []string{"users", "create", userCreateInputString}, noStdinString, noContentString, userCreateDuplicateErrorString},
 		CliTest{false, false, []string{"users", "list"}, noStdinString, userListBothEnvsString, noErrorString},
 

--- a/doc/cli/drpcli_bootenvs.rst
+++ b/doc/cli/drpcli_bootenvs.rst
@@ -26,7 +26,7 @@ SEE ALSO
 -  `drpcli <drpcli.html>`__ - A CLI application for interacting with the
    DigitalRebar Provision API
 -  `drpcli bootenvs create <drpcli_bootenvs_create.html>`__ - Create a
-   new bootenv with the passed-in JSON
+   new bootenv with the passed-in JSON or string key
 -  `drpcli bootenvs destroy <drpcli_bootenvs_destroy.html>`__ - Destroy
    bootenv by id
 -  `drpcli bootenvs exists <drpcli_bootenvs_exists.html>`__ - See if a

--- a/doc/cli/drpcli_bootenvs_create.rst
+++ b/doc/cli/drpcli_bootenvs_create.rst
@@ -1,13 +1,17 @@
 drpcli bootenvs create
 ======================
 
-Create a new bootenv with the passed-in JSON
+Create a new bootenv with the passed-in JSON or string key
 
 Synopsis
 --------
 
 As a useful shortcut, you can pass '-' to indicate that the JSON should
-be read from stdin
+be read from stdin.
+
+In either case, for the Machine, BootEnv, User, and Profile objects, a
+string may be provided to create a new empty object of that type. For
+User, BootEnv, Machine, and Profile, it will be the object's name.
 
 ::
 

--- a/doc/cli/drpcli_leases.rst
+++ b/doc/cli/drpcli_leases.rst
@@ -26,7 +26,7 @@ SEE ALSO
 -  `drpcli <drpcli.html>`__ - A CLI application for interacting with the
    DigitalRebar Provision API
 -  `drpcli leases create <drpcli_leases_create.html>`__ - Create a new
-   lease with the passed-in JSON
+   lease with the passed-in JSON or string key
 -  `drpcli leases destroy <drpcli_leases_destroy.html>`__ - Destroy
    lease by id
 -  `drpcli leases exists <drpcli_leases_exists.html>`__ - See if a lease

--- a/doc/cli/drpcli_leases_create.rst
+++ b/doc/cli/drpcli_leases_create.rst
@@ -1,13 +1,17 @@
 drpcli leases create
 ====================
 
-Create a new lease with the passed-in JSON
+Create a new lease with the passed-in JSON or string key
 
 Synopsis
 --------
 
 As a useful shortcut, you can pass '-' to indicate that the JSON should
-be read from stdin
+be read from stdin.
+
+In either case, for the Machine, BootEnv, User, and Profile objects, a
+string may be provided to create a new empty object of that type. For
+User, BootEnv, Machine, and Profile, it will be the object's name.
 
 ::
 

--- a/doc/cli/drpcli_machines.rst
+++ b/doc/cli/drpcli_machines.rst
@@ -30,7 +30,7 @@ SEE ALSO
 -  `drpcli machines bootenv <drpcli_machines_bootenv.html>`__ - Set the
    machine's bootenv
 -  `drpcli machines create <drpcli_machines_create.html>`__ - Create a
-   new machine with the passed-in JSON
+   new machine with the passed-in JSON or string key
 -  `drpcli machines destroy <drpcli_machines_destroy.html>`__ - Destroy
    machine by id
 -  `drpcli machines exists <drpcli_machines_exists.html>`__ - See if a

--- a/doc/cli/drpcli_machines_create.rst
+++ b/doc/cli/drpcli_machines_create.rst
@@ -1,13 +1,17 @@
 drpcli machines create
 ======================
 
-Create a new machine with the passed-in JSON
+Create a new machine with the passed-in JSON or string key
 
 Synopsis
 --------
 
 As a useful shortcut, you can pass '-' to indicate that the JSON should
-be read from stdin
+be read from stdin.
+
+In either case, for the Machine, BootEnv, User, and Profile objects, a
+string may be provided to create a new empty object of that type. For
+User, BootEnv, Machine, and Profile, it will be the object's name.
 
 ::
 

--- a/doc/cli/drpcli_profiles.rst
+++ b/doc/cli/drpcli_profiles.rst
@@ -26,7 +26,7 @@ SEE ALSO
 -  `drpcli <drpcli.html>`__ - A CLI application for interacting with the
    DigitalRebar Provision API
 -  `drpcli profiles create <drpcli_profiles_create.html>`__ - Create a
-   new profile with the passed-in JSON
+   new profile with the passed-in JSON or string key
 -  `drpcli profiles destroy <drpcli_profiles_destroy.html>`__ - Destroy
    profile by id
 -  `drpcli profiles exists <drpcli_profiles_exists.html>`__ - See if a

--- a/doc/cli/drpcli_profiles_create.rst
+++ b/doc/cli/drpcli_profiles_create.rst
@@ -1,13 +1,17 @@
 drpcli profiles create
 ======================
 
-Create a new profile with the passed-in JSON
+Create a new profile with the passed-in JSON or string key
 
 Synopsis
 --------
 
 As a useful shortcut, you can pass '-' to indicate that the JSON should
-be read from stdin
+be read from stdin.
+
+In either case, for the Machine, BootEnv, User, and Profile objects, a
+string may be provided to create a new empty object of that type. For
+User, BootEnv, Machine, and Profile, it will be the object's name.
 
 ::
 

--- a/doc/cli/drpcli_reservations.rst
+++ b/doc/cli/drpcli_reservations.rst
@@ -26,7 +26,7 @@ SEE ALSO
 -  `drpcli <drpcli.html>`__ - A CLI application for interacting with the
    DigitalRebar Provision API
 -  `drpcli reservations create <drpcli_reservations_create.html>`__ -
-   Create a new reservation with the passed-in JSON
+   Create a new reservation with the passed-in JSON or string key
 -  `drpcli reservations destroy <drpcli_reservations_destroy.html>`__ -
    Destroy reservation by id
 -  `drpcli reservations exists <drpcli_reservations_exists.html>`__ -

--- a/doc/cli/drpcli_reservations_create.rst
+++ b/doc/cli/drpcli_reservations_create.rst
@@ -1,13 +1,17 @@
 drpcli reservations create
 ==========================
 
-Create a new reservation with the passed-in JSON
+Create a new reservation with the passed-in JSON or string key
 
 Synopsis
 --------
 
 As a useful shortcut, you can pass '-' to indicate that the JSON should
-be read from stdin
+be read from stdin.
+
+In either case, for the Machine, BootEnv, User, and Profile objects, a
+string may be provided to create a new empty object of that type. For
+User, BootEnv, Machine, and Profile, it will be the object's name.
 
 ::
 

--- a/doc/cli/drpcli_subnets.rst
+++ b/doc/cli/drpcli_subnets.rst
@@ -26,7 +26,7 @@ SEE ALSO
 -  `drpcli <drpcli.html>`__ - A CLI application for interacting with the
    DigitalRebar Provision API
 -  `drpcli subnets create <drpcli_subnets_create.html>`__ - Create a new
-   subnet with the passed-in JSON
+   subnet with the passed-in JSON or string key
 -  `drpcli subnets destroy <drpcli_subnets_destroy.html>`__ - Destroy
    subnet by id
 -  `drpcli subnets exists <drpcli_subnets_exists.html>`__ - See if a

--- a/doc/cli/drpcli_subnets_create.rst
+++ b/doc/cli/drpcli_subnets_create.rst
@@ -1,13 +1,17 @@
 drpcli subnets create
 =====================
 
-Create a new subnet with the passed-in JSON
+Create a new subnet with the passed-in JSON or string key
 
 Synopsis
 --------
 
 As a useful shortcut, you can pass '-' to indicate that the JSON should
-be read from stdin
+be read from stdin.
+
+In either case, for the Machine, BootEnv, User, and Profile objects, a
+string may be provided to create a new empty object of that type. For
+User, BootEnv, Machine, and Profile, it will be the object's name.
 
 ::
 

--- a/doc/cli/drpcli_templates.rst
+++ b/doc/cli/drpcli_templates.rst
@@ -26,7 +26,7 @@ SEE ALSO
 -  `drpcli <drpcli.html>`__ - A CLI application for interacting with the
    DigitalRebar Provision API
 -  `drpcli templates create <drpcli_templates_create.html>`__ - Create a
-   new template with the passed-in JSON
+   new template with the passed-in JSON or string key
 -  `drpcli templates destroy <drpcli_templates_destroy.html>`__ -
    Destroy template by id
 -  `drpcli templates exists <drpcli_templates_exists.html>`__ - See if a

--- a/doc/cli/drpcli_templates_create.rst
+++ b/doc/cli/drpcli_templates_create.rst
@@ -1,13 +1,17 @@
 drpcli templates create
 =======================
 
-Create a new template with the passed-in JSON
+Create a new template with the passed-in JSON or string key
 
 Synopsis
 --------
 
 As a useful shortcut, you can pass '-' to indicate that the JSON should
-be read from stdin
+be read from stdin.
+
+In either case, for the Machine, BootEnv, User, and Profile objects, a
+string may be provided to create a new empty object of that type. For
+User, BootEnv, Machine, and Profile, it will be the object's name.
 
 ::
 

--- a/doc/cli/drpcli_users.rst
+++ b/doc/cli/drpcli_users.rst
@@ -26,7 +26,7 @@ SEE ALSO
 -  `drpcli <drpcli.html>`__ - A CLI application for interacting with the
    DigitalRebar Provision API
 -  `drpcli users create <drpcli_users_create.html>`__ - Create a new
-   user with the passed-in JSON
+   user with the passed-in JSON or string key
 -  `drpcli users destroy <drpcli_users_destroy.html>`__ - Destroy user
    by id
 -  `drpcli users exists <drpcli_users_exists.html>`__ - See if a user

--- a/doc/cli/drpcli_users_create.rst
+++ b/doc/cli/drpcli_users_create.rst
@@ -1,13 +1,17 @@
 drpcli users create
 ===================
 
-Create a new user with the passed-in JSON
+Create a new user with the passed-in JSON or string key
 
 Synopsis
 --------
 
 As a useful shortcut, you can pass '-' to indicate that the JSON should
-be read from stdin
+be read from stdin.
+
+In either case, for the Machine, BootEnv, User, and Profile objects, a
+string may be provided to create a new empty object of that type. For
+User, BootEnv, Machine, and Profile, it will be the object's name.
 
 ::
 

--- a/doc/operation.rst
+++ b/doc/operation.rst
@@ -26,7 +26,7 @@ Usually, you need to get or set the preferences for your system.
   ::
 
     # Show the current preference settings
-    drpcli prefs list  
+    drpcli prefs list
 
     # Or get a specific one
     drpcli prefs get unknownBootEnv
@@ -43,7 +43,7 @@ Set a preference
     drpcli prefs set unknownBootEnv discovery defaultBootEnv sledgehammer
 
 The system does validate values to make sure they are sane, so watch for errors.
-  
+
 Installing a "Canned" BootEnv
 -----------------------------
 
@@ -61,7 +61,7 @@ This is a CLI helper that is not in the API that will read the provided YAML :re
 upload the included or referenced :ref:`rs_model_template` files (from the *templates* peer directory), upload
 the :ref:`rs_model_bootenv`, and check for an existing ISO in the ISO repository.  If an ISO is not present in
 the already uploaded list, it will check a local isos directory for the file.  If that is not present and the
-:ref:`rs_model_bootenv` contains a URL for the ISO, the ISO will attempt to be downloaded to the local isos 
+:ref:`rs_model_bootenv` contains a URL for the ISO, the ISO will attempt to be downloaded to the local isos
 directory and then uploaded into Digital Rebar Provision.  Once upload, the ISO is "exploded" for access by
 machines in the file server file system space.
 
@@ -75,7 +75,7 @@ inclusion, but for now let's just focus on basic "cut and paste" style editing.
   ::
 
     drpcli bootenvs show ubuntu-16.04-install --format yaml > new-file.yaml
-    # Edit the file 
+    # Edit the file
     #  change the Name field to something new. *MUST DO THIS*
     #  change the OS->Name field to something new if you don't want to sure the same iso directory.
     #  Edit other parameters as needed
@@ -83,6 +83,17 @@ inclusion, but for now let's just focus on basic "cut and paste" style editing.
 
 This is a shallow clone.  It will reuse the templates unless you explictly modify them.  You could use the *install*
 command, but any new templates would need to be added to a *templates* directoy in the current directory.
+
+Creating a BootEnv
+------------------
+
+You can additionally create an empty :ref:`rs_model_bootenv` by doing the following:
+
+  ::
+
+    drpcli bootenvs create emtpy_bootenv
+
+This :ref:`rs_model_bootenv` will not be *Available*, but will allow for additional editing.
 
 Editing a BootEnv
 -----------------
@@ -133,6 +144,63 @@ We use **jq** to get a copy of the current template, edit it, and use the upload
 If you aleady had a template, you could replace it with the upload command.
 
 
+Creating a Profile
+------------------
+
+Sometimes you want to create a :ref:`rs_model_profile`.  You can create an empty profile by doing the following:
+
+  ::
+
+    drpcli profiles create '{ "Name": "myprofile" }'
+
+    or
+
+    drpcli profiles create myprofile
+
+If you just send a string, the system will attempt to use that as the Name of the profile.
+
+Additionally, JSON can be provided to fill in some default values.
+
+  ::
+
+    drpcli profiles create '{ "Name": "myprofile", "Params": { "string_param1": "string", "map_parm1": { "key1": "value", "key2": "value2" } } }'
+
+
+Deleting a Profile
+------------------
+
+Sometimes you want to delete a :ref:`rs_model_profile`.  You can use the destroy command in the profile CLI,
+but the :ref:`rs_model_profile` must not be in use.  Use the following:
+
+  ::
+
+    drpcli profiles destroy myprofile
+
+
+Altering an Existing Profile (including global)
+-----------------------------------------------
+
+Somtimes you want to update an existing :ref:`rs_model_profile`, including **global**.  You can *set*
+parameter values by doing the following:
+
+  ::
+
+    drpcli profiles set myprofile param crazycat to true
+    # These last two will show the value or the whole profile.
+    drpcli profiles get myprofile param crazycat
+    drpcli profiles show myprofile
+
+.. note:: Setting a parameter's value to **null** will clear it from the structure.
+
+Alternatively, you can also use the update command and send raw JSON similar to create.
+
+  ::
+
+    drpcli profiles update myprofile '{ "Params": { "string_param1": "string", "map_parm1": { "key1": "value", "key2": "value2" }, "crazycat": null } }'
+
+Update is an additive operation by default.  So, to remove items, **null** must be passed as
+the value of the key you wish to remove.
+
 Creating a Machine
 ------------------
 
@@ -156,6 +224,48 @@ This would do the same thing as above, but would create the :ref:`rs_model_machi
 
 .. note:: The :ref:`rs_model_bootenv` MUST exist or the create will fail.
 
+To create an empty :ref:`rs_model_machine`, do the following:
+
+  ::
+
+    drpcli machine create jill.rackn.com
+
+This will create an empty :ref:`rs_model_machine` named *jill.rackn.com*.
+
+.. note:: The *defaultBootEnv* :ref:`rs_model_bootenv` MUST exist or the create will fail.
+
+
+Adding or Removing a Profile to a Machine
+-----------------------------------------
+
+Sometimes you want to add or remove a :ref:`rs_model_profile` to a :ref:`rs_model_machine`.  To add a profile, do the following:
+
+  ::
+
+    drpcli machines addprofile "dff3a693-76a7-49ce-baaa-773cbb6d5092" myprofile
+
+
+To remove a profile, do the following:
+
+  ::
+
+    drpcli machines removeprofile "dff3a693-76a7-49ce-baaa-773cbb6d5092" myprofile
+
+The :ref:`rs_model_machine` update command can also be used to modify the list of :ref:`rs_model_profile`.
+
+
+Changing BootEnv on a Machine
+-----------------------------
+
+Sometimes you want to change the :ref:`rs_model_bootenv` associated with a :ref:`rs_model_machine`.  To do this, do the following:
+
+  ::
+
+    drpcli machines bootenv drpcli "dff3a693-76a7-49ce-baaa-773cbb6d5092" mybootenv
+
+.. note:: The :ref:`rs_model_bootenv` *MUST* exists or the command will fail.
+
+
 Creating a Reservation
 ----------------------
 
@@ -166,7 +276,7 @@ a specific IP Adress.  Here is an example command.
 
      drpcli reservations create '{ "Addr": "1.1.1.1", "Token": "08:00:27:33:77:de", "Strategy": "MAC" }'
 
-You can additionally add DHCP options or the Next Boot server.  
+You can additionally add DHCP options or the Next Boot server.
 
   ::
 


### PR DESCRIPTION
for machines, bootenvs, users, and profiles.  This will create
empty objects with those names.

Update the docs and cli help to reflect this.

Also document addition profile and machine CLI options.