### PR TITLE
change 'url' to reference 'window.location' elements

### DIFF
--- a/embedded/assets/swagger-ui/index.html
+++ b/embedded/assets/swagger-ui/index.html
@@ -38,7 +38,9 @@
       if (url && url.length > 1) {
         url = decodeURIComponent(url[1]);
       } else {
-        url = "https://127.0.0.1:8092/swagger.json";
+        // does not work correctly with file:// URIs
+        var Location = window.location.protocol + "//" + window.location.hostname + ":" + window.location.port;
+        url = Location + "/swagger.json";
       }
 
       hljs.configure({


### PR DESCRIPTION
creates a change on first invocation of swagger-ui to use the JavaScript 'window.location.' elements to pre-fill the swagger target.  This helps prevent the initial "why doesn't swagger-ui work", since it's hardcoded to fill-out the 127.0.0.1:8092 location. 