### PR TITLE
fixes to demo and control scripts

### DIFF
--- a/examples/5min-drp/.gitignore
+++ b/examples/5min-drp/.gitignore
@@ -13,6 +13,7 @@ drpcli
 *.bak
 *.backup
 5min-drp-ssh-key*
+5min-node-ssh-key*
 packet-ipmi-plugin-create.json
 stagemap-create.json
 !private-content/secrets

--- a/examples/5min-drp/bin/drp-install.sh
+++ b/examples/5min-drp/bin/drp-install.sh
@@ -28,9 +28,11 @@ os_arch=`uname -i`
 os_type=${os_type,,}
 os_arch=${os_arch,,}
 
+# do not install content - let our outside orchestration handle that for us
+# as we may want CC (community content) or RackN  specific content
 set -x
 curl -fsSL https://raw.githubusercontent.com/digitalrebar/provision/${VER_DRP}/tools/install.sh \
-  | bash -s -- --isolated install --drp-version=${VER_DRP}
+  | bash -s -- install --drp-version=${VER_DRP} --isolated --nocontent
 set +x
 
 ln -s `pwd`/bin/${os_type}/${os_arch}/drpcli bin/drpcli

--- a/examples/5min-drp/demo-run.sh
+++ b/examples/5min-drp/demo-run.sh
@@ -18,35 +18,48 @@
 ################## SEE README for details on usage of this script .... 
 ################## 
 
-source ./bin/color.sh
+[[ -f ./bin/color.sh ]] && source ./bin/color.sh
 ( type -t cprintf > /dev/null 2>&1 ) || function cprintf() { printf "%s" "$*"; }
 
 [[ ":$PATH:" != *":`pwd`/bin:"* ]] && PATH="`pwd`/bin:${PATH}"
 
 cloudia.sh
 
+CONFIRM=${CONFIRM:-"yes"}
+
 function confirm() {
   local _sep="--------------------------------------------------------------------------------"
+  local _err
   local _wait
   local _action=`cprintf "$bold$underline" "ACTION"`
   local _msg=`cprintf $green "$*"`
   local _default=`cprintf $cyan "<Enter>"`
+  local _failed=`cprintf $red "FAILED"`
+  local _success=`cprintf $green "Success... "`
+  local _skipping=`cprintf $yellow "Skipping..."`
 
   echo ""
   cprintf $magenta "${_sep}\n"
   echo "$_action :: $_msg"
-  echo -n "Run next step?  [ $_default | No | Ctrl-C ]  "
-  read _wait
+
+  if [[ $CONFIRM == "yes" ]] 
+  then
+    echo -n "Run next step?  [ $_default | No | Ctrl-C ]  "
+    read _wait
+  fi
 
   if [[ "$_wait" =~ [Nn].* ]] 
   then
-    echo "Skipping..."
+    echo "$_skipping"
     echo "$_sep"
     return
   else
     echo "$_sep"
     echo ""
     $*
+    _err=$?
+
+    (( $_err )) && echo "$_failed" || echo "$_success"
   fi
 }
 
@@ -68,9 +81,9 @@ if [[ "$USER" == "shane" ]]
 then
   echo "<<SHANE>> Staging terraform plugins, private content, and secrets ... "
   set -x
-  cp ../private-content/drp-rack-plugins* ./private-content/
-  cp ../private-content/terraform-provider-packet bin/
-  cp ../private-content/secrets ./private-content
+  cp $HOME/private-content/drp-rack-plugins* ./private-content/
+  cp $HOME/private-content/terraform-provider-packet bin/
+  cp $HOME/private-content/secrets ./private-content
   set +x
 fi
 
@@ -90,6 +103,7 @@ confirm terraform apply -target=packet_ssh_key.5min-nodes-ssh-key
 # build our DRP server
 confirm terraform apply -target=packet_device.5min-drp
 
+
 # view our completed plan status -- NOTE the "5min-nodes"
 # do NOT get applied until after 5min-drp is finished 
 confirm terraform plan                    
@@ -103,6 +117,15 @@ confirm control.sh get-drp-id
 # assign our ID to DRP variable for easy reuse below
 confirm export DRP=`control.sh get-drp-id`
 
+# get our DRP Endpoint IP Address to manipulate our SSH Host Keys
+confirm export ADDR=`control.sh get-address $DRP`
+
+# remove any existing host keys
+confirm ssh-keygen -R $ADDR
+
+# install the newly built DRP Endpoint host key
+confirm ssh-keyscan -H $ADDR >> $HOME/.ssh/known_hosts 2> /dev/null
+
 # install DRP and basic content as identified by <ID>
 confirm control.sh drp-install $DRP     
 
@@ -110,7 +133,7 @@ case $1 in
   local)
     echo "Installing content to DRP endpoint ('$DRP') from local system (push to endpoint)..."
     # installs DRP community content locally
-    confirm control.sh get-drp-content      
+    confirm control.sh get-drp-cc
     # installs DRP Packet Plugins
     confirm control.sh get-drp-plugins      
     # perform content and plugins setup on <ID> endpoint
@@ -118,16 +141,29 @@ case $1 in
   ;;
   remote|*)
     echo "Installing content from DRP endpoint ('$DRP') (pull from endpoint)..."
-    # runs 'get-drp-content', 'get-drp-plugins', and 'drp-setup' on remote <ID>
+    # runs 'get-drp-cc', 'get-drp-plugins', and 'drp-setup' on remote <ID>
     echo ""
     cprintf $bold "   SSH to remote DRP, stop, restart in foreground ... ? "
+    cprintf $bold "   Maybe launch UI to show empty content too ... ? "
+    cprintf $bold "   https://rackn.github.io/provision-ux/#/e/${ADDR}:8092/system "
     echo ""
     confirm control.sh remote-content $DRP  
+    echo ""
+    cprintf $cyan "NOTICE:"
+    echo "         Errors may be 'normal' - ISOs, Kernel, and InitRDs are "
+    echo "         normal as the content has not yet been pused to the DRP"
+    echo "         endpoint.  Other errors should be investigated."
+    echo ""
   ;;
 esac
 
 # inject our DRP endpoint address in to the drp-nodes.tf terraform file
 confirm control.sh set-drp-endpoint $DRP
+
+# bug in Stages causes stage "discover" to be marked bad, only way to 
+# get it to re-eval as good is to force delete content, and re-add which
+# triggers refresh of stage checks
+confirm control.sh ssh $DRP "bin/control.sh fix-stages-bug $DRP"
 
 # bring up our DRP target nodes:
 confirm terraform apply -target=packet_device.5min-nodes

--- a/examples/5min-drp/vars.tf
+++ b/examples/5min-drp/vars.tf
@@ -25,8 +25,9 @@ provider "packet" {
 
 // The Packet data center you would like to deploy into
 variable "packet_facility" {
-  //default = "sjc1"
-  default = "nrt1"
+  //default = "sjc1"  // Sunnyvale, CA USA
+  //default = "nrt1"  // Tokyo, JP
+  default = "ewr1"  // Parsipany, NJ USA
 }
 
 // The path to the private key you created


### PR DESCRIPTION
Minor fixes, tweaks, and enhancements.  Can also now set CONFIRM mode to off, and have 'demo-run.sh' blast through an installation fully unattended, like:
   CONFIRM=no demo-run.sh
