### PR TITLE
Fixed tooltips appearing under other buttons

### DIFF
--- a/embedded/assets/ui/app/dr-provision.css
+++ b/embedded/assets/ui/app/dr-provision.css
@@ -181,6 +181,7 @@ button:active {
 button:hover, button:focus {
   outline: none;
   box-shadow: 0 2px 4px #999;
+  z-index: 3;
 }
 
 button:hover > .tooltip, button:focus > .tooltip {


### PR DESCRIPTION
Before:

![image](https://user-images.githubusercontent.com/4142480/27544760-caac4692-5a53-11e7-88ec-eea7be6f25c9.png)

After:

![image](https://user-images.githubusercontent.com/4142480/27544698-90af5fec-5a53-11e7-8f14-cbf8e3225dde.png)
