### PR TITLE
DHCP Proxy support.

### DIFF
--- a/backend/subnet.go
+++ b/backend/subnet.go
@@ -372,6 +372,34 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 			}
 			return res, nil
 		})
+	res["Proxy"] = index.Make(
+		false,
+		"boolean",
+		func(i, j models.Model) bool {
+			return (!fix(i).Proxy) && fix(j).Proxy
+		},
+		func(ref models.Model) (gte, gt index.Test) {
+			avail := fix(ref).Proxy
+			return func(s models.Model) bool {
+					v := fix(s).Proxy
+					return v || (v == avail)
+				},
+				func(s models.Model) bool {
+					return fix(s).Proxy && !avail
+				}
+		},
+		func(st string) (models.Model, error) {
+			res := &Subnet{Subnet: &models.Subnet{}}
+			switch st {
+			case "true":
+				res.Proxy = true
+			case "false":
+				res.Proxy = false
+			default:
+				return nil, errors.New("Proxy must be true or false")
+			}
+			return res, nil
+		})
 	return res
 }
 

--- a/cli/subnet.go
+++ b/cli/subnet.go
@@ -64,6 +64,8 @@ func (be SubnetOps) List(parms map[string]string) (interface{}, error) {
 			params = params.WithStrategy(&v)
 		case "NextServer":
 			params = params.WithNextServer(&v)
+		case "Proxy":
+			params = params.WithProxy(&v)
 		}
 	}
 

--- a/cli/subnet_test.go
+++ b/cli/subnet_test.go
@@ -15,6 +15,7 @@ var subnetPatchJohnMissingErrorString string = "Error: PATCH: subnets/john2: Not
 var subnetDestroyMissingJohnString string = "Error: DELETE: subnets/john: Not Found\n\n"
 
 var subnetInvalidEnabledBooleanListString = "Error: GET: subnets: Enabled must be true or false\n\n"
+var subnetInvalidProxyBooleanListString = "Error: GET: subnets: Proxy must be true or false\n\n"
 var subnetRangeIPFailureString string = "Error: PATCH: subnets/john: invalid IP address: cq.98.42.1234\n\n"
 var subnetRangeIPBadIpString string = "Error: PATCH: subnets/john: invalid IP address: 192.168.100.500\n\n"
 var subnetSubnetCIDRFailureString = "Error: 1111.11.2223.544/66666 is not a valid subnet CIDR\n\n"
@@ -54,6 +55,7 @@ var subnetShowJohnString string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "MAC",
@@ -107,6 +109,7 @@ var subnetCreateJohnString string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "MAC",
@@ -141,6 +144,7 @@ var subnetListBothEnvsString = `[
       "nextFree",
       "mostExpired"
     ],
+    "Proxy": false,
     "ReadOnly": false,
     "ReservedLeaseTime": 7200,
     "Strategy": "MAC",
@@ -183,6 +187,7 @@ var subnetUpdateJohnString string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "NewStrat",
@@ -222,6 +227,7 @@ var subnetPatchBaseString string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "NewStrat",
@@ -258,6 +264,7 @@ var subnetPatchJohnString string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "bootx64.efi",
@@ -325,6 +332,7 @@ var subnetRangeIPSuccessString string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "NewStrat",
@@ -360,6 +368,7 @@ var subnetSubnetCIDRSuccessString = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "NewStrat",
@@ -395,6 +404,7 @@ var subnetStrategyMacSuccessString string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "a3:b3:51:66:7e:11",
@@ -430,6 +440,7 @@ var subnetPickersSuccessString string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "a3:b3:51:66:7e:11",
@@ -465,6 +476,7 @@ var subnetNextserverIPSuccess string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7200,
   "Strategy": "a3:b3:51:66:7e:11",
@@ -499,6 +511,7 @@ var subnetLeasetimesSuccessString string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7300,
   "Strategy": "a3:b3:51:66:7e:11",
@@ -539,6 +552,7 @@ var subnetSetTo66 string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7300,
   "Strategy": "a3:b3:51:66:7e:11",
@@ -571,6 +585,7 @@ var subnetSetToNull string = `{
     "nextFree",
     "mostExpired"
   ],
+  "Proxy": false,
   "ReadOnly": false,
   "ReservedLeaseTime": 7300,
   "Strategy": "a3:b3:51:66:7e:11",
@@ -603,6 +618,9 @@ func TestSubnetCli(t *testing.T) {
 		CliTest{false, false, []string{"subnets", "list", "Enabled=false"}, noStdinString, subnetListBothEnvsString, noErrorString},
 		CliTest{false, false, []string{"subnets", "list", "Enabled=true"}, noStdinString, subnetEmptyListString, noErrorString},
 		CliTest{false, true, []string{"subnets", "list", "Enabled=george"}, noStdinString, noContentString, subnetInvalidEnabledBooleanListString},
+		CliTest{false, false, []string{"subnets", "list", "Proxy=false"}, noStdinString, subnetListBothEnvsString, noErrorString},
+		CliTest{false, false, []string{"subnets", "list", "Proxy=true"}, noStdinString, subnetEmptyListString, noErrorString},
+		CliTest{false, true, []string{"subnets", "list", "Proxy=george"}, noStdinString, noContentString, subnetInvalidProxyBooleanListString},
 		CliTest{false, false, []string{"subnets", "list", "Subnet=192.168.103.0/24"}, noStdinString, subnetEmptyListString, noErrorString},
 		CliTest{false, false, []string{"subnets", "list", "Subnet=192.168.100.0/24"}, noStdinString, subnetListBothEnvsString, noErrorString},
 		CliTest{false, true, []string{"subnets", "list", "Subnet=false"}, noStdinString, noContentString, subnetExpireTimeErrorString},

--- a/frontend/subnets.go
+++ b/frontend/subnets.go
@@ -68,6 +68,8 @@ type SubnetListPathParameter struct {
 	Name string
 	// in: query
 	Enabled string
+	// in: query
+	Proxy string
 }
 
 func (f *Frontend) InitSubnetApi() {
@@ -89,6 +91,8 @@ func (f *Frontend) InitSubnetApi() {
 	//    Available = boolean
 	//    Valid = boolean
 	//    ReadOnly = boolean
+	//    Enabled = boolean
+	//    Proxy = boolean
 	//
 	// Functions:
 	//    Eq(value) = Return items that are equal to value
@@ -132,6 +136,8 @@ func (f *Frontend) InitSubnetApi() {
 	//    Available = boolean
 	//    Valid = boolean
 	//    ReadOnly = boolean
+	//    Enabled = boolean
+	//    Proxy = boolean
 	//
 	// Functions:
 	//    Eq(value) = Return items that are equal to value

--- a/midlayer/dhcp.go
+++ b/midlayer/dhcp.go
@@ -356,10 +356,10 @@ func (h *DhcpHandler) ServeDHCP(p dhcp.Packet,
 		serverBytes, ok := options[dhcp.OptionServerIdentifier]
 		server := net.IP(serverBytes)
 		if ok && !h.isOneOfMyAddrs(server) {
-			h.Infof("%s: Competing DHCP server on network: %s", xid(p), server)
+			h.Printf("WARNING: %s: Competing DHCP server on network: %s", xid(p), server)
 		}
 		if !h.isOneOfMyAddrs(cm.Src) {
-			h.Infof("%s: Competing DHCP server on network: %s", xid(p), cm.Src)
+			h.Printf("WARNING: %s: Competing DHCP server on network: %s", xid(p), cm.Src)
 		}
 
 		return nil
@@ -412,7 +412,7 @@ func (h *DhcpHandler) ServeDHCP(p dhcp.Packet,
 		serverBytes, ok := options[dhcp.OptionServerIdentifier]
 		server := net.IP(serverBytes)
 		if ok && !h.listenOn(server, cm) {
-			h.Infof("%s: Ignoring request for DHCP server %s", xid(p), net.IP(server))
+			h.Printf("WARNING: %s: Ignoring request for DHCP server %s", xid(p), net.IP(server))
 			return nil
 		}
 		if !req.IsGlobalUnicast() {
@@ -439,6 +439,7 @@ func (h *DhcpHandler) ServeDHCP(p dhcp.Packet,
 						lease.Token,
 						err)
 				} else {
+					h.Printf("WARNING: %s: Another DHCP server may be on the network: %s", xid(p), net.IP(server))
 					h.Infof("%s: %s is no longer able to be leased: %s",
 						xid(p),
 						req,

--- a/models/subnet.go
+++ b/models/subnet.go
@@ -19,6 +19,12 @@ type Subnet struct {
 	//
 	// required: true
 	Enabled bool
+	// Proxy indicates if the subnet should act as a proxy DHCP server.
+	// If true, the subnet will not manage ip addresses but will send
+	// offers to requests.
+	//
+	// required: true
+	Proxy bool
 	// Subnet is the network address in CIDR form that all leases
 	// acquired in its range will use for options, lease times, and NextServer settings
 	// by default

--- a/server/server.go
+++ b/server/server.go
@@ -48,10 +48,12 @@ type ProgOpts struct {
 	DisableTftpServer   bool   `long:"disable-tftp" description:"Disable TFTP server"`
 	DisableProvisioner  bool   `long:"disable-provisioner" description:"Disable provisioner"`
 	DisableDHCP         bool   `long:"disable-dhcp" description:"Disable DHCP server"`
+	DisablePXE          bool   `long:"disable-pxe" description:"Disable PXE/BINL server"`
 	StaticPort          int    `long:"static-port" description:"Port the static HTTP file server should listen on" default:"8091"`
 	TftpPort            int    `long:"tftp-port" description:"Port for the TFTP server to listen on" default:"69"`
 	ApiPort             int    `long:"api-port" description:"Port for the API server to listen on" default:"8092"`
 	DhcpPort            int    `long:"dhcp-port" description:"Port for the DHCP server to listen on" default:"67"`
+	PxePort             int    `long:"pxe-port" description:"Port for the PXE/BINL server to listen on" default:"4011"`
 	UnknownTokenTimeout int    `long:"unknown-token-timeout" description:"The default timeout in seconds for the machine create authorization token" default:"600"`
 	KnownTokenTimeout   int    `long:"known-token-timeout" description:"The default timeout in seconds for the machine update authorization token" default:"3600"`
 	OurAddress          string `long:"static-ip" description:"IP address to advertise for the static HTTP file server" default:"192.168.124.11"`
@@ -228,10 +230,19 @@ func Server(c_opts *ProgOpts) {
 
 	if !c_opts.DisableDHCP {
 		logger.Printf("Starting DHCP server")
-		if svc, err := midlayer.StartDhcpHandler(dt, c_opts.DhcpInterfaces, c_opts.DhcpPort, publishers); err != nil {
+		if svc, err := midlayer.StartDhcpHandler(dt, c_opts.DhcpInterfaces, c_opts.DhcpPort, publishers, false); err != nil {
 			logger.Fatalf("Error starting DHCP server: %v", err)
 		} else {
 			services = append(services, svc)
+		}
+
+		if !c_opts.DisablePXE {
+			logger.Printf("Starting PXE/BINL server")
+			if svc, err := midlayer.StartDhcpHandler(dt, c_opts.DhcpInterfaces, c_opts.PxePort, publishers, true); err != nil {
+				logger.Fatalf("Error starting PXE/BINL server: %v", err)
+			} else {
+				services = append(services, svc)
+			}
 		}
 	}
 


### PR DESCRIPTION
This PR add the ability for a subnet to be place in PROXY mode.  This will generate DHCP proxy messages for DHCP Discover messages that include the subnet options.  If the proxy variable is false the subnet operates like normal.  

Additionally, port 4011 is opened and responses with an additional PXE/BINL(?) protocol to return boot parameters as well.  It uses similar DHCP protocol messages but slightly different.