### PR TITLE
Fix busted Stage revalidation on Bootenv validation update

### DIFF
--- a/backend/bootenv.go
+++ b/backend/bootenv.go
@@ -327,6 +327,7 @@ func (b *BootEnv) Validate() {
 			func() {
 				stage.stores = b.stores
 				defer func() { stage.stores = nil }()
+				stage.ClearValidation()
 				stage.Validate()
 			}()
 		}

--- a/backend/dataTracker_test.go
+++ b/backend/dataTracker_test.go
@@ -25,6 +25,7 @@ type crudTest struct {
 }
 
 func (test *crudTest) Test(t *testing.T, d Stores) {
+	t.Helper()
 	passed, err := test.op(d, test.t)
 	msg := fmt.Sprintf("%s: wanted to pass: %v, passed: %v", test.name, test.pass, passed)
 	if passed == test.pass {

--- a/backend/stage_test.go
+++ b/backend/stage_test.go
@@ -22,13 +22,13 @@ func TestStageCrud(t *testing.T) {
 		{"Create Stage with no BootEnv", dt.Create, &models.Stage{Name: "nobootenv"}, true},
 		{"Create Stage with bad name /", dt.Create, &models.Stage{Name: "no/bootenv"}, false},
 		{"Create Stage with bad name \\", dt.Create, &models.Stage{Name: "no\\bootenv"}, false},
-		{"Create Stage with nonexistent BootEnv", dt.Create, &models.Stage{Name: "missingbootenv", BootEnv: "missingbootenv"}, false},
-		{"Create Stage with missing Task", dt.Create, &models.Stage{Name: "missingtask", BootEnv: "local", Tasks: []string{"jj"}}, false},
-		{"Create Stage with missing profile", dt.Create, &models.Stage{Name: "missingprofile", BootEnv: "local", Profiles: []string{"jj"}}, false},
+		{"Create Stage with nonexistent BootEnv", dt.Create, &models.Stage{Name: "missingbootenv", BootEnv: "missingbootenv"}, true},
+		{"Create Stage with missing Task", dt.Create, &models.Stage{Name: "missingtask", BootEnv: "local", Tasks: []string{"jj"}}, true},
+		{"Create Stage with missing profile", dt.Create, &models.Stage{Name: "missingprofile", BootEnv: "local", Profiles: []string{"jj"}}, true},
 		{"Create Stage with invalid models.TemplateInfo (missing Name)", dt.Create, &models.Stage{Name: "test 3", BootEnv: "local", Templates: []models.TemplateInfo{{Path: "{{ .Env.Name }}", ID: "ok"}}}, false},
 		{"Create Stage with invalid models.TemplateInfo (missing ID)", dt.Create, &models.Stage{Name: "test 3", BootEnv: "local", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }}"}}}, false},
 		{"Create Stage with invalid models.TemplateInfo (missing Path)", dt.Create, &models.Stage{Name: "test 3", BootEnv: "local", Templates: []models.TemplateInfo{{Name: "test 3", ID: "ok"}}}, false},
-		{"Create Stage with invalid models.TemplateInfo (invalid ID)", dt.Create, &models.Stage{Name: "test 3", BootEnv: "local", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }}", ID: "okp"}}}, false},
+		{"Create Stage with invalid models.TemplateInfo (invalid ID)", dt.Create, &models.Stage{Name: "invalidTemplateID", BootEnv: "local", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }}", ID: "okp"}}}, true},
 		{"Create Stage with invalid models.TemplateInfo (invalid Path)", dt.Create, &models.Stage{Name: "test 3", BootEnv: "local", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }", ID: "ok"}}}, false},
 		{"Create Stage with valid models.TemplateInfo (not available}", dt.Create, &models.Stage{Name: "test 1", BootEnv: "local", Templates: []models.TemplateInfo{{Name: "unavailable", Path: "{{ .Env.Name }}", ID: "ok"}}}, true},
 		{"Create Stage with valid models.TemplateInfo (available)", dt.Create, &models.Stage{Name: "available", BootEnv: "local", Templates: []models.TemplateInfo{{Name: "ipxe", Path: "{{ .Env.Name }}", ID: "ok"}}}, true},
@@ -41,8 +41,8 @@ func TestStageCrud(t *testing.T) {
 	// List test.
 	bes := d("stages").Items()
 	if bes != nil {
-		if len(bes) != 4 {
-			t.Errorf("List function should have returned: 4, but got %d\n", len(bes))
+		if len(bes) != 8 {
+			t.Errorf("List function should have returned: 8, but got %d\n", len(bes))
 		}
 	} else {
 		t.Errorf("List function returned nil!!")

--- a/models/templateInfo.go
+++ b/models/templateInfo.go
@@ -41,6 +41,25 @@ func (ti *TemplateInfo) Id() string {
 	return ti.ID
 }
 
+func (ti *TemplateInfo) SanityCheck(idx int, e ErrorAdder, missingPathOK bool) {
+	if ti.Name == "" {
+		e.Errorf("Template[%d] is missing a Name", idx)
+	}
+	if !missingPathOK {
+		if ti.Path == "" {
+			e.Errorf("Template[%d] is missing a Path", idx)
+		} else if _, err := template.New(ti.Name).Parse(ti.Path); err != nil {
+			e.Errorf("Template[%d] Path is not a valid text/template: %v", idx, err)
+		}
+	}
+	if ti.Contents == "" && ti.ID == "" {
+		e.Errorf("Template[%d] must have either an ID or Contents set", idx)
+	}
+	if ti.Contents != "" && ti.ID != "" {
+		e.Errorf("Template[%d] has both an ID and Contents", idx)
+	}
+}
+
 func (ti *TemplateInfo) PathTemplate() *template.Template {
 	return ti.pathTmpl
 }


### PR DESCRIPTION
Stages were not properly clearing their validation state before
revalidating when the availability of their associated BootEnv was
updated.

This change also updates how Stages are validated to allow them to be
flagged as valid (and not available) as long as their are no obvious
syntactic issues with the Stage.  In particular, we no longer require
that the associated BootEnv, Task, Template, or Profiles actually
exist, although we do theck to make sure that the Template list is at
least structurally correct.