### PR TITLE
This address two inconsistencies in our models.

### DIFF
--- a/api/change_stage_test.go
+++ b/api/change_stage_test.go
@@ -23,18 +23,17 @@ BootEnv: local
 Meta:
   feature-flags: ""
 Name: john
-Profile:
-  Params:
-    change-stage/map:
-      stageNoWait: stageDoneNoWait:Success
-      stageNoWait1: stageDoneWait:Success
-      stageWait: stageDoneNoWait:Success
-      stageWait1: stageDoneWait:Success
-      stageStop: stageDoneWait:Stop
-      stageReboot: stageDoneWait:Reboot
-      stageRealReboot: stageDoneWait:Success
-      stageRealReboot1: stageDoneReboot:Success
-      fred-install: stageDoneWait:Success
+Params:
+  change-stage/map:
+    stageNoWait: stageDoneNoWait:Success
+    stageNoWait1: stageDoneWait:Success
+    stageWait: stageDoneNoWait:Success
+    stageWait1: stageDoneWait:Success
+    stageStop: stageDoneWait:Stop
+    stageReboot: stageDoneWait:Reboot
+    stageRealReboot: stageDoneWait:Success
+    stageRealReboot1: stageDoneReboot:Success
+    fred-install: stageDoneWait:Success
 Uuid: 3e7031fe-3062-45f1-835c-92541bc9cbd3
 Validated: true
 `).(*models.Machine)

--- a/api/info_test.go
+++ b/api/info_test.go
@@ -37,6 +37,7 @@ func TestInfo(t *testing.T) {
 				"change-stage-map",
 				"job-exit-states",
 				"package-repository-handling",
+				"profileless-machine",
 			},
 		},
 		expectErr: nil,

--- a/backend/bootenv_test.go
+++ b/backend/bootenv_test.go
@@ -17,25 +17,19 @@ func TestBootEnvCrud(t *testing.T) {
 		return
 	}
 
-	tests := []crudTest{
-		{"Create Bootenv with nonexistent Name", dt.Create, &models.BootEnv{}, false},
-		{"Create Bootenv with no templates", dt.Create, &models.BootEnv{Name: "test 1"}, true},
-		{"Create Bootenv with invalid Name /", dt.Create, &models.BootEnv{Name: "test/greg"}, false},
-		{"Create Bootenv with invalid Name \\", dt.Create, &models.BootEnv{Name: "test\\greg"}, false},
-		{"Create Bootenv with invalid BootParams tmpl", dt.Create, &models.BootEnv{Name: "test 2", BootParams: "{{ }"}, false},
-		{"Create Bootenv with valid BootParams tmpl", dt.Create, &models.BootEnv{Name: "test 2", BootParams: "{{ .Env.Name }}"}, true},
-		{"Create Bootenv with invalid models.TemplateInfo (missing Name)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Path: "{{ .Env.Name }}", ID: "ok"}}}, false},
-		{"Create Bootenv with invalid models.TemplateInfo (missing ID)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }}"}}}, false},
-		{"Create Bootenv with invalid models.TemplateInfo (missing Path)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", ID: "ok"}}}, false},
-		{"Create Bootenv with invalid models.TemplateInfo (invalid ID)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }}", ID: "okp"}}}, false},
-		{"Create Bootenv with invalid models.TemplateInfo (invalid Path)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }", ID: "ok"}}}, false},
-		{"Create Bootenv with valid models.TemplateInfo (not available}", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "unavailable", Path: "{{ .Env.Name }}", ID: "ok"}}}, true},
-		{"Create Bootenv with valid models.TemplateInfo (available)", dt.Create, &models.BootEnv{Name: "available", Templates: []models.TemplateInfo{{Name: "ipxe", Path: "{{ .Env.Name }}", ID: "ok"}}}, true},
-	}
-
-	for _, test := range tests {
-		test.Test(t, d)
-	}
+	crudTest{"Create Bootenv with nonexistent Name", dt.Create, &models.BootEnv{}, false}.Test(t, d)
+	crudTest{"Create Bootenv with no templates", dt.Create, &models.BootEnv{Name: "test 1"}, true}.Test(t, d)
+	crudTest{"Create Bootenv with invalid Name /", dt.Create, &models.BootEnv{Name: "test/greg"}, false}.Test(t, d)
+	crudTest{"Create Bootenv with invalid Name \\", dt.Create, &models.BootEnv{Name: "test\\greg"}, false}.Test(t, d)
+	crudTest{"Create Bootenv with invalid BootParams tmpl", dt.Create, &models.BootEnv{Name: "test 2", BootParams: "{{ }"}, false}.Test(t, d)
+	crudTest{"Create Bootenv with valid BootParams tmpl", dt.Create, &models.BootEnv{Name: "test 2", BootParams: "{{ .Env.Name }}"}, true}.Test(t, d)
+	crudTest{"Create Bootenv with invalid models.TemplateInfo (missing Name)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Path: "{{ .Env.Name }}", ID: "ok"}}}, false}.Test(t, d)
+	crudTest{"Create Bootenv with invalid models.TemplateInfo (missing ID)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }}"}}}, false}.Test(t, d)
+	crudTest{"Create Bootenv with invalid models.TemplateInfo (missing Path)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", ID: "ok"}}}, false}.Test(t, d)
+	crudTest{"Create Bootenv with invalid models.TemplateInfo (invalid ID)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }}", ID: "okp"}}}, false}.Test(t, d)
+	crudTest{"Create Bootenv with invalid models.TemplateInfo (invalid Path)", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "test 3", Path: "{{ .Env.Name }", ID: "ok"}}}, false}.Test(t, d)
+	crudTest{"Create Bootenv with valid models.TemplateInfo (not available}", dt.Create, &models.BootEnv{Name: "test 3", Templates: []models.TemplateInfo{{Name: "unavailable", Path: "{{ .Env.Name }}", ID: "ok"}}}, true}.Test(t, d)
+	crudTest{"Create Bootenv with valid models.TemplateInfo (available)", dt.Create, &models.BootEnv{Name: "available", Templates: []models.TemplateInfo{{Name: "ipxe", Path: "{{ .Env.Name }}", ID: "ok"}}}, true}.Test(t, d)
 
 	// List test.
 	bes := d("bootenvs").Items()
@@ -53,12 +47,7 @@ func TestBootEnvCrud(t *testing.T) {
 		t.Errorf("Failed to create test machine: %v", err)
 		return
 	}
-	rmTests := []crudTest{
-		{"Remove BootEnv that is not in use", dt.Remove, &models.BootEnv{Name: "test 1"}, true},
-		{"Remove nonexistent BootEnv", dt.Remove, &models.BootEnv{Name: "test 1"}, false},
-		{"Remove BootEnv that is in use", dt.Remove, &models.BootEnv{Name: "available"}, false},
-	}
-	for _, test := range rmTests {
-		test.Test(t, d)
-	}
+	crudTest{"Remove BootEnv that is not in use", dt.Remove, &models.BootEnv{Name: "test 1"}, true}.Test(t, d)
+	crudTest{"Remove nonexistent BootEnv", dt.Remove, &models.BootEnv{Name: "test 1"}, false}.Test(t, d)
+	crudTest{"Remove BootEnv that is in use", dt.Remove, &models.BootEnv{Name: "available"}, false}.Test(t, d)
 }

--- a/backend/dataTracker.go
+++ b/backend/dataTracker.go
@@ -53,9 +53,9 @@ chain tftp://{{.ProvisionerAddress}}/${netX/ip}.ipxe || exit
 `,
 				},
 			},
-			MetaData: models.MetaData{Meta: map[string]string{
+			Meta: map[string]string{
 				"feature-flags": "change-stage-v2",
-			}},
+			},
 		}
 
 		localBoot = &models.BootEnv{
@@ -89,28 +89,28 @@ exit
 `,
 				},
 			},
-			MetaData: models.MetaData{Meta: map[string]string{
+			Meta: map[string]string{
 				"feature-flags": "change-stage-v2",
-			}},
+			},
 		}
 		noneStage = &models.Stage{
 			Name:        "none",
 			Description: "Noop / Nothing stage",
-			MetaData: models.MetaData{Meta: map[string]string{
+			Meta: map[string]string{
 				"icon":  "circle thin",
 				"color": "green",
 				"title": "Digital Rebar Provision",
-			}},
+			},
 		}
 		localStage = &models.Stage{
 			Name:        "local",
 			BootEnv:     "local",
 			Description: "Stage to boot into the local BootEnv.",
-			MetaData: models.MetaData{Meta: map[string]string{
+			Meta: map[string]string{
 				"icon":  "radio",
 				"color": "green",
 				"title": "Digital Rebar Provision",
-			}},
+			},
 		}
 	)
 	res, _ := store.Open("memory:///")
@@ -711,11 +711,11 @@ func NewDataTracker(backend store.Store,
 			Name:        res.GlobalProfileName,
 			Description: "Global profile attached automatically to all machines.",
 			Params:      map[string]interface{}{},
-			MetaData: models.MetaData{Meta: map[string]string{
+			Meta: map[string]string{
 				"icon":  "world",
 				"color": "blue",
 				"title": "Digital Rebar Provision",
-			}},
+			},
 		})
 	}
 	users := d("users")

--- a/backend/dataTracker_test.go
+++ b/backend/dataTracker_test.go
@@ -24,7 +24,7 @@ type crudTest struct {
 	pass bool
 }
 
-func (test *crudTest) Test(t *testing.T, d Stores) {
+func (test crudTest) Test(t *testing.T, d Stores) {
 	t.Helper()
 	passed, err := test.op(d, test.t)
 	msg := fmt.Sprintf("%s: wanted to pass: %v, passed: %v", test.name, test.pass, passed)

--- a/backend/dhcpUtils_test.go
+++ b/backend/dhcpUtils_test.go
@@ -101,6 +101,7 @@ type ltc struct {
 }
 
 func (l *ltc) test(t *testing.T, dt *DataTracker) {
+	t.Helper()
 	res, _, _, _ := FindOrCreateLease(dt, l.strat, l.token, l.req, []net.IP{l.via})
 	if l.created {
 		if res == nil {

--- a/cli/test-data/output/TestContentsFunctionalCli/machines.addprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.p1-prof/stdout.expect
+++ b/cli/test-data/output/TestContentsFunctionalCli/machines.addprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.p1-prof/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "greg",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestContentsFunctionalCli/machines.create.7df3aabd2b2a9aa089f7c54b01060cb9/stdout.expect
+++ b/cli/test-data/output/TestContentsFunctionalCli/machines.create.7df3aabd2b2a9aa089f7c54b01060cb9/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "greg",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestJobCli/machines.create.32cb4c9864de6e606c2e84397f300c18/stdout.expect
+++ b/cli/test-data/output/TestJobCli/machines.create.32cb4c9864de6e606c2e84397f300c18/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestJobCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
+++ b/cli/test-data/output/TestJobCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestJobCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.15ef88524f82284ee914fdb15df5a1ef/stdout.expect
+++ b/cli/test-data/output/TestJobCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.15ef88524f82284ee914fdb15df5a1ef/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.addprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.jean/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.addprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.jean/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.addprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.jill/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.addprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.jill/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.bootenv.3e7031fe-3062-45f1-835c-92541bc9cbd3.john2/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.bootenv.3e7031fe-3062-45f1-835c-92541bc9cbd3.john2/stdout.expect
@@ -13,13 +13,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.bootenv.3e7031fe-3062-45f1-835c-92541bc9cbd3.local/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.bootenv.3e7031fe-3062-45f1-835c-92541bc9cbd3.local/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.create.2912607b00fab33ffd503f06c4ee28b8.3/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.create.2912607b00fab33ffd503f06c4ee28b8.3/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.create.2912607b00fab33ffd503f06c4ee28b8/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.create.2912607b00fab33ffd503f06c4ee28b8/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.create.cfb21459eb66dff02c687e0bdfed8ab9/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.create.cfb21459eb66dff02c687e0bdfed8ab9/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.list.2/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.list.2/stdout.expect
@@ -12,13 +12,14 @@
     },
     "Name": "john",
     "OS": "",
+    "Params": {},
     "Profile": {
       "Available": false,
       "Description": "",
-      "Errors": [],
-      "Meta": {},
+      "Errors": null,
+      "Meta": null,
       "Name": "",
-      "Params": {},
+      "Params": null,
       "ReadOnly": false,
       "Validated": false
     },

--- a/cli/test-data/output/TestMachineCli/machines.list.4/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.list.4/stdout.expect
@@ -12,13 +12,14 @@
     },
     "Name": "john",
     "OS": "",
+    "Params": {},
     "Profile": {
       "Available": false,
       "Description": "",
-      "Errors": [],
-      "Meta": {},
+      "Errors": null,
+      "Meta": null,
       "Name": "",
-      "Params": {},
+      "Params": null,
       "ReadOnly": false,
       "Validated": false
     },

--- a/cli/test-data/output/TestMachineCli/machines.list.Address=192.168.100.110/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.list.Address=192.168.100.110/stdout.expect
@@ -12,13 +12,14 @@
     },
     "Name": "john",
     "OS": "",
+    "Params": {},
     "Profile": {
       "Available": false,
       "Description": "",
-      "Errors": [],
-      "Meta": {},
+      "Errors": null,
+      "Meta": null,
       "Name": "",
-      "Params": {},
+      "Params": null,
       "ReadOnly": false,
       "Validated": false
     },

--- a/cli/test-data/output/TestMachineCli/machines.list.BootEnv=local/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.list.BootEnv=local/stdout.expect
@@ -12,13 +12,14 @@
     },
     "Name": "john",
     "OS": "",
+    "Params": {},
     "Profile": {
       "Available": false,
       "Description": "",
-      "Errors": [],
-      "Meta": {},
+      "Errors": null,
+      "Meta": null,
       "Name": "",
-      "Params": {},
+      "Params": null,
       "ReadOnly": false,
       "Validated": false
     },

--- a/cli/test-data/output/TestMachineCli/machines.list.Name=john/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.list.Name=john/stdout.expect
@@ -12,13 +12,14 @@
     },
     "Name": "john",
     "OS": "",
+    "Params": {},
     "Profile": {
       "Available": false,
       "Description": "",
-      "Errors": [],
-      "Meta": {},
+      "Errors": null,
+      "Meta": null,
       "Name": "",
-      "Params": {},
+      "Params": null,
       "ReadOnly": false,
       "Validated": false
     },

--- a/cli/test-data/output/TestMachineCli/machines.list.Runnable=true/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.list.Runnable=true/stdout.expect
@@ -12,13 +12,14 @@
     },
     "Name": "john",
     "OS": "",
+    "Params": {},
     "Profile": {
       "Available": false,
       "Description": "",
-      "Errors": [],
-      "Meta": {},
+      "Errors": null,
+      "Meta": null,
       "Name": "",
-      "Params": {},
+      "Params": null,
       "ReadOnly": false,
       "Validated": false
     },

--- a/cli/test-data/output/TestMachineCli/machines.list.Uuid=3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.list.Uuid=3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
@@ -12,13 +12,14 @@
     },
     "Name": "john",
     "OS": "",
+    "Params": {},
     "Profile": {
       "Available": false,
       "Description": "",
-      "Errors": [],
-      "Meta": {},
+      "Errors": null,
+      "Meta": null,
       "Name": "",
-      "Params": {},
+      "Params": null,
       "ReadOnly": false,
       "Validated": false
     },

--- a/cli/test-data/output/TestMachineCli/machines.removeprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.jean/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.removeprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.jean/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.removeprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.jill/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.removeprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.jill/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.removeprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.justine/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.removeprofile.3e7031fe-3062-45f1-835c-92541bc9cbd3.justine/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3.2/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3.2/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3.3/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3.3/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3.4/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3.4/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3.5/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3.5/stdout.expect
@@ -11,15 +11,16 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {
+    "jj": 3
+  },
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {
-      "jj": 3
-    },
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.show.3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.show.Key:3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.show.Key:3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.show.Name:john/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.show.Name:john/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.show.Uuid:3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.show.Uuid:3e7031fe-3062-45f1-835c-92541bc9cbd3/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.c23ab3adaec8ca15ff3ffd0971be6152.2/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.c23ab3adaec8ca15ff3ffd0971be6152.2/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.c23ab3adaec8ca15ff3ffd0971be6152/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.c23ab3adaec8ca15ff3ffd0971be6152/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.stage1/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.stage1/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.stage2.c23ab3adaec8ca15ff3ffd0971be6152.2/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.stage2.c23ab3adaec8ca15ff3ffd0971be6152.2/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.stage2.c23ab3adaec8ca15ff3ffd0971be6152/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.stage.3e7031fe-3062-45f1-835c-92541bc9cbd3.stage2.c23ab3adaec8ca15ff3ffd0971be6152/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.15ef88524f82284ee914fdb15df5a1ef.2/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.15ef88524f82284ee914fdb15df5a1ef.2/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.15ef88524f82284ee914fdb15df5a1ef/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.15ef88524f82284ee914fdb15df5a1ef/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.21522342df50227b4f678203d499d51a/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.21522342df50227b4f678203d499d51a/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.5372645be509d5c9bddcfa65cf87f668/stdout.expect
+++ b/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.5372645be509d5c9bddcfa65cf87f668/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineTaskCli/machines.create.2912607b00fab33ffd503f06c4ee28b8/stdout.expect
+++ b/cli/test-data/output/TestMachineTaskCli/machines.create.2912607b00fab33ffd503f06c4ee28b8/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.at.0.task4.task3.task2.task1.2/stdout.expect
+++ b/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.at.0.task4.task3.task2.task1.2/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.at.0.task4.task3.task2.task1/stdout.expect
+++ b/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.at.0.task4.task3.task2.task1/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task2.task3.task4.2/stdout.expect
+++ b/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task2.task3.task4.2/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task2.task3.task4.3/stdout.expect
+++ b/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task2.task3.task4.3/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task2.task3.task4/stdout.expect
+++ b/cli/test-data/output/TestMachineTaskCli/machines.tasks.add.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task2.task3.task4/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineTaskCli/machines.tasks.del.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task1/stdout.expect
+++ b/cli/test-data/output/TestMachineTaskCli/machines.tasks.del.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task1/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineTaskCli/machines.tasks.del.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task3/stdout.expect
+++ b/cli/test-data/output/TestMachineTaskCli/machines.tasks.del.3e7031fe-3062-45f1-835c-92541bc9cbd3.task1.task3/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestMachineTaskCli/machines.tasks.del.3e7031fe-3062-45f1-835c-92541bc9cbd3.task2.task4/stdout.expect
+++ b/cli/test-data/output/TestMachineTaskCli/machines.tasks.del.3e7031fe-3062-45f1-835c-92541bc9cbd3.task2.task4/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestParamsDefaultGet/machines.create.2912607b00fab33ffd503f06c4ee28b8/stdout.expect
+++ b/cli/test-data/output/TestParamsDefaultGet/machines.create.2912607b00fab33ffd503f06c4ee28b8/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestProcessJobsCli/machines.create.2912607b00fab33ffd503f06c4ee28b8/stdout.expect
+++ b/cli/test-data/output/TestProcessJobsCli/machines.create.2912607b00fab33ffd503f06c4ee28b8/stdout.expect
@@ -11,13 +11,14 @@
   },
   "Name": "john",
   "OS": "",
+  "Params": {},
   "Profile": {
     "Available": false,
     "Description": "",
-    "Errors": [],
-    "Meta": {},
+    "Errors": null,
+    "Meta": null,
     "Name": "",
-    "Params": {},
+    "Params": null,
     "ReadOnly": false,
     "Validated": false
   },

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
@@ -10,7 +10,8 @@ RE:
       "common-blob-size",
       "change-stage-map",
       "job-exit-states",
-      "package-repository-handling"
+      "package-repository-handling",
+      "profileless-machine"
     \],
     "file_port": 10002,
     "id": "Fred",

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
@@ -10,7 +10,8 @@ RE:
       "common-blob-size",
       "change-stage-map",
       "job-exit-states",
-      "package-repository-handling"
+      "package-repository-handling",
+      "profileless-machine"
     \],
     "file_port": 10002,
     "id": "Fred",

--- a/frontend/info.go
+++ b/frontend/info.go
@@ -36,6 +36,7 @@ func (f *Frontend) GetInfo(drpid string) (*models.Info, *models.Error) {
 			"change-stage-map",
 			"job-exit-states",
 			"package-repository-handling",
+			"profileless-machine",
 		},
 	}
 

--- a/midlayer/controller.go
+++ b/midlayer/controller.go
@@ -387,7 +387,7 @@ func (pc *PluginController) importPluginProvider(provider string) error {
 					return err
 				}
 			} else {
-				content.Meta.MetaData.Meta = pp.MetaData.Meta
+				content.Meta.Meta = pp.Meta
 			}
 			cName := pp.Name
 			content.Meta.Name = cName

--- a/models/bootenv.go
+++ b/models/bootenv.go
@@ -31,7 +31,7 @@ type OsInfo struct {
 type BootEnv struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// The name of the boot environment.  Boot environments that install
 	// an operating system must end in '-install'.
 	//
@@ -127,8 +127,10 @@ func (b *BootEnv) ToModels(obj interface{}) []Model {
 }
 
 func (b *BootEnv) Fill() {
-	b.MetaData.fill()
 	b.Validation.fill()
+	if b.Meta == nil {
+		b.Meta = Meta{}
+	}
 	if b.Initrds == nil {
 		b.Initrds = []string{}
 	}

--- a/models/content.go
+++ b/models/content.go
@@ -3,7 +3,7 @@ package models
 import "github.com/digitalrebar/store"
 
 type ContentMetaData struct {
-	MetaData
+	Meta
 
 	// required: true
 	Name        string
@@ -122,7 +122,9 @@ func (c *Content) Key() string {
 }
 
 func (c *Content) Fill() {
-	c.Meta.MetaData.fill()
+	if c.Meta.Meta == nil {
+		c.Meta.Meta = Meta{}
+	}
 	if c.Sections == nil {
 		c.Sections = Sections(map[string]Section{})
 	}
@@ -140,7 +142,9 @@ type ContentSummary struct {
 }
 
 func (c *ContentSummary) Fill() {
-	c.Meta.fill()
+	if c.Meta.Meta == nil {
+		c.Meta.Meta = Meta{}
+	}
 	if c.Counts == nil {
 		c.Counts = map[string]int{}
 	}

--- a/models/interface.go
+++ b/models/interface.go
@@ -3,7 +3,7 @@ package models
 // swagger:model
 type Interface struct {
 	Access
-	MetaData
+	Meta
 	// Name of the interface
 	//
 	// required: true
@@ -24,7 +24,9 @@ type Interface struct {
 func (i *Interface) Prefix() string { return "interfaces" }
 func (i *Interface) Key() string    { return i.Name }
 func (i *Interface) Fill() {
-	i.MetaData.fill()
+	if i.Meta == nil {
+		i.Meta = Meta{}
+	}
 	if i.Addresses == nil {
 		i.Addresses = []string{}
 	}

--- a/models/job.go
+++ b/models/job.go
@@ -24,7 +24,7 @@ type JobAction struct {
 type Job struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// The UUID of the job.  The primary key.
 	// required: true
 	// swagger:strfmt uuid
@@ -88,7 +88,9 @@ func (j *Job) Key() string {
 }
 
 func (j *Job) Fill() {
-	j.MetaData.fill()
+	if j.Meta == nil {
+		j.Meta = Meta{}
+	}
 	j.Validation.fill()
 }
 

--- a/models/lease.go
+++ b/models/lease.go
@@ -20,7 +20,7 @@ func Hexaddr(addr net.IP) string {
 type Lease struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// Addr is the IP address that the lease handed out.
 	//
 	// required: true
@@ -60,7 +60,9 @@ func (l *Lease) Key() string {
 }
 
 func (l *Lease) Fill() {
-	l.MetaData.fill()
+	if l.Meta == nil {
+		l.Meta = Meta{}
+	}
 	l.Validation.fill()
 }
 

--- a/models/machine.go
+++ b/models/machine.go
@@ -14,7 +14,7 @@ import (
 type Machine struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// The name of the machine.  THis must be unique across all
 	// machines, and by convention it is the FQDN of the machine,
 	// although nothing enforces that.
@@ -54,8 +54,11 @@ type Machine struct {
 	Profiles []string
 	//
 	// The Machine specific Profile Data - only used for the map (name and other
-	// fields not used
+	// fields not used - THIS IS DEPRECATED AND WILL GO AWAY.
+	// Data will migrated from this struct to Params and then cleared.
 	Profile Profile
+	// Replaces the Profile.
+	Params map[string]interface{}
 	// The tasks this machine has to run.
 	Tasks []string
 	// required: true
@@ -99,7 +102,9 @@ func (n *Machine) Key() string {
 }
 
 func (n *Machine) Fill() {
-	n.MetaData.fill()
+	if n.Meta == nil {
+		n.Meta = Meta{}
+	}
 	n.Validation.fill()
 	if n.Profiles == nil {
 		n.Profiles = []string{}
@@ -107,7 +112,9 @@ func (n *Machine) Fill() {
 	if n.Tasks == nil {
 		n.Tasks = []string{}
 	}
-	n.Profile.Fill()
+	if n.Params == nil {
+		n.Params = map[string]interface{}{}
+	}
 }
 
 func (n *Machine) AuthKey() string {
@@ -130,11 +137,11 @@ func (b *Machine) ToModels(obj interface{}) []Model {
 
 // match Paramer interface
 func (b *Machine) GetParams() map[string]interface{} {
-	return b.Profile.Params
+	return b.Params
 }
 
 func (b *Machine) SetParams(p map[string]interface{}) {
-	b.Profile.Params = p
+	b.Params = p
 }
 
 // match Profiler interface

--- a/models/meta.go
+++ b/models/meta.go
@@ -9,30 +9,20 @@ import (
 // Initial usage will be for UX elements.
 //
 // swagger: model
-type MetaData struct {
-	Meta map[string]string
+type Meta map[string]string
+
+func (m Meta) ClearFeatures() {
+	m["feature-flags"] = ""
 }
 
-func (m *MetaData) fill() {
-	if m.Meta == nil {
-		m.Meta = map[string]string{}
-	}
-}
-
-func (m *MetaData) ClearFeatures() {
-	m.fill()
-	m.Meta["feature-flags"] = ""
-}
-
-func (m *MetaData) Features() []string {
-	m.fill()
-	if flags, ok := m.Meta["feature-flags"]; ok && len(flags) > 0 {
+func (m Meta) Features() []string {
+	if flags, ok := m["feature-flags"]; ok && len(flags) > 0 {
 		return strings.Split(flags, ",")
 	}
 	return []string{}
 }
 
-func (m *MetaData) HasFeature(flag string) bool {
+func (m Meta) HasFeature(flag string) bool {
 	flag = strings.TrimSpace(flag)
 	for _, testFlag := range m.Features() {
 		if flag == strings.TrimSpace(testFlag) {
@@ -42,7 +32,7 @@ func (m *MetaData) HasFeature(flag string) bool {
 	return false
 }
 
-func (m *MetaData) AddFeature(flag string) {
+func (m Meta) AddFeature(flag string) {
 	flag = strings.TrimSpace(flag)
 	if m.HasFeature(flag) || flag == "" {
 		return
@@ -50,10 +40,10 @@ func (m *MetaData) AddFeature(flag string) {
 	flags := m.Features()
 	flags = append(flags, flag)
 	sort.Strings(flags)
-	m.Meta["feature-flags"] = strings.Join(flags, ",")
+	m["feature-flags"] = strings.Join(flags, ",")
 }
 
-func (m *MetaData) RemoveFeature(flag string) {
+func (m Meta) RemoveFeature(flag string) {
 	flag = strings.TrimSpace(flag)
 	newFlags := []string{}
 	for _, testFlag := range m.Features() {
@@ -62,10 +52,10 @@ func (m *MetaData) RemoveFeature(flag string) {
 		}
 		newFlags = append(newFlags, testFlag)
 	}
-	m.Meta["feature-flags"] = strings.Join(newFlags, ",")
+	m["feature-flags"] = strings.Join(newFlags, ",")
 }
 
-func (m *MetaData) MergeFeatures(other []string) {
+func (m Meta) MergeFeatures(other []string) {
 	flags := map[string]struct{}{}
 	for _, flag := range m.Features() {
 		flags[flag] = struct{}{}
@@ -81,5 +71,5 @@ func (m *MetaData) MergeFeatures(other []string) {
 		newFlags = append(newFlags, k)
 	}
 	sort.Strings(newFlags)
-	m.Meta["feature-flags"] = strings.Join(newFlags, ",")
+	m["feature-flags"] = strings.Join(newFlags, ",")
 }

--- a/models/param.go
+++ b/models/param.go
@@ -10,7 +10,7 @@ import "github.com/xeipuuv/gojsonschema"
 type Param struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// Name is the name of the param.  Params must be uniquely named.
 	//
 	// required: true
@@ -70,7 +70,9 @@ func (p *Param) Key() string {
 }
 
 func (p *Param) Fill() {
-	p.MetaData.fill()
+	if p.Meta == nil {
+		p.Meta = Meta{}
+	}
 	p.Validation.fill()
 }
 

--- a/models/plugin.go
+++ b/models/plugin.go
@@ -6,7 +6,7 @@ package models
 type Plugin struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// The name of the plugin instance.  THis must be unique across all
 	// plugins.
 	//
@@ -48,7 +48,9 @@ func (n *Plugin) Key() string {
 }
 
 func (n *Plugin) Fill() {
-	n.MetaData.fill()
+	if n.Meta == nil {
+		n.Meta = Meta{}
+	}
 	n.Validation.fill()
 	if n.Params == nil {
 		n.Params = map[string]interface{}{}

--- a/models/plugin_provider.go
+++ b/models/plugin_provider.go
@@ -11,7 +11,7 @@ import (
 // instantiated by a plugin.
 // swagger:model
 type PluginProvider struct {
-	MetaData
+	Meta
 
 	Name    string
 	Version string
@@ -48,7 +48,9 @@ func (p *PluginProvider) ToModels(obj interface{}) []Model {
 }
 
 func (p *PluginProvider) Fill() {
-	p.MetaData.fill()
+	if p.Meta == nil {
+		p.Meta = Meta{}
+	}
 	if p.RequiredParams == nil {
 		p.RequiredParams = []string{}
 	}

--- a/models/preference.go
+++ b/models/preference.go
@@ -5,7 +5,7 @@ package models
 // default bootenv for known systems, etc.
 //
 type Pref struct {
-	MetaData
+	Meta
 	Name string
 	Val  string
 }
@@ -19,7 +19,9 @@ func (p *Pref) Key() string {
 }
 
 func (p *Pref) Fill() {
-	p.MetaData.fill()
+	if p.Meta == nil {
+		p.Meta = Meta{}
+	}
 }
 
 func (p *Pref) AuthKey() string {

--- a/models/profile.go
+++ b/models/profile.go
@@ -11,7 +11,7 @@ package models
 type Profile struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// The name of the profile.  This must be unique across all
 	// profiles.
 	//
@@ -43,7 +43,9 @@ func (p *Profile) Key() string {
 
 func (p *Profile) Fill() {
 	p.Validation.fill()
-	p.MetaData.fill()
+	if p.Meta == nil {
+		p.Meta = Meta{}
+	}
 	if p.Params == nil {
 		p.Params = map[string]interface{}{}
 	}

--- a/models/reservation.go
+++ b/models/reservation.go
@@ -8,7 +8,7 @@ import "net"
 type Reservation struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// Addr is the IP address permanently assigned to the strategy/token combination.
 	//
 	// required: true
@@ -42,7 +42,9 @@ func (r *Reservation) Key() string {
 
 func (r *Reservation) Fill() {
 	r.Validation.fill()
-	r.MetaData.fill()
+	if r.Meta == nil {
+		r.Meta = Meta{}
+	}
 	if r.Options == nil {
 		r.Options = []DhcpOption{}
 	}

--- a/models/stage.go
+++ b/models/stage.go
@@ -7,7 +7,7 @@ package models
 type Stage struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// The name of the boot environment.  Boot environments that install
 	// an operating system must end in '-install'.
 	//
@@ -88,7 +88,9 @@ func (s *Stage) Key() string {
 
 func (s *Stage) Fill() {
 	s.Validation.fill()
-	s.MetaData.fill()
+	if s.Meta == nil {
+		s.Meta = Meta{}
+	}
 	if s.Templates == nil {
 		s.Templates = []TemplateInfo{}
 	}

--- a/models/subnet.go
+++ b/models/subnet.go
@@ -8,7 +8,7 @@ import "net"
 type Subnet struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// Name is the name of the subnet.
 	// Subnet names must be unique
 	//
@@ -118,7 +118,9 @@ func (s *Subnet) Key() string {
 
 func (s *Subnet) Fill() {
 	s.Validation.fill()
-	s.MetaData.fill()
+	if s.Meta == nil {
+		s.Meta = Meta{}
+	}
 	if s.Options == nil {
 		s.Options = []*DhcpOption{}
 	}

--- a/models/task.go
+++ b/models/task.go
@@ -6,7 +6,7 @@ package models
 type Task struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// Name is the name of this Task.  Task names must be globally unique
 	//
 	// required: true
@@ -55,7 +55,9 @@ func (t *Task) Key() string {
 
 func (t *Task) Fill() {
 	t.Validation.fill()
-	t.MetaData.fill()
+	if t.Meta == nil {
+		t.Meta = Meta{}
+	}
 	if t.Templates == nil {
 		t.Templates = []TemplateInfo{}
 	}

--- a/models/template.go
+++ b/models/template.go
@@ -7,7 +7,7 @@ package models
 type Template struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// ID is a unique identifier for this template.  It cannot change once it is set.
 	//
 	// required: true
@@ -35,7 +35,9 @@ func (t *Template) Key() string {
 
 func (t *Template) Fill() {
 	t.Validation.fill()
-	t.MetaData.fill()
+	if t.Meta == nil {
+		t.Meta = Meta{}
+	}
 }
 
 func (t *Template) AuthKey() string {

--- a/models/user.go
+++ b/models/user.go
@@ -9,7 +9,7 @@ import (
 type User struct {
 	Validation
 	Access
-	MetaData
+	Meta
 	// Name is the name of the user
 	//
 	// required: true
@@ -38,7 +38,9 @@ func (u *User) Key() string {
 
 func (u *User) Fill() {
 	u.Validation.fill()
-	u.MetaData.fill()
+	if u.Meta == nil {
+		u.Meta = Meta{}
+	}
 }
 
 func (u *User) CheckPassword(pass string) bool {


### PR DESCRIPTION
1. Within the go structure, the meta data field is contained in
   substructures that are not mapped correctly for the json and
   store layers.  They are transfered and initialized, but patches
   and updates are not safe against them.  This patch fixes this.
   This only effects the internal structure representation.  The
   json/yaml format and store formats do not change.  This applies
   to all objects.

2. The machine object has an embedded Profile object just to hold
   parameters.  This patch creates a Params field (like profile
   and plugin) that holds the parameter data.  The profile object
   is deprecated will be removed one day (A few releases down the
   road).  To handle existing data or clients that still send Profile
   Parameter info, the create and loading functions will migrate data
   out of the profile and into the parameter.  This does not change
   the update path (but most things use the parameters functions which
   do the right thing).  A new feature flag, profileless-machine, has
   been added so that the callers can see what is supported.