### PR TITLE
Change how job exit state us handled in the job runner.

### DIFF
--- a/backend/machines.go
+++ b/backend/machines.go
@@ -465,6 +465,9 @@ func (n *Machine) OnCreate() error {
 	}
 	bootenvs := n.stores("bootenvs")
 	stages := n.stores("stages")
+	if n.Tasks == nil {
+		n.Tasks = []string{}
+	}
 	if bootenvs.Find(n.BootEnv) == nil {
 		n.Errorf("Bootenv %s does not exist", n.BootEnv)
 	} else if stages.Find(n.Stage) == nil {

--- a/backend/machines.go
+++ b/backend/machines.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"net/http"
 	"path"
+	"reflect"
 	"strings"
 
 	"github.com/digitalrebar/provision/backend/index"
@@ -457,6 +458,7 @@ func (n *Machine) setDT(p *DataTracker) {
 func (n *Machine) OnCreate() error {
 	if n.Stage == "" {
 		n.Stage = n.p.pref("defaultStage")
+		n.oldStage = "none"
 	}
 	if n.BootEnv == "" {
 		n.BootEnv = n.p.pref("defaultBootEnv")
@@ -470,6 +472,9 @@ func (n *Machine) OnCreate() error {
 	} else {
 		// All machines start runnable.
 		n.Runnable = true
+	}
+	if n.Tasks != nil && len(n.Tasks) > 0 {
+		n.CurrentTask = -1
 	}
 	return n.MakeError(422, ValidationError, n)
 }
@@ -588,6 +593,7 @@ func (n *Machine) OnLoad() error {
 	}
 	if n.Stage == "" {
 		n.Stage = "none"
+		n.oldStage = "none"
 	}
 	defer func() { n.stores = nil }()
 	return n.BeforeSave()
@@ -600,17 +606,24 @@ func (n *Machine) OnChange(oldThing store.KeySaver) error {
 
 	// If we are changing stages and we aren't done running tasks,
 	// Fail unless the users marks a force
-	if n.oldStage != n.Stage && oldm.CurrentTask != len(oldm.Tasks) && !n.ChangeForced() {
-		e := &models.Error{Code: http.StatusUnprocessableEntity, Type: ValidationError}
-		e.Errorf("Can not change stages with pending tasks unless forced")
-		return e
-	}
 	// If we have a stage set, don't change bootenv unless force
 	if n.Stage == "" {
 		n.Stage = "none"
 	}
+	e := &models.Error{Code: http.StatusUnprocessableEntity, Type: ValidationError}
+	if n.oldStage != n.Stage && oldm.CurrentTask != len(oldm.Tasks) && !n.ChangeForced() {
+		e.Errorf("Can not change stages with pending tasks unless forced")
+		return e
+	}
+	if oldm.Tasks != nil && len(oldm.Tasks) != 0 && n.Stage == oldm.Stage {
+		if n.Tasks == nil || len(n.Tasks) < len(oldm.Tasks) {
+			e.Errorf("Cannot remove tasks from machines without changing stage")
+		}
+		if !reflect.DeepEqual(n.Tasks[:len(oldm.Tasks)], oldm.Tasks) {
+			e.Errorf("Can only append tasks to the task list on a machine.")
+		}
+	}
 	if n.Stage != "none" && n.oldStage == n.Stage && n.oldBootEnv != n.BootEnv && !n.ChangeForced() {
-		e := &models.Error{Code: http.StatusUnprocessableEntity, Type: ValidationError}
 		e.Errorf("Can not change bootenv while in a stage unless forced. old: %s new %s", n.oldBootEnv, n.BootEnv)
 		return e
 	}
@@ -623,7 +636,7 @@ func (n *Machine) AfterSave() {
 		// If we don't have a stage, init structs
 		if n.Stage == "" && n.Tasks == nil {
 			n.Tasks = []string{}
-			n.CurrentTask = 0
+			n.CurrentTask = -1
 			_, e2 := n.p.Save(n.stores, n)
 			if e2 != nil {
 				n.p.Logger.Printf("Failed to save machine in after Save. %v\n", n)

--- a/backend/task.go
+++ b/backend/task.go
@@ -139,6 +139,9 @@ func (t *Task) OnLoad() error {
 
 func (t *Task) BeforeSave() error {
 	t.Validate()
+	if !t.HasFeature("sane-exit-codes") {
+		t.AddFeature("original-exit-codes")
+	}
 	if !t.Useable() {
 		return t.MakeError(422, ValidationError, t)
 	}

--- a/cli/jobs_test.go
+++ b/cli/jobs_test.go
@@ -10,6 +10,9 @@ var jobDefaultListString string = "[]\n"
 var jobTask1Create string = `{
   "Available": true,
   "Errors": [],
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
   "Name": "task1",
   "OptionalParams": null,
   "ReadOnly": false,
@@ -21,6 +24,9 @@ var jobTask1Create string = `{
 var jobTask2Create string = `{
   "Available": true,
   "Errors": [],
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
   "Name": "task2",
   "OptionalParams": null,
   "ReadOnly": false,
@@ -38,6 +44,9 @@ var jobTask2Create string = `{
 var jobTask3Create string = `{
   "Available": true,
   "Errors": [],
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
   "Name": "task3",
   "OptionalParams": null,
   "ReadOnly": false,

--- a/cli/machines_test.go
+++ b/cli/machines_test.go
@@ -613,6 +613,9 @@ var machineRunActionGoodStdinString string = `{
 var machineJamieCreate string = `{
   "Available": true,
   "Errors": [],
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
   "Name": "jamie",
   "OptionalParams": null,
   "ReadOnly": false,
@@ -624,6 +627,9 @@ var machineJamieCreate string = `{
 var machineJustineCreate string = `{
   "Available": true,
   "Errors": [],
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
   "Name": "justine",
   "OptionalParams": null,
   "ReadOnly": false,

--- a/cli/process_jobs.go
+++ b/cli/process_jobs.go
@@ -21,14 +21,217 @@ import (
 )
 
 var exitOnFailure = false
+var runnerDir string
+var actuallyPowerThings = true
 
-func Log(uuid *strfmt.UUID, s string) error {
-	buf := bytes.NewBufferString(s)
+var cmdHelper = []byte(`
+#!/bin/bash
+
+# To force dpkg on Debian-based distros to play nice.
+export DEBIAN_FRONTEND=noninteractive DEBCONF_NONINTERACTIVE_SEEN=true
+
+# Force everything to use the C locale to keep things sane
+export LC_ALL=C LANGUAGE=C LANG=C
+
+# Make sure we play nice with debugging
+export PS4='${BASH_SOURCE}@${LINENO}(${FUNCNAME[0]}): '
+
+# Make sure the scripts are somewhat typo-resistant
+set -o pipefail -o errexit
+shopt -s nullglob extglob globstar
+
+# Make sure that $PATH is somewhat sane.
+fix_path() {
+    local -A pathparts
+    local part
+    local IFS=':'
+    for part in $PATH; do
+        pathparts["$part"]="true"
+    done
+    local wanted_pathparts=("/usr/local/bin" "/usr/local/sbin" "/bin" "/sbin" "/usr/bin" "/usr/sbin")
+    for part in "${wanted_pathparts[@]}"; do
+        [[ ${pathparts[$part]} ]] && continue
+        PATH="$part:$PATH"
+    done
+}
+fix_path
+unset fix_path
+
+# Figure out what Linux distro we are running on.
+export OS_TYPE= OS_VER= OS_NAME=
+if [[ -f /etc/os-release ]]; then
+    . /etc/os-release
+    OS_TYPE=${ID,,}
+    OS_VER=${VERSION_ID,,}
+elif [[ -f /etc/lsb-release ]]; then
+    . /etc/lsb-release
+    OS_VER=${DISTRIB_RELEASE,,}
+    OS_TYPE=${DISTRIB_ID,,}
+elif [[ -f /etc/centos-release || -f /etc/fedora-release || -f /etc/redhat-release ]]; then
+    for rel in centos-release fedora-release redhat-release; do
+        [[ -f /etc/$rel ]] || continue
+        OS_TYPE=${rel%%-*}
+        OS_VER="$(egrep -o '[0-9.]+' "/etc/$rel")"
+        break
+    done
+    if [[ ! $OS_TYPE ]]; then
+        echo "Cannot determine Linux version we are running on!"
+        exit 1
+    fi
+elif [[ -f /etc/debian_version ]]; then
+    OS_TYPE=debian
+    OS_VER=$(cat /etc/debian_version)
+fi
+OS_NAME="$OS_TYPE-$OS_VER"
+
+case $OS_TYPE in
+    centos|redhat|fedora|rhel|scientificlinux) OS_FAMILY="rhel";;
+    debian|ubuntu) OS_FAMILY="debian";;
+    *) OS_FAMILY=$OS_TYPE;;
+esac
+
+if_update_needed() {
+    local timestampref=/tmp/pkg_cache_update
+    if [[ ! -f $timestampref ]] || \
+           (( ($(stat -c '%Y' "$timestampref") - $(date '+%s')) > 86400 )); then
+        touch "$timestampref"
+        "$@"
+    fi
+}
+
+# Install a package
+install() {
+    local to_install=()
+    local pkg
+    for pkg in "$@"; do
+        to_install+=("$pkg")
+    done
+    case $OS_FAMILY in
+        rhel)
+            if_update_needed yum -y makecache
+            yum -y install "${to_install[@]}";;
+        debian)
+            if_update_needed apt-get -y update
+            apt-get -y install "${to_install[@]}";;
+        alpine)
+            if_update_needed apk update
+            apk add "${to_install[@]}";;
+        *) echo "No idea how to install packages on $OS_NAME"
+           exit 1;;
+    esac
+}
+
+INITSTYLE="sysv"
+if which systemctl &>/dev/null; then
+    INITSTYLE="systemd"
+elif which initctl &>/dev/null; then
+    INITSTYLE="upstart"
+fi
+
+# Perform service actions.
+service() {
+    # $1 = service name
+    # $2 = action to perform
+    local svc="$1"
+    shift
+    if which systemctl &>/dev/null; then
+        systemctl "$1" "$svc.service"
+    elif which chkconfig &>/dev/null; then
+        case $1 in
+            enable) chkconfig "$svc" on;;
+            disable) chkconfig "$svc" off;;
+            *)  command service "$svc" "$@";;
+        esac
+    elif which initctl &>/dev/null && initctl version 2>/dev/null | grep -q upstart ; then
+        /usr/sbin/service "$svc" "$1"
+    elif [[ -f /etc/init/$svc.unit ]]; then
+        initctl "$1" "$svc"
+    elif which update-rc.d &>/dev/null; then
+        case $1 in
+            enable|disable) update-rc.d "$svc" "$1";;
+            *) "/etc/init.d/$svc" "$1";;
+        esac
+    elif [[ -x /etc/init.d/$svc ]]; then
+        "/etc/init.d/$svc" "$1"
+    else
+        echo "No idea how to manage services on $OS_NAME"
+        exit 1
+    fi
+}
+
+get_param() {
+    # $1 attrib to get.  Attrib will be fetched in the context of the current machine
+    local attr
+    drpcli machines get "$RS_UUID" param "$1"
+}
+
+set_param() {
+    # $1 = name of the parameter to set
+    # $2 = parameter to set.
+    #      if $2 == "", then we will read from stdin
+    local src="$2"
+    if [[ ! $src ]]; then src="-"; fi
+    drpcli machines set "$RS_UUID" param "$1" to "$src"
+}
+
+__sane_exit() {
+    touch "$RS_TASK_DIR/.sane-exit-codes"
+}
+
+__exit() {
+    __sane_exit
+    exit $1
+}
+
+exit_incomplete() {
+    __exit 128
+}
+
+exit_reboot() {
+    __exit 64
+}
+
+exit_shutdown() {
+    __exit 32
+}
+
+exit_incomplete_reboot() {
+    __exit 192
+}
+
+exit_incomplete_shutdown() {
+    __exit 160
+}
+
+addr_port() {
+    if [[ $1 =~ ':' ]]; then
+        printf '[%s]:%d' "$1" "$2"
+    else
+        printf '%s:%d' "$1" "$2"
+    fi
+}
+
+if ! (which jq &>/dev/null || install jq); then
+    echo "JQ not installed and not installable.  The script jig requires it to function"
+    exit 1
+fi
+`)
+
+func putLog(uuid *strfmt.UUID, buf *bytes.Buffer) error {
 	_, err := session.Jobs.PutJobLog(jobs.NewPutJobLogParams().WithUUID(*uuid).WithBody(buf), basicAuth)
 	if err != nil {
 		fmt.Printf("Failed to log to job log, %s: %v\n", uuid.String(), err)
 	}
 	return err
+}
+
+func Log(uuid *strfmt.UUID, echo bool, s string, args ...interface{}) error {
+	buf := &bytes.Buffer{}
+	fmt.Fprintf(buf, s, args...)
+	if echo {
+		fmt.Printf(s, args...)
+	}
+	return putLog(uuid, buf)
 }
 
 func writeStringToFile(filename, content string) error {
@@ -82,7 +285,7 @@ func (cr *CommandRunner) ReadLog() {
 	// read command's stderr line by line - for logging
 	in := bufio.NewScanner(cr.stderr)
 	for in.Scan() {
-		Log(cr.uuid, in.Text())
+		putLog(cr.uuid, bytes.NewBuffer(in.Bytes()))
 	}
 	cr.finished <- true
 }
@@ -91,7 +294,7 @@ func (cr *CommandRunner) ReadReply() {
 	// read command's stdout line by line - for replies
 	in := bufio.NewScanner(cr.stdout)
 	for in.Scan() {
-		Log(cr.uuid, in.Text())
+		putLog(cr.uuid, bytes.NewBuffer(in.Bytes()))
 	}
 	cr.finished <- true
 }
@@ -102,9 +305,7 @@ func (cr *CommandRunner) Run() (failed, incomplete, reboot, poweroff bool) {
 	if err != nil {
 		failed = true
 		reboot = false
-		s := fmt.Sprintf("Command %s failed to start: %v\n", cr.name, err)
-		fmt.Printf(s)
-		Log(cr.uuid, s)
+		Log(cr.uuid, true, "Command %s failed to start: %v\n", cr.name, err)
 		return
 	}
 
@@ -140,6 +341,11 @@ func (cr *CommandRunner) Run() (failed, incomplete, reboot, poweroff bool) {
 							break
 						}
 					}
+				}
+			}
+			if !sane {
+				if st, err := os.Stat(".sane-exit-codes"); err == nil && st.Mode().IsRegular() {
+					sane = true
 				}
 			}
 			code := uint(status.ExitStatus())
@@ -178,39 +384,29 @@ func (cr *CommandRunner) Run() (failed, incomplete, reboot, poweroff bool) {
 			reboot = false
 		}
 	}
-	s := fmt.Sprintf("Command %s: failed: %v, incomplete: %v, reboot: %v, poweroff: %v\n",
+	Log(cr.uuid, true, "Command %s: failed: %v, incomplete: %v, reboot: %v, poweroff: %v\n",
 		cr.name,
 		failed,
 		incomplete,
 		reboot,
 		poweroff)
-	fmt.Printf(s)
-	Log(cr.uuid, s)
 	// Remove script
 	os.Remove(cr.cmd.Path)
 
 	return
 }
 
-func NewCommandRunner(uuid *strfmt.UUID, name, content string) (*CommandRunner, error) {
+func NewCommandRunner(uuid *strfmt.UUID, name, content, loc string) (*CommandRunner, error) {
 	answer := &CommandRunner{name: name, uuid: uuid}
-
-	// Make script file
-	tmpFile, err := ioutil.TempFile(".", "script")
-	if err != nil {
+	if err := ioutil.WriteFile(path.Join(loc, "script"), []byte(content), 0700); err != nil {
 		return nil, err
 	}
-	if _, err := tmpFile.Write([]byte(content)); err != nil {
+	if err := ioutil.WriteFile(path.Join(loc, "helper"), cmdHelper, 0400); err != nil {
 		return nil, err
 	}
-	path := "./" + tmpFile.Name()
-	if err := tmpFile.Close(); err != nil {
-		return nil, err
-	}
-	os.Chmod(path, 0700)
-
-	answer.cmd = exec.Command(path)
-
+	answer.cmd = exec.Command("./script")
+	answer.cmd.Dir = loc
+	answer.cmd.Env = append(os.Environ(), "RS_TASK_DIR="+loc, "RS_RUNNER_DIR="+runnerDir)
 	var err2 error
 	answer.stderr, err2 = answer.cmd.StderrPipe()
 	if err2 != nil {
@@ -233,15 +429,18 @@ func NewCommandRunner(uuid *strfmt.UUID, name, content string) (*CommandRunner, 
 }
 
 func runContent(uuid *strfmt.UUID, action *models.JobAction, task *models.Task) (failed, incomplete, reboot, poweroff bool) {
+	tmpDir, err := ioutil.TempDir(runnerDir, *task.Name+"-")
+	if err != nil {
+		Log(uuid, true, "Could not create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
 
-	Log(uuid, fmt.Sprintf("Starting Content Execution for: %s\n", *action.Name))
+	Log(uuid, false, "Starting Content Execution for: %s\n", *action.Name)
 
-	runner, err := NewCommandRunner(uuid, *action.Name, *action.Content)
+	runner, err := NewCommandRunner(uuid, *action.Name, *action.Content, tmpDir)
 	if err != nil {
 		failed = true
-		s := fmt.Sprintf("Creating command %s failed: %v\n", *action.Name, err)
-		fmt.Printf(s)
-		Log(uuid, s)
+		Log(uuid, true, "Creating command %s failed: %v\n", *action.Name, err)
 		return
 	}
 	runner.task = task
@@ -280,6 +479,12 @@ the stage runner wait flag.
 			} else {
 				machine = obj.(*models.Machine)
 			}
+			var err error
+			runnerDir, err = ioutil.TempDir("", "runner-")
+			if err != nil {
+				return generateError(err, "Error making temp runner dir")
+			}
+			defer os.RemoveAll(runnerDir)
 
 			fmt.Printf("Processing jobs for %s\n", uuid)
 
@@ -348,9 +553,7 @@ the stage runner wait flag.
 				var task *models.Task
 
 				if obj, err := Get(job.Task, to); err != nil {
-					s := fmt.Sprintf("Error loading task content: %v, continuing", err)
-					fmt.Printf(s)
-					Log(job.UUID, s)
+					Log(job.UUID, true, "Error loading task content: %v, continuing", err)
 					markJob(job.UUID.String(), "failed", jo)
 				} else {
 					task = obj.(*models.Task)
@@ -359,9 +562,7 @@ the stage runner wait flag.
 				// Get the job data
 				var list []*models.JobAction
 				if resp, err := session.Jobs.GetJobActions(jobs.NewGetJobActionsParams().WithUUID(*job.UUID), basicAuth); err != nil {
-					s := fmt.Sprintf("Error loading task content: %v, continuing", err)
-					fmt.Printf(s)
-					Log(job.UUID, s)
+					Log(job.UUID, true, "Error loading task content: %v, continuing", err)
 					markJob(job.UUID.String(), "failed", jo)
 					continue
 				} else {
@@ -370,9 +571,7 @@ the stage runner wait flag.
 
 				// Mark job as running
 				if _, err := Update(job.UUID.String(), `{"State": "running"}`, jo, false); err != nil {
-					s := fmt.Sprintf("Error marking job as running: %v, continue\n", err)
-					fmt.Printf(s)
-					Log(job.UUID, s)
+					Log(job.UUID, true, "Error marking job as running: %v, continue\n", err)
 					markJob(job.UUID.String(), "failed", jo)
 					continue
 				}
@@ -397,15 +596,12 @@ the stage runner wait flag.
 						failed, incomplete, reboot, poweroff = runContent(job.UUID, action, task)
 					} else {
 						fmt.Printf("Putting Content in place for Task Template: %s\n", *action.Name)
-						var s string
 						if err := writeStringToFile(*action.Path, *action.Content); err != nil {
 							failed = true
-							s = fmt.Sprintf("Task Template: %s - Copying contents to %s failed\n%v", *action.Name, *action.Path, err)
+							Log(job.UUID, true, "Task Template: %s - Copying contents to %s failed\n%v", *action.Name, *action.Path, err)
 						} else {
-							s = fmt.Sprintf("Task Template: %s - Copied contents to %s successfully\n", *action.Name, *action.Path)
+							Log(job.UUID, true, "Task Template: %s - Copied contents to %s successfully\n", *action.Name, *action.Path)
 						}
-						fmt.Printf(s)
-						Log(job.UUID, s)
 					}
 
 					if failed {
@@ -431,15 +627,23 @@ the stage runner wait flag.
 				// Loop back and wait for the machine to get marked runnable again
 
 				if reboot {
-					_, err := exec.Command("reboot").Output()
-					if err != nil {
-						Log(job.UUID, "Failed to issue reboot\n")
+					if actuallyPowerThings {
+						_, err := exec.Command("reboot").Output()
+						if err != nil {
+							Log(job.UUID, false, "Failed to issue reboot\n")
+						}
+					} else {
+						Log(job.UUID, true, "Would have rebooted")
 					}
 				}
 				if poweroff {
-					_, err := exec.Command("poweroff").Output()
-					if err != nil {
-						Log(job.UUID, "Failed to issue poweroff\n")
+					if actuallyPowerThings {
+						_, err := exec.Command("poweroff").Output()
+						if err != nil {
+							Log(job.UUID, false, "Failed to issue poweroff\n")
+						}
+					} else {
+						Log(job.UUID, true, "Would have powered down")
 					}
 				}
 

--- a/cli/process_jobs_test.go
+++ b/cli/process_jobs_test.go
@@ -7,7 +7,65 @@ import (
 )
 
 var processJobsJustineCreateTaskString = `{
+  "Meta": {
+    "feature-flags": "sane-exit-codes"
+  },
   "Name": "justine",
+  "Templates": [
+    {
+      "Contents": "test.txt Content\n\nHere\n",
+      "Name": "part 1 - copy file",
+      "Path": "test.txt"
+    },
+    {
+      "Contents": "#!/bin/bash\n\ndata\necho\nexit 0\n",
+      "Name": "part 2 - Print Date - success",
+      "Path": ""
+    },
+    {
+      "Contents": "#!/bin/bash\n\nif [ -e incomplete.txt ] ; then\ntouch failed.txt\nrm incomplete.txt\necho \"Return failed\"\nexit 1\nelif [ -e failed.txt ] ; then\necho \"Return success\"\nexit 0\nfi\n\ntouch incomplete.txt\necho \"Return incomplete\"\nexit 128\n\n",
+      "Name": "part 3 - Test Return Codes",
+      "Path": ""
+    }
+  ]
+}
+`
+var processJobsJustineCreateOutputString string = `{
+  "Available": true,
+  "Errors": [],
+  "Meta": {
+    "feature-flags": "sane-exit-codes"
+  },
+  "Name": "justine",
+  "OptionalParams": null,
+  "ReadOnly": false,
+  "RequiredParams": null,
+  "Templates": [
+    {
+      "Contents": "test.txt Content\n\nHere\n",
+      "Name": "part 1 - copy file",
+      "Path": "test.txt"
+    },
+    {
+      "Contents": "#!/bin/bash\n\ndata\necho\nexit 0\n",
+      "Name": "part 2 - Print Date - success",
+      "Path": ""
+    },
+    {
+      "Contents": "#!/bin/bash\n\nif [ -e incomplete.txt ] ; then\ntouch failed.txt\nrm incomplete.txt\necho \"Return failed\"\nexit 1\nelif [ -e failed.txt ] ; then\necho \"Return success\"\nexit 0\nfi\n\ntouch incomplete.txt\necho \"Return incomplete\"\nexit 128\n\n",
+      "Name": "part 3 - Test Return Codes",
+      "Path": ""
+    }
+  ],
+  "Validated": true
+}
+`
+
+var processJobsYakovCreateTaskString = `{
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
+  "Name": "yakov",
   "Templates": [
     {
       "Contents": "test.txt Content\n\nHere\n",
@@ -27,10 +85,13 @@ var processJobsJustineCreateTaskString = `{
   ]
 }
 `
-var processJobsJustineCreateOutputString string = `{
+var processJobsYakovCreateOutputString string = `{
   "Available": true,
   "Errors": [],
-  "Name": "justine",
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
+  "Name": "yakov",
   "OptionalParams": null,
   "ReadOnly": false,
   "RequiredParams": null,
@@ -81,6 +142,143 @@ var processJobsSetMachineToLocalOutputString = `{
   "Validated": true
 }
 `
+
+var yakovCreateInputString string = `{
+  "Address": "192.168.100.111",
+  "name": "yakov",
+  "Uuid": "3e7031fe-3062-45f1-835c-92541bc9cbd4",
+  "Bootenv": "local",
+  "Tasks": [
+    "yakov"
+  ],
+}
+`
+
+var processYakovSetMachineToLocalOutputString = `{
+  "Address": "192.168.100.111",
+  "Available": true,
+  "BootEnv": "local",
+  "CurrentTask": -1,
+  "Errors": [],
+  "Name": "yakov",
+  "Profile": {
+    "Available": false,
+    "Errors": null,
+    "Name": "",
+    "ReadOnly": false,
+    "Validated": false
+  },
+  "Profiles": null,
+  "ReadOnly": false,
+  "Runnable": true,
+  "Stage": "none",
+  "Tasks": [
+    "yakov"
+  ],
+  "Uuid": "3e7031fe-3062-45f1-835c-92541bc9cbd4",
+  "Validated": true
+}
+`
+
+var (
+	processYakovOutputSuccessString = `RE:
+Processing jobs for 3e7031fe-3062-45f1-835c-92541bc9cbd4
+Starting Task: yakov \([\S\s]*\)
+Putting Content in place for Task Template: part 1 - copy file
+Task Template: part 1 - copy file - Copied contents to test.txt successfully
+Task Template , part 1 - copy file, finished
+Running Task Template: part 2 - Print Date - success
+Command part 2 - Print Date - success: failed: false, incomplete: false, reboot: false, poweroff: false
+Task Template , part 2 - Print Date - success, finished
+Running Task Template: part 3 - Test Return Codes
+Command part 3 - Test Return Codes: failed: false, incomplete: true, reboot: false, poweroff: false
+Task Template , part 3 - Test Return Codes, incomplete
+Task: yakov incomplete
+Starting Task: yakov \([\S\s]*\)
+Putting Content in place for Task Template: part 1 - copy file
+Task Template: part 1 - copy file - Copied contents to test.txt successfully
+Task Template , part 1 - copy file, finished
+Running Task Template: part 2 - Print Date - success
+Command part 2 - Print Date - success: failed: false, incomplete: false, reboot: false, poweroff: false
+Task Template , part 2 - Print Date - success, finished
+Running Task Template: part 3 - Test Return Codes
+Command part 3 - Test Return Codes: failed: true, incomplete: false, reboot: false, poweroff: false
+Task Template , part 3 - Test Return Codes, failed
+Task: yakov failed
+`
+	processYakovErrorSuccessString      = "Error: Task failed, exiting ...\n\n\n"
+	processYakovShowFailedMachineString = `RE:
+{
+  "Address": "192.168.100.111",
+  "Available": true,
+  "BootEnv": "local",
+  "CurrentJob": "[\S\s]*",
+  "CurrentTask": 0,
+  "Errors": \[\],
+  "Name": "yakov",
+  "Profile": {
+    "Available": false,
+    "Errors": null,
+    "Name": "",
+    "ReadOnly": false,
+    "Validated": false
+  },
+  "Profiles": null,
+  "ReadOnly": false,
+  "Runnable": false,
+  "Stage": "none",
+  "Tasks": \[
+    "yakov"
+  \],
+  "Uuid": "3e7031fe-3062-45f1-835c-92541bc9cbd4",
+  "Validated": true
+}
+`
+	processYakovRunnableString            = `{ "Runnable": true }`
+	processYakovShowRunnableMachineString = `RE:
+{
+  "Address": "192.168.100.111",
+  "Available": true,
+  "BootEnv": "local",
+  "CurrentJob": "[\S\s]*",
+  "CurrentTask": 0,
+  "Errors": \[\],
+  "Name": "yakov",
+  "Profile": {
+    "Available": false,
+    "Errors": null,
+    "Name": "",
+    "ReadOnly": false,
+    "Validated": false
+  },
+  "Profiles": null,
+  "ReadOnly": false,
+  "Runnable": true,
+  "Stage": "none",
+  "Tasks": \[
+    "yakov"
+  \],
+  "Uuid": "3e7031fe-3062-45f1-835c-92541bc9cbd4",
+  "Validated": true
+}
+`
+	processYakovOutputSecondPassSuccessString = `RE:
+Processing jobs for 3e7031fe-3062-45f1-835c-92541bc9cbd4
+Starting Task: yakov \([\S\s]*\)
+Putting Content in place for Task Template: part 1 - copy file
+Task Template: part 1 - copy file - Copied contents to test.txt successfully
+Task Template , part 1 - copy file, finished
+Running Task Template: part 2 - Print Date - success
+Command part 2 - Print Date - success: failed: false, incomplete: false, reboot: false, poweroff: false
+Task Template , part 2 - Print Date - success, finished
+Running Task Template: part 3 - Test Return Codes
+Command part 3 - Test Return Codes: failed: false, incomplete: false, reboot: false, poweroff: false
+Task Template , part 3 - Test Return Codes, finished
+Task: yakov finished
+Jobs finished
+`
+)
+
 var processJobsNoArgsString = "Error: drpcli machines processjobs [id] [flags] requires at least 1 argument\n"
 var processJobsTooManyArgsString = "Error: drpcli machines processjobs [id] [flags] requires at most 1 arguments\n"
 var processJobsMissingMachineString = "Error: machines GET: p1: Not Found\n\n"
@@ -96,10 +294,10 @@ Putting Content in place for Task Template: part 1 - copy file
 Task Template: part 1 - copy file - Copied contents to test.txt successfully
 Task Template , part 1 - copy file, finished
 Running Task Template: part 2 - Print Date - success
-Command part 2 - Print Date - success succeeded
+Command part 2 - Print Date - success: failed: false, incomplete: false, reboot: false, poweroff: false
 Task Template , part 2 - Print Date - success, finished
 Running Task Template: part 3 - Test Return Codes
-Command part 3 - Test Return Codes incomplete
+Command part 3 - Test Return Codes: failed: false, incomplete: true, reboot: false, poweroff: false
 Task Template , part 3 - Test Return Codes, incomplete
 Task: justine incomplete
 Starting Task: justine \([\S\s]*\)
@@ -107,12 +305,28 @@ Putting Content in place for Task Template: part 1 - copy file
 Task Template: part 1 - copy file - Copied contents to test.txt successfully
 Task Template , part 1 - copy file, finished
 Running Task Template: part 2 - Print Date - success
-Command part 2 - Print Date - success succeeded
+Command part 2 - Print Date - success: failed: false, incomplete: false, reboot: false, poweroff: false
 Task Template , part 2 - Print Date - success, finished
 Running Task Template: part 3 - Test Return Codes
-Command part 3 - Test Return Codes failed
+Command part 3 - Test Return Codes: failed: true, incomplete: false, reboot: false, poweroff: false
 Task Template , part 3 - Test Return Codes, failed
 Task: justine failed
+`
+
+var processJobsOutputSecondPassSuccessString = `RE:
+Processing jobs for 3e7031fe-3062-45f1-835c-92541bc9cbd3
+Starting Task: justine \([\S\s]*\)
+Putting Content in place for Task Template: part 1 - copy file
+Task Template: part 1 - copy file - Copied contents to test.txt successfully
+Task Template , part 1 - copy file, finished
+Running Task Template: part 2 - Print Date - success
+Command part 2 - Print Date - success: failed: false, incomplete: false, reboot: false, poweroff: false
+Task Template , part 2 - Print Date - success, finished
+Running Task Template: part 3 - Test Return Codes
+Command part 3 - Test Return Codes: failed: false, incomplete: false, reboot: false, poweroff: false
+Task Template , part 3 - Test Return Codes, finished
+Task: justine finished
+Jobs finished
 `
 
 var processJobsRemoveProfileSuccessString = `RE:
@@ -229,22 +443,6 @@ var processJobsShowRunnableMachineString = `RE:
 }
 `
 
-var processJobsOutputSecondPassSuccessString = `RE:
-Processing jobs for 3e7031fe-3062-45f1-835c-92541bc9cbd3
-Starting Task: justine \([\S\s]*\)
-Putting Content in place for Task Template: part 1 - copy file
-Task Template: part 1 - copy file - Copied contents to test.txt successfully
-Task Template , part 1 - copy file, finished
-Running Task Template: part 2 - Print Date - success
-Command part 2 - Print Date - success succeeded
-Task Template , part 2 - Print Date - success, finished
-Running Task Template: part 3 - Test Return Codes
-Command part 3 - Test Return Codes succeeded
-Task Template , part 3 - Test Return Codes, finished
-Task: justine finished
-Jobs finished
-`
-
 var processJobsCreateStage1InputString = `{
   "Name": "stage1",
   "BootEnv": "local",
@@ -276,7 +474,9 @@ func TestProcessJobsCli(t *testing.T) {
 		// Setup
 		CliTest{false, false, []string{"tasks", "create", "jamie"}, noStdinString, machineJamieCreate, noErrorString},
 		CliTest{false, false, []string{"tasks", "create", "-"}, processJobsJustineCreateTaskString, processJobsJustineCreateOutputString, noErrorString},
+		CliTest{false, false, []string{"tasks", "create", "-"}, processJobsYakovCreateTaskString, processJobsYakovCreateOutputString, noErrorString},
 		CliTest{false, false, []string{"machines", "create", machineCreateInputString}, noStdinString, machineCreateJohnString, noErrorString},
+		CliTest{false, false, []string{"machines", "create", yakovCreateInputString}, noStdinString, processYakovSetMachineToLocalOutputString, noErrorString},
 		CliTest{false, false, []string{"stages", "create", processJobsCreateStage1InputString}, noStdinString, processJobsCreateStage1SuccessString, noErrorString},
 
 		// Test basic process jobs cli
@@ -291,6 +491,21 @@ func TestProcessJobsCli(t *testing.T) {
 		CliTest{false, false, []string{"machines", "show", "3e7031fe-3062-45f1-835c-92541bc9cbd3"}, noStdinString, processJobsShowFailedMachineString, noErrorString},
 		CliTest{false, false, []string{"machines", "update", "3e7031fe-3062-45f1-835c-92541bc9cbd3", processJobsRunnableString}, noStdinString, processJobsShowRunnableMachineString, noErrorString},
 		CliTest{false, false, []string{"machines", "processjobs", "3e7031fe-3062-45f1-835c-92541bc9cbd3"}, noStdinString, processJobsOutputSecondPassSuccessString, noErrorString},
+	}
+
+	for _, test := range tests {
+		testCli(t, test)
+	}
+	// Run tasks on yakov
+
+	os.Remove("test.txt")
+	os.Remove("failed.txt")
+	os.Remove("incomplete.txt")
+	tests = []CliTest{
+		CliTest{false, true, []string{"machines", "processjobs", "3e7031fe-3062-45f1-835c-92541bc9cbd4", "--exit-on-failure"}, noStdinString, processYakovOutputSuccessString, processYakovErrorSuccessString},
+		CliTest{false, false, []string{"machines", "show", "3e7031fe-3062-45f1-835c-92541bc9cbd4"}, noStdinString, processYakovShowFailedMachineString, noErrorString},
+		CliTest{false, false, []string{"machines", "update", "3e7031fe-3062-45f1-835c-92541bc9cbd4", processYakovRunnableString}, noStdinString, processYakovShowRunnableMachineString, noErrorString},
+		CliTest{false, false, []string{"machines", "processjobs", "3e7031fe-3062-45f1-835c-92541bc9cbd4"}, noStdinString, processYakovOutputSecondPassSuccessString, noErrorString},
 
 		// Test some other clean up actions
 		CliTest{false, true, []string{"machines", "stage", "3e7031fe-3062-45f1-835c-92541bc9cbd3", "fred"}, noStdinString, noContentString, processJobsStageMissingString},
@@ -298,9 +513,11 @@ func TestProcessJobsCli(t *testing.T) {
 		// Clean Up
 		CliTest{false, false, []string{"machines", "stage", "3e7031fe-3062-45f1-835c-92541bc9cbd3", ""}, noStdinString, processJobsResetToLocalSuccessString, noErrorString},
 		CliTest{false, false, []string{"machines", "destroy", "3e7031fe-3062-45f1-835c-92541bc9cbd3"}, noStdinString, machineDestroyJohnString, noErrorString},
+		CliTest{false, false, []string{"machines", "destroy", "3e7031fe-3062-45f1-835c-92541bc9cbd4"}, noStdinString, "Deleted machine 3e7031fe-3062-45f1-835c-92541bc9cbd4\n", noErrorString},
 		CliTest{false, false, []string{"stages", "destroy", "stage1"}, noStdinString, "Deleted stage stage1\n", noErrorString},
 		CliTest{false, false, []string{"tasks", "destroy", "jamie"}, noStdinString, "Deleted task jamie\n", noErrorString},
 		CliTest{false, false, []string{"tasks", "destroy", "justine"}, noStdinString, "Deleted task justine\n", noErrorString},
+		CliTest{false, false, []string{"tasks", "destroy", "yakov"}, noStdinString, "Deleted task yakov\n", noErrorString},
 	}
 
 	for _, test := range tests {

--- a/cli/tasks_test.go
+++ b/cli/tasks_test.go
@@ -18,6 +18,9 @@ var taskShowMissingArgErrorString string = "Error: tasks GET: jill: Not Found\n\
 var taskShowJohnString string = `{
   "Available": true,
   "Errors": [],
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
   "Name": "john",
   "OptionalParams": null,
   "ReadOnly": false,
@@ -46,6 +49,9 @@ var taskCreateInputString string = `{
 var taskCreateJohnString string = `{
   "Available": true,
   "Errors": [],
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
   "Name": "john",
   "OptionalParams": null,
   "ReadOnly": false,
@@ -60,6 +66,9 @@ var taskListTasksString = `[
   {
     "Available": true,
     "Errors": [],
+    "Meta": {
+      "feature-flags": "original-exit-codes"
+    },
     "Name": "john",
     "OptionalParams": null,
     "ReadOnly": false,
@@ -73,6 +82,9 @@ var taskListBothEnvsString = `[
   {
     "Available": true,
     "Errors": [],
+    "Meta": {
+      "feature-flags": "original-exit-codes"
+    },
     "Name": "john",
     "OptionalParams": null,
     "ReadOnly": false,
@@ -94,6 +106,9 @@ var taskUpdateInputString string = `{
 var taskUpdateJohnString string = `{
   "Available": true,
   "Errors": [],
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
   "Name": "john",
   "OptionalParams": [
     "jillparam"
@@ -134,6 +149,9 @@ var taskPatchInputString string = `{
 var taskPatchJohnString string = `{
   "Available": true,
   "Errors": [],
+  "Meta": {
+    "feature-flags": "original-exit-codes"
+  },
   "Name": "john",
   "OptionalParams": [
     "joan"

--- a/cli/user_test.go
+++ b/cli/user_test.go
@@ -164,6 +164,9 @@ var userTokenSuccessString string = `RE:
     "api_port": 10001,
     "arch": "[\s\S]*",
     "dhcp_enabled": false,
+    "Features": \[
+      "api-v3"
+    \],
     "file_port": 10002,
     "id": "Fred",
     "os": "[\s\S]*",

--- a/frontend/info.go
+++ b/frontend/info.go
@@ -29,6 +29,7 @@ func (f *Frontend) GetInfo(drpid string) (*models.Info, *models.Error) {
 		DhcpEnabled:        !f.NoDhcp,
 		ProvisionerEnabled: !f.NoProv,
 		Stats:              make([]*models.Stat, 0, 0),
+		Features:           []string{"api-v3"},
 	}
 
 	res := &models.Error{

--- a/glide.lock
+++ b/glide.lock
@@ -14,7 +14,7 @@ imports:
 - name: github.com/digitalrebar/pinger
   version: 5430ec21bf3a5c1dd6c4ce4db1e0fc0a17b94bde
 - name: github.com/digitalrebar/store
-  version: b8c5d72c674964fc50e04e58657cddbeb9b28c12
+  version: 8e3591adaba7c97d5587e9c9503a4b7167c23637
 - name: github.com/elazarl/go-bindata-assetfs
   version: 30f82fa23fd844bd5bb1e5f216db87fd77b5eb43
 - name: github.com/elithrar/simple-scrypt

--- a/models/info.go
+++ b/models/info.go
@@ -1,0 +1,34 @@
+package models
+
+// swagger:model
+type Stat struct {
+	// required: true
+	Name string `json:"name"`
+	// required: true
+	Count int `json:"count"`
+}
+
+// swagger:model
+type Info struct {
+	// required: true
+	Arch string `json:"arch"`
+	// required: true
+	Os string `json:"os"`
+	// required: true
+	Version string `json:"version"`
+	// required: true
+	Id string `json:"id"`
+	// required: true
+	ApiPort int `json:"api_port"`
+	// required: true
+	FilePort int `json:"file_port"`
+	// required: true
+	TftpEnabled bool `json:"tftp_enabled"`
+	// required: true
+	DhcpEnabled bool `json:"dhcp_enabled"`
+	// required: true
+	ProvisionerEnabled bool `json:"prov_enabled"`
+	// required: true
+	Stats    []*Stat `json:"stats"`
+	Features []string
+}

--- a/models/meta.go
+++ b/models/meta.go
@@ -1,9 +1,76 @@
 package models
 
+import (
+	"sort"
+	"strings"
+)
+
 // Meta holds information about arbritary things.
 // Initial usage will be for UX elements.
 //
 // swagger: model
 type MetaData struct {
 	Meta map[string]string
+}
+
+func (m *MetaData) Features() []string {
+	if m.Meta == nil {
+		m.Meta = map[string]string{}
+	}
+	if flags, ok := m.Meta["feature-flags"]; ok && len(flags) > 0 {
+		return strings.Split(flags, ",")
+	}
+	return []string{}
+}
+
+func (m *MetaData) HasFeature(flag string) bool {
+	flag = strings.TrimSpace(flag)
+	for _, testFlag := range m.Features() {
+		if flag == strings.TrimSpace(testFlag) {
+			return true
+		}
+	}
+	return false
+}
+
+func (m *MetaData) AddFeature(flag string) {
+	flag = strings.TrimSpace(flag)
+	if m.HasFeature(flag) || flag == "" {
+		return
+	}
+	flags := m.Features()
+	flags = append(flags, flag)
+	sort.Strings(flags)
+	m.Meta["feature-flags"] = strings.Join(flags, ",")
+}
+
+func (m *MetaData) RemoveFeature(flag string) {
+	flag = strings.TrimSpace(flag)
+	newFlags := []string{}
+	for _, testFlag := range m.Features() {
+		if flag == testFlag {
+			continue
+		}
+		newFlags = append(newFlags, testFlag)
+	}
+	m.Meta["feature-flags"] = strings.Join(newFlags, ",")
+}
+
+func (m *MetaData) MergeFeatures(other []string) {
+	flags := map[string]struct{}{}
+	for _, flag := range m.Features() {
+		flags[flag] = struct{}{}
+	}
+	for _, flag := range other {
+		flag = strings.TrimSpace(flag)
+		if flag != "" {
+			flags[flag] = struct{}{}
+		}
+	}
+	newFlags := make([]string, 0, len(flags))
+	for k := range flags {
+		newFlags = append(newFlags, k)
+	}
+	sort.Strings(newFlags)
+	m.Meta["feature-flags"] = strings.Join(newFlags, ",")
 }

--- a/models/token.go
+++ b/models/token.go
@@ -1,38 +1,6 @@
 package models
 
 // swagger:model
-type Stat struct {
-	// required: true
-	Name string `json:"name"`
-	// required: true
-	Count int `json:"count"`
-}
-
-// swagger:model
-type Info struct {
-	// required: true
-	Arch string `json:"arch"`
-	// required: true
-	Os string `json:"os"`
-	// required: true
-	Version string `json:"version"`
-	// required: true
-	Id string `json:"id"`
-	// required: true
-	ApiPort int `json:"api_port"`
-	// required: true
-	FilePort int `json:"file_port"`
-	// required: true
-	TftpEnabled bool `json:"tftp_enabled"`
-	// required: true
-	DhcpEnabled bool `json:"dhcp_enabled"`
-	// required: true
-	ProvisionerEnabled bool `json:"prov_enabled"`
-	// required: true
-	Stats []*Stat `json:"stats"`
-}
-
-// swagger:model
 type UserToken struct {
 	Token string
 	Info  Info


### PR DESCRIPTION
The upper 3 bits now handle reporting whether the job is incomplete,
needs the system to reboot, or needs the system to shut down.

To set that the job is incomplete, exit $(($? | 128))

To set that the runner should reboot the system, exit $(($? | 64))

To set that the runner should shut the system down, exit $(($? | 32))

If the reboot and the shutdown bits are both set, the system will
reboot.

All scripts that use exit status to signal the job runner will need to
be updated to set the appropriate bits in the final exit status.

In particular, exit 1 is now just a standard fail exit code, not a
success with reboot code.