### PR TITLE
Address issues with / in parameter names.

### DIFF
--- a/backend/bootenv.go
+++ b/backend/bootenv.go
@@ -197,6 +197,9 @@ func (b *BootEnv) Validate() {
 	b.renderers = renderers{}
 	// First, the stuff that must be correct in order for
 	b.AddError(index.CheckUnique(b, b.stores("bootenvs").Items()))
+	if strings.Contains(b.Name, "/") || strings.Contains(b.Name, "\\") {
+		b.Errorf("Name must not contain a '/' or '\\'")
+	}
 	// If our basic templates do not parse, it is game over for us
 	b.p.tmplMux.Lock()
 	b.tmplMux.Lock()

--- a/backend/bootenv_test.go
+++ b/backend/bootenv_test.go
@@ -20,6 +20,8 @@ func TestBootEnvCrud(t *testing.T) {
 	tests := []crudTest{
 		{"Create Bootenv with nonexistent Name", dt.Create, &models.BootEnv{}, false},
 		{"Create Bootenv with no templates", dt.Create, &models.BootEnv{Name: "test 1"}, true},
+		{"Create Bootenv with invalid Name /", dt.Create, &models.BootEnv{Name: "test/greg"}, false},
+		{"Create Bootenv with invalid Name \\", dt.Create, &models.BootEnv{Name: "test\\greg"}, false},
 		{"Create Bootenv with invalid BootParams tmpl", dt.Create, &models.BootEnv{Name: "test 2", BootParams: "{{ }"}, false},
 		{"Create Bootenv with valid BootParams tmpl", dt.Create, &models.BootEnv{Name: "test 2", BootParams: "{{ .Env.Name }}"}, true},
 		{"Create Bootenv with invalid models.TemplateInfo (missing Name)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Path: "{{ .Env.Name }}", ID: "ok"}}}, false},

--- a/backend/machines.go
+++ b/backend/machines.go
@@ -481,6 +481,9 @@ func (n *Machine) Validate() {
 	if n.Name == "" {
 		n.Errorf("Machine %s must have a name", n.Uuid)
 	}
+	if strings.Contains(n.Name, "/") || strings.Contains(n.Name, "\\") {
+		n.Errorf("Name must not contain a '/' or '\\'")
+	}
 	validateMaybeZeroIP4(n, n.Address)
 	n.AddError(index.CheckUnique(n, n.stores("machines").Items()))
 	n.SetValid()

--- a/backend/machines_test.go
+++ b/backend/machines_test.go
@@ -56,6 +56,8 @@ func TestMachineCrud(t *testing.T) {
 		{"Create known-good Bootenv", dt.Create, &models.BootEnv{Name: "default", Templates: []models.TemplateInfo{{Name: "ipxe", Path: "{{ .Env.Name }}", ID: "default"}}}, true},
 		{"Create known-unavailable Bootenv", dt.Create, &models.BootEnv{Name: "unavailable"}, true},
 		{"Create empty machine", dt.Create, &models.Machine{}, false},
+		{"Create machine with bad Name /", dt.Create, &models.Machine{Name: "greg/greg"}, false},
+		{"Create machine with bad Name \\", dt.Create, &models.Machine{Name: "greg\\greg"}, false},
 		{"Create unnamed machine", dt.Create, &models.Machine{Uuid: okUUID}, false},
 		{"Create named machine", dt.Create, &models.Machine{Uuid: okUUID, Name: "default.fqdn"}, true},
 		{"Create new machine with same UUID", dt.Create, &models.Machine{Uuid: okUUID, Name: "other.fqdn"}, false},

--- a/backend/plugins.go
+++ b/backend/plugins.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"strings"
+
 	"github.com/digitalrebar/provision/backend/index"
 	"github.com/digitalrebar/provision/models"
 	"github.com/digitalrebar/store"
@@ -123,6 +125,9 @@ func (n *Plugin) Validate() {
 	n.AddError(index.CheckUnique(n, n.stores("plugins").Items()))
 	if n.Provider == "" {
 		n.Errorf("Plugin %s must have a provider", n.Name)
+	}
+	if strings.Contains(n.Name, "/") || strings.Contains(n.Name, "\\") {
+		n.Errorf("Name must not contain a '/' or '\\'")
 	}
 	n.SetValid()
 	n.SetAvailable()

--- a/backend/stage.go
+++ b/backend/stage.go
@@ -2,6 +2,7 @@ package backend
 
 import (
 	"errors"
+	"strings"
 	"sync"
 	"text/template"
 
@@ -143,6 +144,9 @@ func (s *Stage) genRoot(commonRoot *template.Template, e models.ErrorAdder) *tem
 }
 
 func (s *Stage) Validate() {
+	if strings.Contains(s.Name, "/") || strings.Contains(s.Name, "\\") {
+		s.Errorf("Name must not contain a '/' or '\\'")
+	}
 	s.renderers = renderers{}
 	// First, the stuff that must be correct in order for
 	s.AddError(index.CheckUnique(s, s.stores("stages").Items()))

--- a/backend/stage_test.go
+++ b/backend/stage_test.go
@@ -20,6 +20,8 @@ func TestStageCrud(t *testing.T) {
 	tests := []crudTest{
 		{"Create Stage with nonexistent Name", dt.Create, &models.Stage{}, false},
 		{"Create Stage with no BootEnv", dt.Create, &models.Stage{Name: "nobootenv"}, true},
+		{"Create Stage with bad name /", dt.Create, &models.Stage{Name: "no/bootenv"}, false},
+		{"Create Stage with bad name \\", dt.Create, &models.Stage{Name: "no\\bootenv"}, false},
 		{"Create Stage with nonexistent BootEnv", dt.Create, &models.Stage{Name: "missingbootenv", BootEnv: "missingbootenv"}, false},
 		{"Create Stage with missing Task", dt.Create, &models.Stage{Name: "missingtask", BootEnv: "local", Tasks: []string{"jj"}}, false},
 		{"Create Stage with missing profile", dt.Create, &models.Stage{Name: "missingprofile", BootEnv: "local", Profiles: []string{"jj"}}, false},

--- a/backend/subnet.go
+++ b/backend/subnet.go
@@ -7,6 +7,7 @@ import (
 	"math/big"
 	"net"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/digitalrebar/provision/backend/index"
@@ -481,6 +482,9 @@ func AsSubnets(o []models.Model) []*Subnet {
 }
 
 func (s *Subnet) Validate() {
+	if strings.Contains(s.Name, "/") || strings.Contains(s.Name, "\\") {
+		s.Errorf("Name must not contain a '/' or '\\'")
+	}
 	_, subnet, err := net.ParseCIDR(s.Subnet.Subnet)
 	if err != nil {
 		s.Errorf("Invalid subnet %s: %v", s.Subnet.Subnet, err)

--- a/backend/subnet_test.go
+++ b/backend/subnet_test.go
@@ -13,6 +13,8 @@ func TestSubnetCrud(t *testing.T) {
 	defer unlocker()
 	createTests := []crudTest{
 		{"Create empty Subnet", dt.Create, &models.Subnet{}, false},
+		{"Create with bad name /", dt.Create, &models.Subnet{Name: "greg/24"}, false},
+		{"Create with bad name \\", dt.Create, &models.Subnet{Name: "greg\\24"}, false},
 		{"Create valid Subnet", dt.Create, &models.Subnet{Name: "test", Subnet: "192.168.124.0/24", ActiveStart: net.ParseIP("192.168.124.80"), ActiveEnd: net.ParseIP("192.168.124.254"), ActiveLeaseTime: 60, ReservedLeaseTime: 7200, Strategy: "mac"}, true},
 		{"Create duplicate Subnet", dt.Create, &models.Subnet{Name: "test", Subnet: "192.168.124.0/24", ActiveStart: net.ParseIP("192.168.124.80"), ActiveEnd: net.ParseIP("192.168.124.254"), ActiveLeaseTime: 60, ReservedLeaseTime: 7200, Strategy: "mac"}, false},
 		{"Create invalid Subnet(bad Subnet)", dt.Create, &models.Subnet{Name: "test2", Subnet: "127.0.0.0", ActiveStart: net.ParseIP("192.168.124.80"), ActiveEnd: net.ParseIP("192.168.124.254"), ActiveLeaseTime: 60, ReservedLeaseTime: 7200, Strategy: "mac"}, false},

--- a/backend/task.go
+++ b/backend/task.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"strings"
 	"sync"
 	"text/template"
 
@@ -92,6 +93,9 @@ func (t *Task) genRoot(common *template.Template, e models.ErrorAdder) *template
 }
 
 func (t *Task) Validate() {
+	if strings.Contains(t.Name, "/") || strings.Contains(t.Name, "\\") {
+		t.Errorf("Name must not contain a '/' or '\\'")
+	}
 	t.tmplMux.Lock()
 	defer t.tmplMux.Unlock()
 	t.p.tmplMux.Lock()

--- a/backend/task_test.go
+++ b/backend/task_test.go
@@ -18,6 +18,8 @@ func TestTaskCrud(t *testing.T) {
 	tests := []crudTest{
 		{"Create Task with nonexistent Name", dt.Create, &models.Task{}, false},
 		{"Create Task with no templates", dt.Create, &models.Task{Name: "test 1"}, true},
+		{"Create Task with bad name /", dt.Create, &models.Task{Name: "test/1"}, false},
+		{"Create Task with bad name \\", dt.Create, &models.Task{Name: "test\\1"}, false},
 		{"Create Task with invalid models.TemplateInfo (missing Name)", dt.Create, &models.Task{Name: "test 3", Templates: []models.TemplateInfo{{Path: "{{ .Env.Name }}", ID: "ok"}}}, false},
 		{"Create Task with invalid models.TemplateInfo (missing ID)", dt.Create, &models.Task{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }}"}}}, false},
 		{"Create Task with invalid models.TemplateInfo (invalid ID)", dt.Create, &models.Task{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }}", ID: "okp"}}}, false},

--- a/backend/template.go
+++ b/backend/template.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"bytes"
 	"fmt"
+	"strings"
 	"text/template"
 
 	"github.com/digitalrebar/provision/backend/index"
@@ -106,6 +107,9 @@ func (t *Template) Validate() {
 	if t.ID == "" {
 		t.Errorf("Template must have an ID")
 		return
+	}
+	if strings.Contains(t.ID, "/") || strings.Contains(t.ID, "\\") {
+		t.Errorf("ID must not contain a '/' or '\\'")
 	}
 	var err error
 	t.p.tmplMux.Lock()

--- a/backend/template_test.go
+++ b/backend/template_test.go
@@ -12,6 +12,8 @@ func TestTemplateCrud(t *testing.T) {
 	defer unlocker()
 	tests := []crudTest{
 		{"Create Template with No ID", dt.Create, &models.Template{}, false},
+		{"Create Template with Bad / ID", dt.Create, &models.Template{ID: "test/greg"}, false},
+		{"Create Template with Bad \\ ID", dt.Create, &models.Template{ID: "test\\greg"}, false},
 		{"Create Valid Empty Template", dt.Create, &models.Template{ID: "test1"}, true},
 		{"Create Valid Nonempty Template", dt.Create, &models.Template{ID: "test2", Contents: "{{ .Foo }}"}, true},
 		{"Create Duplicate Template", dt.Create, &models.Template{ID: "test1"}, false},

--- a/backend/user.go
+++ b/backend/user.go
@@ -1,6 +1,8 @@
 package backend
 
 import (
+	"strings"
+
 	"github.com/digitalrebar/provision/backend/index"
 	"github.com/digitalrebar/provision/models"
 	"github.com/digitalrebar/store"
@@ -92,6 +94,9 @@ func (u *User) ChangePassword(d Stores, newPass string) error {
 
 func (u *User) Validate() {
 	u.AddError(index.CheckUnique(u, u.stores("users").Items()))
+	if strings.Contains(u.Name, "/") || strings.Contains(u.Name, "\\") {
+		u.Errorf("Name must not contain a '/' or '\\'")
+	}
 	u.SetValid()
 	u.SetAvailable()
 }

--- a/backend/user_test.go
+++ b/backend/user_test.go
@@ -12,6 +12,8 @@ func TestUserCrud(t *testing.T) {
 	defer unlocker()
 	tests := []crudTest{
 		{"Create empty user", dt.Create, &models.User{}, false},
+		{"Create with bad user /", dt.Create, &models.User{Name: "greg/asdg"}, false},
+		{"Create with bad user \\", dt.Create, &models.User{Name: "greg\\agsd"}, false},
 		{"Create new user with name", dt.Create, &models.User{Name: "Test User"}, true},
 		{"Create Duplicate User", dt.Create, &models.User{Name: "Test User"}, false},
 		{"Delete User", dt.Remove, &models.User{Name: "Test User"}, true},

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -170,6 +170,7 @@ func (f *Frontend) makeParamEndpoints(obj backend.Paramer, idKey string) (
 				aggregate = true
 			}
 			paramKey := c.Param("key")
+			paramKey = strings.TrimLeft(paramKey, `/`)
 			val, _ := func() (interface{}, bool) {
 				d, unlocker := f.dt.LockEnts(obj.(Lockable).Locks("get")...)
 				defer unlocker()
@@ -202,6 +203,7 @@ func (f *Frontend) makeParamEndpoints(obj backend.Paramer, idKey string) (
 			}
 			id := c.Param(idKey)
 			paramKey := c.Param("key")
+			paramKey = strings.TrimLeft(paramKey, `/`)
 			var ref models.Model
 			func() {
 				d, unlocker := f.dt.LockEnts(obj.(Lockable).Locks("get")...)

--- a/frontend/machines.go
+++ b/frontend/machines.go
@@ -420,7 +420,7 @@ func (f *Frontend) InitMachineApi() {
 	//       401: NoContentResponse
 	//       403: NoContentResponse
 	//       404: ErrorResponse
-	f.ApiGroup.GET("/machines/:uuid/params/:key", pGetOne)
+	f.ApiGroup.GET("/machines/:uuid/params/*key", pGetOne)
 
 	// swagger:route POST /machines/{uuid}/params/{key} Machines postMachineParam
 	//
@@ -432,7 +432,7 @@ func (f *Frontend) InitMachineApi() {
 	//       403: NoContentResponse
 	//       404: ErrorResponse
 	//       409: ErrorResponse
-	f.ApiGroup.POST("/machines/:uuid/params/:key", pSetOne)
+	f.ApiGroup.POST("/machines/:uuid/params/*key", pSetOne)
 
 	// swagger:route GET /machines/{uuid}/actions Machines getMachineActions
 	//

--- a/frontend/params.go
+++ b/frontend/params.go
@@ -1,6 +1,8 @@
 package frontend
 
 import (
+	"strings"
+
 	"github.com/VictorLowther/jsonpatch2"
 	"github.com/digitalrebar/provision/backend"
 	"github.com/digitalrebar/provision/models"
@@ -145,9 +147,10 @@ func (f *Frontend) InitParamApi() {
 	//       401: NoContentResponse
 	//       403: NoContentResponse
 	//       404: ErrorResponse
-	f.ApiGroup.GET("/params/:name",
+	f.ApiGroup.GET("/params/*name",
 		func(c *gin.Context) {
-			f.Fetch(c, &backend.Param{}, c.Param(`name`))
+			name := strings.TrimLeft(c.Param(`name`), `/`)
+			f.Fetch(c, &backend.Param{}, name)
 		})
 
 	// swagger:route HEAD /params/{name} Params headParam
@@ -161,9 +164,10 @@ func (f *Frontend) InitParamApi() {
 	//       401: NoContentResponse
 	//       403: NoContentResponse
 	//       404: NoContentResponse
-	f.ApiGroup.HEAD("/params/:name",
+	f.ApiGroup.HEAD("/params/*name",
 		func(c *gin.Context) {
-			f.Exists(c, &backend.Param{}, c.Param(`name`))
+			name := strings.TrimLeft(c.Param(`name`), `/`)
+			f.Exists(c, &backend.Param{}, name)
 		})
 
 	// swagger:route PATCH /params/{name} Params patchParam
@@ -180,9 +184,10 @@ func (f *Frontend) InitParamApi() {
 	//       404: ErrorResponse
 	//       406: ErrorResponse
 	//       422: ErrorResponse
-	f.ApiGroup.PATCH("/params/:name",
+	f.ApiGroup.PATCH("/params/*name",
 		func(c *gin.Context) {
-			f.Patch(c, &backend.Param{}, c.Param(`name`))
+			name := strings.TrimLeft(c.Param(`name`), `/`)
+			f.Patch(c, &backend.Param{}, name)
 		})
 
 	// swagger:route PUT /params/{name} Params putParam
@@ -198,9 +203,10 @@ func (f *Frontend) InitParamApi() {
 	//       403: NoContentResponse
 	//       404: ErrorResponse
 	//       422: ErrorResponse
-	f.ApiGroup.PUT("/params/:name",
+	f.ApiGroup.PUT("/params/*name",
 		func(c *gin.Context) {
-			f.Update(c, &backend.Param{}, c.Param(`name`))
+			name := strings.TrimLeft(c.Param(`name`), `/`)
+			f.Update(c, &backend.Param{}, name)
 		})
 
 	// swagger:route DELETE /params/{name} Params deleteParam
@@ -214,10 +220,9 @@ func (f *Frontend) InitParamApi() {
 	//       401: NoContentResponse
 	//       403: NoContentResponse
 	//       404: ErrorResponse
-	f.ApiGroup.DELETE("/params/:name",
+	f.ApiGroup.DELETE("/params/*name",
 		func(c *gin.Context) {
-			f.Remove(c, &backend.Param{}, c.Param(`name`))
-
+			name := strings.TrimLeft(c.Param(`name`), `/`)
+			f.Remove(c, &backend.Param{}, name)
 		})
-
 }

--- a/frontend/profiles.go
+++ b/frontend/profiles.go
@@ -283,7 +283,7 @@ func (f *Frontend) InitProfileApi() {
 	//       401: NoContentResponse
 	//       403: NoContentResponse
 	//       404: ErrorResponse
-	f.ApiGroup.GET("/profiles/:name/params/:key", pGetOne)
+	f.ApiGroup.GET("/profiles/:name/params/*key", pGetOne)
 
 	// swagger:route POST /profiles/{name}/params/{key} Profiles postProfileParam
 	//
@@ -295,5 +295,5 @@ func (f *Frontend) InitProfileApi() {
 	//       403: NoContentResponse
 	//       404: ErrorResponse
 	//       409: ErrorResponse
-	f.ApiGroup.POST("/profiles/:name/params/:key", pSetOne)
+	f.ApiGroup.POST("/profiles/:name/params/*key", pSetOne)
 }


### PR DESCRIPTION
First, make sure that all objects return errors when
a slash or backslash is used in their names (except
params).

Second, update the name parsing of parameter api
calls to enable a / in the name.  This will allow
the objects to be picked up and manipulated again.