### PR TITLE
Populate the address cache when handling API requests.

### DIFF
--- a/backend/conncache_bsd.go
+++ b/backend/conncache_bsd.go
@@ -1,0 +1,38 @@
+// +build darwin dragonfly freebsd netbsd openbsd
+
+package backend
+
+import (
+	"net"
+
+	"golang.org/x/net/route"
+)
+
+func defaultIPByRoute() (*net.Interface, net.IP, error) {
+	rib, _ := route.FetchRIB(0, route.RIBTypeRoute, 0)
+	messages, err := route.ParseRIB(route.RIBTypeRoute, rib)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, message := range messages {
+		msg, ok := message.(*route.RouteMessage)
+		if !ok || len(msg.Addrs) < 2 {
+			continue
+		}
+		addresses := msg.Addrs
+
+		dest, ok1 := addresses[0].(*route.Inet4Addr)
+		gw, ok2 := addresses[1].(*route.Inet4Addr)
+		if !(ok1 && ok2) || dest == nil || gw == nil || dest.IP != [4]byte{0, 0, 0, 0} {
+			continue
+		}
+		gwAddr := net.IP(make([]byte, 4))
+		copy(gwAddr, gw.IP[:])
+		iface, err := net.InterfaceByIndex(msg.Index)
+		if err != nil {
+			return nil, nil, err
+		}
+		return iface, gwAddr, nil
+	}
+	return nil, nil, nil
+}

--- a/backend/conncache_linux.go
+++ b/backend/conncache_linux.go
@@ -1,0 +1,27 @@
+// +build linux
+
+package backend
+
+import (
+	"net"
+
+	"github.com/vishvananda/netlink"
+)
+
+func defaultIPByRoute() (*net.Interface, net.IP, error) {
+	routes, err := netlink.RouteList(nil, 0)
+	if err != nil {
+		return nil, nil, err
+	}
+	for _, route := range routes {
+		if route.Gw == nil {
+			continue
+		}
+		iface, err := net.InterfaceByIndex(route.LinkIndex)
+		if err != nil {
+			return nil, nil, err
+		}
+		return iface, route.Gw, nil
+	}
+	return nil, nil, nil
+}

--- a/backend/conncache_other.go
+++ b/backend/conncache_other.go
@@ -1,0 +1,9 @@
+// +build !linux,!darwin,!dragonfly,!freebsd,!netbsd,!openbsd
+
+package backend
+
+import "net"
+
+func defaultIPByRoute() (*net.Interface, net.IP, error) {
+	return nil, nil, nil
+}

--- a/backend/conncache_test.go
+++ b/backend/conncache_test.go
@@ -12,6 +12,8 @@ func TestConnCache(t *testing.T) {
 	addrCacheMux.Lock()
 	connCacheTimeout = time.Second * 5
 	addrCacheMux.Unlock()
+	defaultIP := DefaultIP()
+	t.Logf("Last-ditch fallback IP address: %s", defaultIP)
 
 	t.Log("Testing ConnCache - takes a minute")
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,6 @@
-hash: 063f9bbefaeef564e5b2b221c6dcf5512e0b12db75ddbec3f016896479ecfd70
-updated: 2017-08-29T10:29:43.395897483-05:00
+hash: ad2591c8c9253d589addf3b93d5c93ab9b83c2c63be57f1a819204e6c1ce039d
+updated: 2017-12-11T13:26:44.153061063-06:00
 imports:
-- name: github.com/asaskevich/govalidator
-  version: 15028e809df8c71964e8efa6c11e81d5c0262302
 - name: github.com/boltdb/bolt
   version: 2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8
 - name: github.com/cpuguy83/go-md2man
@@ -35,28 +33,6 @@ imports:
   - binding
   - json
   - render
-- name: github.com/go-openapi/analysis
-  version: 8ed83f2ea9f00f945516462951a288eaa68bf0d6
-- name: github.com/go-openapi/errors
-  version: 03cfca65330da08a5a440053faf994a3c682b5bf
-- name: github.com/go-openapi/jsonpointer
-  version: 779f45308c19820f1a69e9a4cd965f496e0da10f
-- name: github.com/go-openapi/jsonreference
-  version: 36d33bfe519efae5632669801b180bf1a245da3b
-- name: github.com/go-openapi/loads
-  version: a80dea3052f00e5f032e860dd7355cd0cc67e24d
-- name: github.com/go-openapi/runtime
-  version: d6605b7c17ac3b1033ca794886e6142a4141f5b0
-  subpackages:
-  - client
-- name: github.com/go-openapi/spec
-  version: 3faa0055dbbf2110abc1f3b4e3adbb22721e96e7
-- name: github.com/go-openapi/strfmt
-  version: 610b6cacdcde6852f4de68998bd20ce1dac85b22
-- name: github.com/go-openapi/swag
-  version: f3f9494671f93fcff853e3c6e9e948b3eb71e590
-- name: github.com/go-openapi/validate
-  version: 8a82927c942c94794a5cd8b8b50ce2f48a955c0c
 - name: github.com/golang/protobuf
   version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
   subpackages:
@@ -85,28 +61,16 @@ imports:
   version: 4de04cc59d6e4223583ec8117238e4d57e8b176d
   subpackages:
   - conn
-- name: github.com/mailru/easyjson
-  version: 3b3bbef4e2d9a6f24d7ee73a894afbc064f0e057
-  subpackages:
-  - buffer
-  - jlexer
-  - jwriter
 - name: github.com/mattn/go-isatty
   version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
 - name: github.com/mitchellh/go-homedir
   version: b8bc1bf767474819792c23f32d8286a45736f1c6
-- name: github.com/mitchellh/mapstructure
-  version: d0303fe809921458f417bcf828397a65db30a7e4
 - name: github.com/pborman/uuid
   version: e790cca94e6cc75c7064b1332e63811d4aae1a53
 - name: github.com/pin/tftp
   version: d715325c1fc1f1a22a8272a60dc6783a5ab093ba
   subpackages:
   - netascii
-- name: github.com/PuerkitoBio/purell
-  version: 7cf257f0a33260797b0febf39f95fccd86aab2a3
-- name: github.com/PuerkitoBio/urlesc
-  version: de5bf2ad457846296e2031421a34e2568e304e35
 - name: github.com/russross/blackfriday
   version: 4048872b16cc0fc2c5fd9eacf0ed2c2fedaa0c8c
 - name: github.com/spf13/cobra
@@ -125,6 +89,12 @@ imports:
   version: 728f2fee2a186b5764d9c9a8fa904279a22b1960
   subpackages:
   - utils
+- name: github.com/vishvananda/netlink
+  version: f67b75edbf5e3bb7dfe70bb788610693a71be3d1
+  subpackages:
+  - nl
+- name: github.com/vishvananda/netns
+  version: be1fbeda19366dea804f00efff2dd73a1642fdcc
 - name: github.com/xeipuuv/gojsonpointer
   version: 6fe8760cad3569743d51ddbb243b26f8456742dc
 - name: github.com/xeipuuv/gojsonreference
@@ -141,25 +111,16 @@ imports:
   subpackages:
   - bpf
   - context
-  - context/ctxhttp
   - icmp
-  - idna
   - internal/iana
   - internal/socket
   - ipv4
   - ipv6
+  - route
 - name: golang.org/x/sys
   version: 2d6f6f883a06fc0d5f4b14a81e4c28705ea64c15
   subpackages:
   - unix
-- name: golang.org/x/text
-  version: 18c65dde6afd36dbc39197ca72008895b8dfbfb6
-  subpackages:
-  - secure/bidirule
-  - transform
-  - unicode/bidi
-  - unicode/norm
-  - width
 - name: gopkg.in/go-playground/validator.v8
   version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/mgo.v2
@@ -167,7 +128,6 @@ imports:
   repo: https://github.com/go-mgo/mgo
   subpackages:
   - bson
-  - internal/json
 - name: gopkg.in/olahol/melody.v1
   version: d521390733761fe1db13de575c253afd5c743085
 - name: gopkg.in/yaml.v2

--- a/glide.yaml
+++ b/glide.yaml
@@ -27,6 +27,7 @@ import:
 - package: github.com/gorilla/websocket
 - package: gopkg.in/olahol/melody.v1
 - package: github.com/fsnotify/fsnotify
+- package: github.com/vishvananda/netlink
 - package: golang.org/x/net
   subpackages:
   - context

--- a/midlayer/dhcp.go
+++ b/midlayer/dhcp.go
@@ -253,7 +253,10 @@ func (h *DhcpHandler) respondFrom(testAddr net.IP, cm *ipv4.ControlMessage) net.
 		return addrs[0].IP.To4()
 	}
 	// Well, this really sucks.  Return our global listen-on address
-	return net.ParseIP(h.bk.OurAddress).To4()
+	if h.bk.OurAddress != "" {
+		return net.ParseIP(h.bk.OurAddress).To4()
+	}
+	return backend.DefaultIP()
 }
 
 func (h *DhcpHandler) listenOn(testAddr net.IP, cm *ipv4.ControlMessage) bool {


### PR DESCRIPTION
This also changes the default static IP from 192.168.124.11 to ``,
and adds a fallback to try and figure out a valid static IP by
figuring out which interface the default route goes through and using it.

dr-provision will log whenever it has to fall back to using --static-ip or
the IP of the interface with the default route instead of the address cache.