### PR TITLE
Move plugin content into layers

### DIFF
--- a/cli/contents_test.go
+++ b/cli/contents_test.go
@@ -11,7 +11,7 @@ var contentDefaultListString string = `[
       "jobs": 0,
       "leases": 0,
       "machines": 0,
-      "params": 3,
+      "params": 0,
       "plugins": 0,
       "preferences": 0,
       "profiles": 1,
@@ -55,6 +55,19 @@ var contentDefaultListString string = `[
       "Source": "Unspecified",
       "Type": "default",
       "Version": "user"
+    }
+  },
+  {
+    "Counts": {
+      "params": 3
+    },
+    "Warnings": null,
+    "meta": {
+      "Description": "Content layer for incrementer plugin provider",
+      "Name": "incrementer",
+      "Source": "FromPluginProvider",
+      "Type": "dynamic",
+      "Version": "v3.0.2-pre-alpha-NotSet"
     }
   },
   {
@@ -123,7 +136,7 @@ var contentListContentsString = `[
       "jobs": 0,
       "leases": 0,
       "machines": 0,
-      "params": 3,
+      "params": 0,
       "plugins": 0,
       "preferences": 0,
       "profiles": 1,
@@ -174,6 +187,19 @@ var contentListContentsString = `[
       "Source": "Unspecified",
       "Type": "default",
       "Version": "user"
+    }
+  },
+  {
+    "Counts": {
+      "params": 3
+    },
+    "Warnings": null,
+    "meta": {
+      "Description": "Content layer for incrementer plugin provider",
+      "Name": "incrementer",
+      "Source": "FromPluginProvider",
+      "Type": "dynamic",
+      "Version": "v3.0.2-pre-alpha-NotSet"
     }
   },
   {

--- a/cli/contents_test.go
+++ b/cli/contents_test.go
@@ -64,7 +64,7 @@ var contentDefaultListString string = `[
     "Warnings": null,
     "meta": {
       "Description": "Content layer for incrementer plugin provider",
-      "Name": "incrementer",
+      "Name": "plugin-provider-incrementer",
       "Source": "FromPluginProvider",
       "Type": "dynamic",
       "Version": "v3.0.2-pre-alpha-NotSet"
@@ -196,7 +196,7 @@ var contentListContentsString = `[
     "Warnings": null,
     "meta": {
       "Description": "Content layer for incrementer plugin provider",
-      "Name": "incrementer",
+      "Name": "plugin-provider-incrementer",
       "Source": "FromPluginProvider",
       "Type": "dynamic",
       "Version": "v3.0.2-pre-alpha-NotSet"

--- a/cli/params_test.go
+++ b/cli/params_test.go
@@ -9,7 +9,7 @@ var paramDefaultListString string = `[
     "Available": true,
     "Errors": [],
     "Name": "incrementer/parameter",
-    "ReadOnly": false,
+    "ReadOnly": true,
     "Schema": {
       "type": "string"
     },
@@ -19,7 +19,7 @@ var paramDefaultListString string = `[
     "Available": true,
     "Errors": [],
     "Name": "incrementer/step",
-    "ReadOnly": false,
+    "ReadOnly": true,
     "Schema": {
       "type": "integer"
     },
@@ -29,7 +29,7 @@ var paramDefaultListString string = `[
     "Available": true,
     "Errors": [],
     "Name": "incrementer/touched",
-    "ReadOnly": false,
+    "ReadOnly": true,
     "Schema": {
       "type": "integer"
     },
@@ -91,7 +91,7 @@ var paramListParamsString = `[
     "Available": true,
     "Errors": [],
     "Name": "incrementer/parameter",
-    "ReadOnly": false,
+    "ReadOnly": true,
     "Schema": {
       "type": "string"
     },
@@ -101,7 +101,7 @@ var paramListParamsString = `[
     "Available": true,
     "Errors": [],
     "Name": "incrementer/step",
-    "ReadOnly": false,
+    "ReadOnly": true,
     "Schema": {
       "type": "integer"
     },
@@ -111,7 +111,7 @@ var paramListParamsString = `[
     "Available": true,
     "Errors": [],
     "Name": "incrementer/touched",
-    "ReadOnly": false,
+    "ReadOnly": true,
     "Schema": {
       "type": "integer"
     },
@@ -243,8 +243,8 @@ func TestParamCli(t *testing.T) {
 		CliTest{false, false, []string{"params", "list", "Valid=true"}, noStdinString, paramListParamsString, noErrorString},
 		CliTest{false, false, []string{"params", "list", "Valid=false"}, noStdinString, paramEmptyListString, noErrorString},
 		CliTest{false, true, []string{"params", "list", "Valid=fred"}, noStdinString, noContentString, bootEnvBadValidString},
-		CliTest{false, false, []string{"params", "list", "ReadOnly=true"}, noStdinString, paramEmptyListString, noErrorString},
-		CliTest{false, false, []string{"params", "list", "ReadOnly=false"}, noStdinString, paramListParamsString, noErrorString},
+		CliTest{false, false, []string{"params", "list", "ReadOnly=true"}, noStdinString, paramDefaultListString, noErrorString},
+		CliTest{false, false, []string{"params", "list", "ReadOnly=false"}, noStdinString, paramListJohnOnlyString, noErrorString},
 		CliTest{false, true, []string{"params", "list", "ReadOnly=fred"}, noStdinString, noContentString, bootEnvBadReadOnlyString},
 
 		CliTest{true, true, []string{"params", "show"}, noStdinString, noContentString, paramShowNoArgErrorString},

--- a/cli/plugin_providers_test.go
+++ b/cli/plugin_providers_test.go
@@ -153,6 +153,19 @@ var plugin_providerUploadMissingArgErrorString = "Error: Failed to open john: op
 
 var plugin_providerDestroySuccesString = "Deleted plugin_provider incrementer\n"
 
+var plugin_providerParamString = `{
+  "Available": true,
+  "Errors": [],
+  "Name": "incrementer/parameter",
+  "ReadOnly": true,
+  "Schema": {
+    "type": "string"
+  },
+  "Validated": true
+}
+`
+var plugin_providerMissingParamString = "Error: params GET: incrementer/parameter: Not Found\n\n"
+
 func TestPluginProviderCli(t *testing.T) {
 
 	srcFolder := tmpDir + "/plugins/incrementer"
@@ -181,7 +194,9 @@ func TestPluginProviderCli(t *testing.T) {
 		CliTest{true, true, []string{"plugin_providers", "destroy"}, noStdinString, noContentString, plugin_providerDestroyNoArgErrorString},
 		CliTest{true, true, []string{"plugin_providers", "destroy", "john", "john2"}, noStdinString, noContentString, plugin_providerDestroyTooManyArgErrorString},
 		CliTest{false, true, []string{"plugin_providers", "destroy", "john"}, noStdinString, noContentString, plugin_providerDestroyMissingArgErrorString},
+		CliTest{false, false, []string{"params", "show", "incrementer/parameter"}, noStdinString, plugin_providerParamString, noErrorString},
 		CliTest{false, false, []string{"plugin_providers", "destroy", "incrementer"}, noStdinString, plugin_providerDestroySuccesString, noErrorString},
+		CliTest{false, true, []string{"params", "show", "incrementer/parameter"}, noStdinString, noContentString, plugin_providerMissingParamString},
 	}
 	for _, test := range tests {
 		testCli(t, test)

--- a/glide.lock
+++ b/glide.lock
@@ -14,7 +14,7 @@ imports:
 - name: github.com/digitalrebar/pinger
   version: 5430ec21bf3a5c1dd6c4ce4db1e0fc0a17b94bde
 - name: github.com/digitalrebar/store
-  version: 8e3591adaba7c97d5587e9c9503a4b7167c23637
+  version: f88fa4df9c617dc0bbd7b4361fd882dabbc44ad6
 - name: github.com/elazarl/go-bindata-assetfs
   version: 30f82fa23fd844bd5bb1e5f216db87fd77b5eb43
 - name: github.com/elithrar/simple-scrypt

--- a/midlayer/controller.go
+++ b/midlayer/controller.go
@@ -394,7 +394,8 @@ func forceParamRemoval(d *DataStack, l store.Store) error {
 		}
 	}
 	for _, item := range toRemove {
-		dSubs[item[0]].Remove(item[1])
+		dSub := d.Subs()[item[0]]
+		dSub.Remove(item[1])
 	}
 	return nil
 }

--- a/midlayer/controller.go
+++ b/midlayer/controller.go
@@ -416,7 +416,8 @@ func (pc *PluginController) importPluginProvider(provider string) error {
 
 			content := &models.Content{}
 
-			content.Meta.Name = fmt.Sprintf("plugin-provider-%s", pp.Name)
+			cName := fmt.Sprintf("plugin-provider-%s", pp.Name)
+			content.Meta.Name = cName
 			content.Meta.Version = pp.Version
 			content.Meta.Description = fmt.Sprintf("Content layer for %s plugin provider", pp.Name)
 			content.Meta.Source = "FromPluginProvider"
@@ -447,7 +448,7 @@ func (pc *PluginController) importPluginProvider(provider string) error {
 						defer unlocker()
 						// Add replace the plugin content
 						ds := pc.dt.Backend.(*DataStack)
-						if nbs, hard, _ := ds.AddReplacePlugin(pp.Name, ns, pc.dt.Logger, forceParamRemoval); hard != nil {
+						if nbs, hard, _ := ds.AddReplacePlugin(cName, ns, pc.dt.Logger, forceParamRemoval); hard != nil {
 							pc.dt.Infof("debugPlugins", "Skipping %s because of bad store errors: %v\n", pp.Name, hard)
 							return hard
 						} else {

--- a/midlayer/controller.go
+++ b/midlayer/controller.go
@@ -1,7 +1,6 @@
 package midlayer
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,6 +17,7 @@ import (
 	"github.com/digitalrebar/provision/backend"
 	"github.com/digitalrebar/provision/backend/index"
 	"github.com/digitalrebar/provision/models"
+	"github.com/digitalrebar/store"
 	"github.com/fsnotify/fsnotify"
 	"github.com/gin-gonic/gin"
 )
@@ -334,6 +334,71 @@ func (pc *PluginController) restartPlugin(d backend.Stores, plugin *backend.Plug
 	pc.dt.Infof("debugPlugins", "Restarting plugin: %s(%s) complete\n", plugin.Name, plugin.Provider)
 }
 
+func (pc *PluginController) buildNewStore(content *models.Content) (newStore store.Store, err error) {
+	filename := fmt.Sprintf("memory:///")
+
+	newStore, err = store.Open(filename)
+	if err != nil {
+		return
+	}
+
+	if md, ok := newStore.(store.MetaSaver); ok {
+		data := map[string]string{
+			"Name":        content.Meta.Name,
+			"Source":      content.Meta.Source,
+			"Description": content.Meta.Description,
+			"Version":     content.Meta.Version,
+		}
+		md.SetMetaData(data)
+	}
+
+	for prefix, objs := range content.Sections {
+		var sub store.Store
+		sub, err = newStore.MakeSub(prefix)
+		if err != nil {
+			return
+		}
+
+		for k, obj := range objs {
+			err = sub.Save(k, obj)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}
+
+func forceParamRemoval(d *DataStack, l store.Store) error {
+	toRemove := [][]string{}
+	layer0 := d.Layers()[0]
+	lSubs := l.Subs()
+	dSubs := layer0.Subs()
+	for k, v := range lSubs {
+		dSub := dSubs[k]
+		if dSub == nil {
+			continue
+		}
+		lKeys, _ := v.Keys()
+		for _, key := range lKeys {
+			var dItem interface{}
+			var lItem interface{}
+			if err := dSub.Load(key, &dItem); err != nil {
+				continue
+			}
+			if err := v.Load(key, &lItem); err != nil {
+				return err
+			}
+			toRemove = append(toRemove, []string{k, key})
+		}
+	}
+	for _, item := range toRemove {
+		dSubs[item[0]].Remove(item[1])
+	}
+	return nil
+}
+
 // Try to add to available - Must lock before calling
 func (pc *PluginController) importPluginProvider(provider string) error {
 	pc.dt.Infof("debugPlugins", "Importing plugin provider: %s\n", provider)
@@ -347,6 +412,17 @@ func (pc *PluginController) importPluginProvider(provider string) error {
 			pc.dt.Infof("debugPlugins", "Skipping %s because of bad json: %s\n%s\n", provider, err, out)
 		} else {
 			skip := false
+
+			content := &models.Content{}
+
+			content.Meta.Name = pp.Name
+			content.Meta.Version = pp.Version
+			content.Meta.Description = fmt.Sprintf("Content layer for %s plugin provider", pp.Name)
+			content.Meta.Source = "FromPluginProvider"
+			content.Meta.MetaData.Meta = pp.MetaData.Meta
+			content.Sections = models.Sections{}
+			content.Sections["params"] = models.Section{}
+
 			for _, p := range pp.Parameters {
 				p.ClearValidation()
 				p.AddError(p.ValidateSchema())
@@ -354,29 +430,26 @@ func (pc *PluginController) importPluginProvider(provider string) error {
 					pc.dt.Infof("debugPlugins", "Skipping %s because of bad required scheme: %s %s\n", pp.Name, p.Name, err)
 					skip = true
 				} else {
-					// Attempt create if it doesn't exist already.
-					ref := &backend.Param{}
-					d, unlocker := pc.dt.LockEnts(ref.Locks("create")...)
-					ref2 := d(ref.Prefix()).Find(p.Name)
-					if ref2 == nil {
-						if _, err := pc.dt.Create(d, p); err != nil {
-							pc.dt.Infof("debugPlugins", "Skipping %s because parameter could not be created: %s %s\n", pp.Name, p.Name, err)
-							skip = true
-						}
-					} else {
-						j1str, _ := json.Marshal(p.Schema)
-						j2str, _ := json.Marshal(ref2.(*backend.Param).Schema)
-						if bytes.Compare(j1str, j2str) != 0 {
-							p.Errorf("%s schema in plugin doesn't match existing parameter", p.Name)
-						}
-					}
-					unlocker()
+					content.Sections["params"][p.Name] = p
 				}
 				p.SetValid()
 				p.SetAvailable()
 			}
 
 			if !skip {
+				if ns, err := pc.buildNewStore(content); err != nil {
+					pc.dt.Infof("debugPlugins", "Skipping %s because of bad store: %v\n", pp.Name, err)
+					return err
+				} else {
+					// Add replace the plugin content
+					ds := pc.dt.Backend.(*DataStack)
+					if nbs, hard, _ := ds.AddReplacePlugin(pp.Name, ns, pc.dt.Logger, forceParamRemoval); hard != nil {
+						pc.dt.Infof("debugPlugins", "Skipping %s because of bad store errors: %v\n", pp.Name, hard)
+					} else {
+						pc.dt.ReplaceBackend(nbs)
+					}
+				}
+
 				if _, ok := pc.AvailableProviders[pp.Name]; !ok {
 					pc.dt.Infof("debugPlugins", "Adding plugin provider: %s\n", pp.Name)
 					pc.AvailableProviders[pp.Name] = &pp
@@ -423,6 +496,14 @@ func (pc *PluginController) removePluginProvider(provider string) {
 
 		pc.dt.Infof("debugPlugins", "Removing plugin provider: %s\n", name)
 		pc.publishers.Publish("plugin_provider", "delete", name, pc.AvailableProviders[name])
+
+		// Remove the plugin content
+		ds := pc.dt.Backend.(*DataStack)
+		if nbs, hard, _ := ds.RemovePlugin(name, pc.dt.Logger); hard != nil {
+			pc.dt.Infof("debugPlugins", "Skipping removal of plugin content layer %s because of bad store errors: %v\n", name, hard)
+		} else {
+			pc.dt.ReplaceBackend(nbs)
+		}
 		delete(pc.AvailableProviders, name)
 	}
 }

--- a/midlayer/controller.go
+++ b/midlayer/controller.go
@@ -416,7 +416,7 @@ func (pc *PluginController) importPluginProvider(provider string) error {
 
 			content := &models.Content{}
 
-			content.Meta.Name = pp.Name
+			content.Meta.Name = fmt.Sprintf("plugin-provider-%s", pp.Name)
 			content.Meta.Version = pp.Version
 			content.Meta.Description = fmt.Sprintf("Content layer for %s plugin provider", pp.Name)
 			content.Meta.Source = "FromPluginProvider"
@@ -512,7 +512,8 @@ func (pc *PluginController) removePluginProvider(provider string) {
 			_, unlocker := pc.dt.LockAll()
 			defer unlocker()
 			ds := pc.dt.Backend.(*DataStack)
-			if nbs, hard, _ := ds.RemovePlugin(name, pc.dt.Logger); hard != nil {
+			cName := fmt.Sprintf("plugin-provider-%s", name)
+			if nbs, hard, _ := ds.RemovePlugin(cName, pc.dt.Logger); hard != nil {
 				pc.dt.Infof("debugPlugins", "Skipping removal of plugin content layer %s because of bad store errors: %v\n", name, hard)
 			} else {
 				pc.dt.ReplaceBackend(nbs)

--- a/midlayer/stack.go
+++ b/midlayer/stack.go
@@ -82,6 +82,8 @@ func (d *DataStack) rebuild(oldStore store.Store, logger *log.Logger, fixup Fixe
 	if hard == nil && oldStore != nil {
 		CleanUpStore(oldStore)
 	}
+	if hard != nil {
+	}
 	return d, hard, soft
 }
 
@@ -150,7 +152,8 @@ func fixBasic(d *DataStack, l store.Store) error {
 		}
 	}
 	for _, item := range toRemove {
-		dSubs[item[0]].Remove(item[1])
+		dSub := d.Subs()[item[0]]
+		dSub.Remove(item[1])
 	}
 	return nil
 }


### PR DESCRIPTION
This creates content layers for plugin-providers and uses the already added plugin content layers in the data stack.

This also fixes issues with the fixup routines that will actually remove layers items correctly.