### PR TITLE
Subnet Helpers

### DIFF
--- a/cli/subnet.go
+++ b/cli/subnet.go
@@ -2,10 +2,14 @@ package cli
 
 import (
 	"fmt"
+	"net"
+	"strconv"
+	"strings"
 
 	"github.com/digitalrebar/provision/backend"
 	"github.com/digitalrebar/provision/client/subnets"
 	"github.com/digitalrebar/provision/models"
+	"github.com/go-openapi/strfmt"
 	"github.com/spf13/cobra"
 )
 
@@ -117,7 +121,315 @@ func addSubnetCommands() (res *cobra.Command) {
 		Use:   name,
 		Short: fmt.Sprintf("Access CLI commands relating to %v", name),
 	}
-	commands := commonOps(&SubnetOps{CommonOps{Name: name, SingularName: singularName}})
+	op := &SubnetOps{CommonOps{Name: name, SingularName: singularName}}
+	commands := commonOps(op)
+
+	commands = append(commands, &cobra.Command{
+		Use:   "range [subnetName] [startIP] [endIP]",
+		Short: fmt.Sprintf("set the range of a subnet"),
+		Long:  `Helper function to set the range of a given subnet.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 3 {
+				return fmt.Errorf("%s requires 3 arguments", c.UseLine())
+			}
+			dumpUsage = false
+			subName := args[0]
+			StartAddr := args[1]
+			EndAddr := args[2]
+
+			d, err := session.Subnets.GetSubnet(subnets.NewGetSubnetParams().WithName(subName), basicAuth)
+			if err != nil {
+				return err
+			}
+			sub := d.Payload
+
+			var IPfirst strfmt.IPv4
+			e := IPfirst.Scan(StartAddr)
+			if e != nil {
+				return fmt.Errorf("%s is not a valid IPv4", StartAddr)
+			}
+
+			var IPlast strfmt.IPv4
+			e = IPlast.Scan(EndAddr)
+			if e != nil {
+				return fmt.Errorf("%s is not a valid IPv4", EndAddr)
+			}
+
+			sub.ActiveStart = &IPfirst
+			sub.ActiveEnd = &IPlast
+			_, err = session.Subnets.PutSubnet(subnets.NewPutSubnetParams().WithName(subName).WithBody(sub), basicAuth)
+			if err != nil {
+				return generateError(err, "Failed to post updated Subnet %v: %v", singularName, subName)
+			}
+			fmt.Printf("startIP: %s\nendIP: %s\n", *sub.ActiveStart, *sub.ActiveEnd)
+			return nil
+
+		},
+	})
+
+	commands = append(commands, &cobra.Command{
+		Use:   "subnet [subnetName] [subnet CIDR]",
+		Short: fmt.Sprintf("Set the CIDR network address"),
+		Long:  `Helper function to set the CIDR of a given subnet.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("%s requires 2 arguments", c.UseLine())
+			}
+			dumpUsage = false
+			subName := args[0]
+			CIDR := args[1]
+
+			d, e := session.Subnets.GetSubnet(subnets.NewGetSubnetParams().WithName(subName), basicAuth)
+			if e != nil {
+				return e
+			}
+			sub := d.Payload
+
+			_, _, e2 := net.ParseCIDR(CIDR)
+			if e2 != nil {
+				return fmt.Errorf("%s is not a valid subnet CIDR", CIDR)
+
+			}
+			sub.Subnet = &CIDR
+			_, e = session.Subnets.PutSubnet(subnets.NewPutSubnetParams().WithName(subName).WithBody(sub), basicAuth)
+			if e != nil {
+				return generateError(e, "Failed to post updated Subnet %s: %s", singularName, subName)
+			}
+			fmt.Printf("%s\n", *sub.Subnet)
+			return nil
+
+		},
+	})
+
+	commands = append(commands, &cobra.Command{
+		Use:   "strategy [subnetName] [MAC]",
+		Short: fmt.Sprintf("Set Subnet strategy"),
+		Long:  `Helper function to set the strategy of a given subnet.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("%s requires 2 arguments", c.UseLine())
+			}
+			dumpUsage = false
+			subName := args[0]
+			MACAddress := args[1]
+
+			d, e := session.Subnets.GetSubnet(subnets.NewGetSubnetParams().WithName(subName), basicAuth)
+			if e != nil {
+				return e
+			}
+			sub := d.Payload
+
+			_, e = net.ParseMAC(MACAddress)
+			if e != nil {
+				return fmt.Errorf("%s is not a valid MAC address", MACAddress)
+			}
+
+			sub.Strategy = &MACAddress
+
+			_, e = session.Subnets.PutSubnet(subnets.NewPutSubnetParams().WithName(subName).WithBody(sub), basicAuth)
+			if e != nil {
+				return generateError(e, "Failed to post updated Subnet %s: %s", singularName, subName)
+			}
+
+			fmt.Printf("%v\n", *sub.Strategy)
+			return nil
+		},
+	})
+
+	commands = append(commands, &cobra.Command{
+		Use:   "pickers [subnetName] [list]",
+		Short: fmt.Sprintf("assigns IP allocation methods to a subnet"),
+		Long:  `Helper function that accepts a string of methods to allocate IP addresses separated by commas`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("%v requires 2 arguments", c.UseLine())
+			}
+			dumpUsage = false
+			subName := args[0]
+			pickerString := args[1]
+
+			d, e := session.Subnets.GetSubnet(subnets.NewGetSubnetParams().WithName(subName), basicAuth)
+			if e != nil {
+				return e
+			}
+			sub := d.Payload
+
+			sub.Pickers = strings.Split(pickerString, ",")
+
+			_, e = session.Subnets.PutSubnet(subnets.NewPutSubnetParams().WithName(subName).WithBody(sub), basicAuth)
+			if e != nil {
+				return generateError(e, "Failed to post updated Subnet %v: %v", singularName, subName)
+			}
+
+			fmt.Printf(strings.Join(sub.Pickers, ", "))
+			return nil
+
+		},
+	})
+
+	commands = append(commands, &cobra.Command{
+		Use:   "nextserver [subnetName] [IP]",
+		Short: fmt.Sprintf("Set next non-reserved IP"),
+		Long:  `Helper function to set the first non-reserved IP of a subnet.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 2 {
+				return fmt.Errorf("%v requires 2 arguments", c.UseLine())
+			}
+			dumpUsage = false
+			subName := args[0]
+			IPAddr := args[1]
+
+			d, e := session.Subnets.GetSubnet(subnets.NewGetSubnetParams().WithName(subName), basicAuth)
+			if e != nil {
+				return e
+			}
+			sub := d.Payload
+
+			var nextIP strfmt.IPv4
+			e = nextIP.Scan(IPAddr)
+			if e != nil {
+				return fmt.Errorf("%v is not a valid IPv4", IPAddr)
+			}
+
+			sub.NextServer = &nextIP
+
+			_, e = session.Subnets.PutSubnet(subnets.NewPutSubnetParams().WithName(subName).WithBody(sub), basicAuth)
+			if e != nil {
+				return generateError(e, "Failed to post updated Subnet %v: %v", singularName, subName)
+			}
+
+			fmt.Printf("%v\n", *sub.NextServer)
+			return nil
+
+		},
+	})
+
+	commands = append(commands, &cobra.Command{
+		Use:   "leasetimes [subnetName] [active] [reserved]",
+		Short: fmt.Sprintf("Set the leasetimes of a subnet"),
+		Long:  `Helper function to get the range of a given subnet.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 3 {
+				return fmt.Errorf("%v requires 3 arguments", c.UseLine())
+			}
+			dumpUsage = false
+			subName := args[0]
+			activeTimeString := args[1]
+			reservedTimeString := args[2]
+
+			d, e := session.Subnets.GetSubnet(subnets.NewGetSubnetParams().WithName(subName), basicAuth)
+			if e != nil {
+				return e
+			}
+			sub := d.Payload
+
+			activeTime64Int, e := strconv.ParseInt(activeTimeString, 10, 32)
+			if e != nil {
+				return fmt.Errorf("%v could not be read as a number", activeTimeString)
+
+			}
+			activeTime := int32(activeTime64Int)
+
+			reservedTime64Int, e := strconv.ParseInt(reservedTimeString, 10, 32)
+			if e != nil {
+				return fmt.Errorf("%v could not be read as a number", reservedTimeString)
+
+			}
+			reservedTime := int32(reservedTime64Int)
+
+			sub.ActiveLeaseTime = &activeTime
+			sub.ReservedLeaseTime = &reservedTime
+
+			_, e = session.Subnets.PutSubnet(subnets.NewPutSubnetParams().WithName(subName).WithBody(sub), basicAuth)
+			if e != nil {
+				return generateError(e, "Failed to post updated Subnet %v: %v", singularName, subName)
+			}
+
+			fmt.Printf("Active Lease Times=%v\nReserved Lease Times=%v\n", *sub.ActiveLeaseTime, *sub.ReservedLeaseTime)
+			return nil
+
+		},
+	})
+
+	commands = append(commands, &cobra.Command{
+		Use:   "set [subnetName] option [number] to [value]",
+		Short: fmt.Sprintf("Set the given subnet's dhcpOption to a value"),
+		Long:  `Helper function that sets the specified dhcpOption from a given subnet to a value. If an option does not exist yet, it adds a new option`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 5 {
+				return fmt.Errorf("%v requires 5 arguments", c.UseLine())
+			}
+			dumpUsage = false
+			subName := args[0]
+			ChangedVal := args[2]
+			newVal := args[4]
+
+			d, e := session.Subnets.GetSubnet(subnets.NewGetSubnetParams().WithName(subName), basicAuth)
+			if e != nil {
+				return e
+			}
+			sub := d.Payload
+
+			changeVal, err := strconv.Atoi(ChangedVal)
+			if err != nil {
+				return fmt.Errorf("%v could not be read as a number", ChangedVal)
+
+			}
+
+			if changeVal >= len(sub.Options) {
+				for i := changeVal - len(sub.Options); i >= 0; i-- {
+					newOption := new(models.DhcpOption)
+					sub.Options = append(sub.Options, newOption)
+
+				}
+			}
+
+			sub.Options[changeVal] = &models.DhcpOption{
+				Value: &newVal,
+			}
+
+			_, e = session.Subnets.PutSubnet(subnets.NewPutSubnetParams().WithName(subName).WithBody(sub), basicAuth)
+			if e != nil {
+				return generateError(e, "Failed to post updated Subnet %v: %v", singularName, subName)
+			}
+
+			fmt.Printf("%v to %v\n", changeVal, *sub.Options[changeVal].Value)
+			return nil
+		},
+	})
+
+	commands = append(commands, &cobra.Command{
+		Use:   "get [subnetName] option [number]",
+		Short: fmt.Sprintf("Get dhcpOption [number]"),
+		Long:  `Helper function that gets the specified dhcpOption from a given subnet.`,
+		RunE: func(c *cobra.Command, args []string) error {
+			if len(args) != 3 {
+				return fmt.Errorf("%v requires 3 arguments", c.UseLine())
+			}
+			dumpUsage = false
+			subName := args[0]
+			gettingVal := args[2]
+
+			d, e := session.Subnets.GetSubnet(subnets.NewGetSubnetParams().WithName(subName), basicAuth)
+			if e != nil {
+				return e
+			}
+
+			getVal, err := strconv.Atoi(gettingVal)
+			if err != nil {
+				return fmt.Errorf("%v could not be read as a number", gettingVal)
+			}
+
+			sub := d.Payload
+			if len(sub.Options) <= getVal {
+				return fmt.Errorf("option %v does not exist", getVal)
+			}
+			fmt.Printf("Option %v: %v\n", getVal, *sub.Options[getVal].Value)
+			return nil
+
+		},
+	})
+
 	res.AddCommand(commands...)
 	return res
 }

--- a/cli/subnet_test.go
+++ b/cli/subnet_test.go
@@ -264,6 +264,47 @@ var subnetDestroyMissingJohnString string = "Error: subnets: DELETE john: Not Fo
 
 var subnetInvalidEnabledBooleanListString = "Error: Enabled must be true or false\n\n"
 
+var subnetRangeNoArgErrorString string = "Error: drpcli subnets range [subnetName] [startIP] [endIP] requires 3 arguments\n"
+var subnetRangeTooManyArgErrorString string = "Error: drpcli subnets range [subnetName] [startIP] [endIP] requires 3 arguments\n"
+var subnetRangeIPSuccessString string = "startIP: 192.168.100.10\nendIP: 192.168.100.200\n"
+
+var subnetRangeIPFailureString string = "Error: invalid IP address: cq.98.42.1234\n\n"
+var subnetRangeIPBadIpString string = "Error: invalid IP address: 192.168.100.500\n\n"
+
+var subnetSubnetNoArgErrorString string = "Error: drpcli subnets subnet [subnetName] [subnet CIDR] requires 2 arguments\n"
+var subnetSubnetTooManyArgErrorString string = "Error: drpcli subnets subnet [subnetName] [subnet CIDR] requires 2 arguments\n"
+var subnetSubnetCIDRSuccessString = "192.168.100.0/10\n"
+var subnetSubnetCIDRFailureString = "Error: 1111.11.2223.544/66666 is not a valid subnet CIDR\n\n"
+
+var subnetStrategyNoArgErrorString string = "Error: drpcli subnets strategy [subnetName] [MAC] requires 2 arguments\n"
+var subnetStrategyTooManyArgErrorString string = "Error: drpcli subnets strategy [subnetName] [MAC] requires 2 arguments\n"
+var subnetStrategyMacSuccessString string = "a3:b3:51:66:7e:11\n"
+var subnetStrategyMacFailureErrorString string = "Error: t5:44:llll:b is not a valid MAC address\n\n"
+
+var subnetPickersNoArgErrorString string = "Error: drpcli subnets pickers [subnetName] [list] requires 2 arguments\n"
+var subnetPickersTooManyArgErrorString string = "Error: drpcli subnets pickers [subnetName] [list] requires 2 arguments\n"
+var subnetPickersSuccessString string = "none, nextFree, mostExpired"
+
+var subnetNextserverNoArgErrorString string = "Error: drpcli subnets nextserver [subnetName] [IP] requires 2 arguments\n"
+var subnetNextserverTooManyArgErrorString string = "Error: drpcli subnets nextserver [subnetName] [IP] requires 2 arguments\n"
+var subnetNextserverIPSuccess string = "1.24.36.16\n"
+
+var subnetLeasetimesNoArgErrorString string = "Error: drpcli subnets leasetimes [subnetName] [active] [reserved] requires 3 arguments\n"
+var subnetLeasetimesTooManyArgErrorString string = "Error: drpcli subnets leasetimes [subnetName] [active] [reserved] requires 3 arguments\n"
+var subnetLeasetimesSuccessString string = "Active Lease Times=65\nReserved Lease Times=7300\n"
+var subnetLeasetimesIntFailureString string = "Error: 4x5 could not be read as a number\n\n"
+
+var subnetSetNoArgErrorString string = "Error: drpcli subnets set [subnetName] option [number] to [value] requires 5 arguments\n"
+var subnetSetTooManyArgErrorString string = "Error: drpcli subnets set [subnetName] option [number] to [value] requires 5 arguments\n"
+var subnetSetIntFailureErrorString string = "Error: 6tl could not be read as a number\n\n"
+var subnetSetTo66 string = "6 to 66\n"
+var subnetSetToNull string = "2 to null\n"
+
+var subnetGetNoArgErrorString string = "Error: drpcli subnets get [subnetName] option [number] requires 3 arguments\n"
+var subnetGetTooManyArgErrorString string = "Error: drpcli subnets get [subnetName] option [number] requires 3 arguments\n"
+var subnetGetTo66 string = "Option 6: 66\n"
+var subnetGetToNull string = "Option 2: null\n"
+
 func TestSubnetCli(t *testing.T) {
 	tests := []CliTest{
 		CliTest{true, false, []string{"subnets"}, noStdinString, "Access CLI commands relating to subnets\n", ""},
@@ -288,12 +329,12 @@ func TestSubnetCli(t *testing.T) {
 		CliTest{false, false, []string{"subnets", "list", "NextServer=3.3.3.3"}, noStdinString, subnetListBothEnvsString, noErrorString},
 		CliTest{false, false, []string{"subnets", "list", "NextServer=1.1.1.1"}, noStdinString, subnetEmptyListString, noErrorString},
 		CliTest{false, true, []string{"subnets", "list", "NextServer=fred"}, noStdinString, noContentString, subnetAddrErrorString},
-		CliTest{false, false, []string{"subnets", "list", "Subnet=192.168.103.0/24"}, noStdinString, subnetEmptyListString, noErrorString},
-		CliTest{false, false, []string{"subnets", "list", "Subnet=192.168.100.0/24"}, noStdinString, subnetListBothEnvsString, noErrorString},
-		CliTest{false, true, []string{"subnets", "list", "Subnet=false"}, noStdinString, noContentString, subnetExpireTimeErrorString},
 		CliTest{false, false, []string{"subnets", "list", "Enabled=false"}, noStdinString, subnetListBothEnvsString, noErrorString},
 		CliTest{false, false, []string{"subnets", "list", "Enabled=true"}, noStdinString, subnetEmptyListString, noErrorString},
 		CliTest{false, true, []string{"subnets", "list", "Enabled=george"}, noStdinString, noContentString, subnetInvalidEnabledBooleanListString},
+		CliTest{false, false, []string{"subnets", "list", "Subnet=192.168.103.0/24"}, noStdinString, subnetEmptyListString, noErrorString},
+		CliTest{false, false, []string{"subnets", "list", "Subnet=192.168.100.0/24"}, noStdinString, subnetListBothEnvsString, noErrorString},
+		CliTest{false, true, []string{"subnets", "list", "Subnet=false"}, noStdinString, noContentString, subnetExpireTimeErrorString},
 
 		CliTest{true, true, []string{"subnets", "show"}, noStdinString, noContentString, subnetShowNoArgErrorString},
 		CliTest{true, true, []string{"subnets", "show", "john", "john2"}, noStdinString, noContentString, subnetShowTooManyArgErrorString},
@@ -331,6 +372,47 @@ func TestSubnetCli(t *testing.T) {
 		CliTest{false, false, []string{"subnets", "list"}, noStdinString, subnetListBothEnvsString, noErrorString},
 		CliTest{false, false, []string{"subnets", "update", "john", "-"}, subnetUpdateInputString + "\n", subnetUpdateJohnString, noErrorString},
 		CliTest{false, false, []string{"subnets", "show", "john"}, noStdinString, subnetUpdateJohnString, noErrorString},
+
+		CliTest{true, true, []string{"subnets", "range"}, noStdinString, noContentString, subnetRangeNoArgErrorString},
+		CliTest{true, true, []string{"subnets", "range", "john", "1.24.36.7", "1.24.36.16", "1.24.36.16"}, noStdinString, noContentString, subnetRangeTooManyArgErrorString},
+		CliTest{false, true, []string{"subnets", "range", "john", "192.168.100.10", "192.168.100.500"}, noStdinString, noContentString, subnetRangeIPBadIpString},
+		CliTest{false, true, []string{"subnets", "range", "john", "cq.98.42.1234", "1.24.36.16"}, noStdinString, noContentString, subnetRangeIPFailureString},
+		CliTest{false, false, []string{"subnets", "range", "john", "192.168.100.10", "192.168.100.200"}, noStdinString, subnetRangeIPSuccessString, noErrorString},
+
+		CliTest{true, true, []string{"subnets", "subnet"}, noStdinString, noContentString, subnetSubnetNoArgErrorString},
+		CliTest{true, true, []string{"subnets", "subnet", "john", "june", "1.24.36.16"}, noStdinString, noContentString, subnetSubnetTooManyArgErrorString},
+		CliTest{false, false, []string{"subnets", "subnet", "john", "192.168.100.0/10"}, noStdinString, subnetSubnetCIDRSuccessString, noErrorString},
+		CliTest{false, true, []string{"subnets", "subnet", "john", "1111.11.2223.544/66666"}, noStdinString, noContentString, subnetSubnetCIDRFailureString},
+
+		CliTest{true, true, []string{"subnets", "strategy"}, noStdinString, noContentString, subnetStrategyNoArgErrorString},
+		CliTest{true, true, []string{"subnets", "strategy", "john", "june", "a3:b3:51:66:7e:11"}, noStdinString, noContentString, subnetStrategyTooManyArgErrorString},
+		CliTest{false, false, []string{"subnets", "strategy", "john", "a3:b3:51:66:7e:11"}, noStdinString, subnetStrategyMacSuccessString, noErrorString},
+		CliTest{false, true, []string{"subnets", "strategy", "john", "t5:44:llll:b"}, noStdinString, noContentString, subnetStrategyMacFailureErrorString},
+
+		CliTest{true, true, []string{"subnets", "pickers"}, noStdinString, noContentString, subnetPickersNoArgErrorString},
+		CliTest{true, true, []string{"subnets", "pickers", "john", "june", "test1,test2,test3"}, noStdinString, noContentString, subnetPickersTooManyArgErrorString},
+		CliTest{false, false, []string{"subnets", "pickers", "john", "none,nextFree,mostExpired"}, noStdinString, subnetPickersSuccessString, noErrorString},
+
+		CliTest{true, true, []string{"subnets", "nextserver"}, noStdinString, noContentString, subnetNextserverNoArgErrorString},
+		CliTest{true, true, []string{"subnets", "nextserver", "john", "june", "1.24.36.16"}, noStdinString, noContentString, subnetNextserverTooManyArgErrorString},
+		CliTest{false, false, []string{"subnets", "nextserver", "john", "1.24.36.16"}, noStdinString, subnetNextserverIPSuccess, noErrorString},
+
+		CliTest{true, true, []string{"subnets", "leasetimes"}, noStdinString, noContentString, subnetLeasetimesNoArgErrorString},
+		CliTest{true, true, []string{"subnets", "leasetimes", "john", "june", "32", "55"}, noStdinString, noContentString, subnetLeasetimesTooManyArgErrorString},
+		CliTest{false, false, []string{"subnets", "leasetimes", "john", "65", "7300"}, noStdinString, subnetLeasetimesSuccessString, noErrorString},
+		CliTest{false, true, []string{"subnets", "leasetimes", "john", "4x5", "55"}, noStdinString, noContentString, subnetLeasetimesIntFailureString},
+
+		CliTest{true, true, []string{"subnets", "set"}, noStdinString, noContentString, subnetSetNoArgErrorString},
+		CliTest{true, true, []string{"subnets", "set", "john", "option", "45", "to", "34", "77"}, noStdinString, noContentString, subnetSetTooManyArgErrorString},
+		CliTest{true, true, []string{"subnets", "get"}, noStdinString, noContentString, subnetGetNoArgErrorString},
+		CliTest{true, true, []string{"subnets", "get", "john", "option", "45", "77"}, noStdinString, noContentString, subnetGetTooManyArgErrorString},
+		CliTest{false, true, []string{"subnets", "set", "john", "option", "6tl", "to", "66"}, noStdinString, noContentString, subnetSetIntFailureErrorString},
+		CliTest{false, false, []string{"subnets", "set", "john", "option", "6", "to", "66"}, noStdinString, subnetSetTo66, noErrorString},
+		CliTest{false, false, []string{"subnets", "get", "john", "option", "6"}, noStdinString, subnetGetTo66, noErrorString},
+		CliTest{false, false, []string{"subnets", "set", "john", "option", "2", "to", "null"}, noStdinString, subnetSetToNull, noErrorString},
+		CliTest{false, false, []string{"subnets", "get", "john", "option", "2"}, noStdinString, subnetGetToNull, noErrorString},
+
+		//End of Helpers
 
 		CliTest{false, false, []string{"subnets", "destroy", "john"}, noStdinString, subnetDestroyJohnString, noErrorString},
 		CliTest{false, false, []string{"subnets", "list"}, noStdinString, subnetDefaultListString, noErrorString},

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -11,15 +11,16 @@ import (
 	"strings"
 
 	"github.com/VictorLowther/jsonpatch2"
-	"github.com/digitalrebar/store"
 	"github.com/digitalrebar/provision/backend"
 	"github.com/digitalrebar/provision/backend/index"
 	"github.com/digitalrebar/provision/embedded"
 	"github.com/digitalrebar/provision/plugin"
+	"github.com/digitalrebar/store"
 	assetfs "github.com/elazarl/go-bindata-assetfs"
 	"github.com/gin-contrib/cors"
 	"github.com/gin-contrib/location"
 	"github.com/gin-gonic/gin"
+	"github.com/gin-gonic/gin/binding"
 	"gopkg.in/olahol/melody.v1"
 )
 
@@ -279,7 +280,7 @@ func assureDecode(c *gin.Context, val interface{}) bool {
 	if !assureContentType(c, "application/json") {
 		return false
 	}
-	marshalErr := c.Bind(&val)
+	marshalErr := binding.JSON.Bind(c.Request, &val)
 	if marshalErr == nil {
 		return true
 	}


### PR DESCRIPTION
This is the completion of work started by @niemanme.

This adds as set of CLI helpers to set various subnet fields without
having to go through the json blob paths.

This also fixes a latent bug in the assureDecode code path.
GIN was sending 400 with strings and confusing the client on
bad json object.  This needs to use a lower level call to avoid
the GIN help.