### PR TITLE
Fix 5min-drp to use new tip content names

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -458,7 +458,7 @@ func (j *Job) RenderActions() ([]*models.JobAction, error) {
 		}
 		m := AsMachine(mo)
 
-		err := &models.Error{}
+		err := &models.Error{Code: http.StatusUnprocessableEntity, Type: ValidationError}
 		renderers := t.Render(d, m, err)
 		if err.HasError() != nil {
 			return nil, nil, err

--- a/cli/process_jobs.go
+++ b/cli/process_jobs.go
@@ -553,6 +553,13 @@ the stage runner wait flag.
 					task = obj.(*models.Task)
 				}
 
+				// Mark job as running
+				if _, err := Update(job.UUID.String(), `{"State": "running"}`, jo, false); err != nil {
+					Log(job.UUID, true, "Error marking job as running: %v, continue\n", err)
+					markJob(job.UUID.String(), "failed", jo)
+					continue
+				}
+
 				// Get the job data
 				var list []*models.JobAction
 				if resp, err := session.Jobs.GetJobActions(jobs.NewGetJobActionsParams().WithUUID(*job.UUID), basicAuth); err != nil {
@@ -563,12 +570,6 @@ the stage runner wait flag.
 					list = resp.Payload
 				}
 
-				// Mark job as running
-				if _, err := Update(job.UUID.String(), `{"State": "running"}`, jo, false); err != nil {
-					Log(job.UUID, true, "Error marking job as running: %v, continue\n", err)
-					markJob(job.UUID.String(), "failed", jo)
-					continue
-				}
 				fmt.Printf("Starting Task: %s (%s)\n", job.Task, job.UUID.String())
 
 				failed := false

--- a/examples/5min-drp/bin/drp-install.sh
+++ b/examples/5min-drp/bin/drp-install.sh
@@ -60,8 +60,8 @@ cat <<'EOFISOS' > drp-isos.sh
 # for 5min demo we don't want any community content - we use RackN 
 # content for pacekt.net functionality
 
-#ISOS="ce-ubuntu-16.04-install ce-centos-7.3.1611-install ce-sledgehammer"
-#ISOS="ce-centos-7.3.1611-install ce-sledgehammer"
+#ISOS="ubuntu-16.04-install centos-7-install sledgehammer"
+#ISOS="centos-7-install sledgehammer"
 
 if [[ -n "$ISOS" ]]
 then


### PR DESCRIPTION
Backend jobs should not send an error on rendering without a return
code.

Make the job running immediately so that failed jobs have a good start
time.