### PR TITLE
added KRIB support to pkt-demo tooling

### DIFF
--- a/examples/pkt-demo/bin/functions.sh
+++ b/examples/pkt-demo/bin/functions.sh
@@ -59,6 +59,26 @@ function os_info() {
 } # end os_family()
 
 ###
+#  simple helper loop functions, expects:
+#
+#   UUIDS = global var with space separated list of UUIDS to operate on
+#   $1    = `machines` sub-command to run
+#   $2    = action/argument to sub-commnand
+#
+#  example:
+#
+#     export UUIDS="uuid_1 uuid_2 ... uuid_N"
+#     my_machines addprofile krib-cluster-live
+#
+#  which runs:
+#
+#     drpcli machines addprofile <UUID> krib-cluster-live
+#
+#  $2 can be empty if it doesnot apply (eg 'my_machines show')
+###
+function my_machines() { local _u; for _u in $UUIDS; do set -x; drpcli machines $1 $_u $2; set +x; done; }
+
+###
 #  accept as ARGv1 a sha256 check sum file to test - files will be tested
 #  relative to the path/filename found in the SHA256 sum file
 ###

--- a/examples/pkt-demo/demo-krib.sh
+++ b/examples/pkt-demo/demo-krib.sh
@@ -146,7 +146,7 @@ case $1 in
   local)
     echo "Installing content to DRP endpoint ('$DRP') from local system (push to endpoint)..."
     # runs get-drp-cc, get-drp-plugins, and drp-setup locally
-    confirm control.sh local-content-demo $DRP
+    confirm control.sh local-content-krib $DRP
   ;;
   remote|*)
     echo "Installing content from DRP endpoint ('$DRP') (pull from endpoint)..."
@@ -156,7 +156,7 @@ case $1 in
     cprintf $bold "   Maybe launch UI to show empty content too ... ? \n"
     cprintf $bold "   https://rackn.github.io/provision-ux/#/e/${ADDR}:8092/system "
     echo ""
-    confirm control.sh remote-content-demo $DRP  
+    confirm control.sh remote-content-krib $DRP  
     echo ""
     cprintf $cyan "NOTICE:"
     echo "  Errors may be 'normal' - ISOs, Kernel, and InitRDs are "
@@ -168,11 +168,6 @@ esac
 
 # inject our DRP endpoint address in to the drp-machines.tf terraform file
 confirm control.sh set-drp-endpoint $DRP
-
-# bug in Stages causes stage "discover" to be marked bad
-# the simplest fix is to HUP the dr-provision service
-#confirm echo "Restart DRP Endpoint to fix stages bug ?" \
-#  && control.sh ssh $DRP 'kill -HUP `pidof dr-provision`'
 
 # bring up our DRP target machines:
 confirm terraform apply -target=packet_device.drp-machines -auto-approve


### PR DESCRIPTION
- added Terraform install version support - since TF strictly enforces versions related to tfstate files - you can easily end up needing to install a specific version of TF
- added helper function my_machines() 
- removed CONFIRM prompts for export of DRP and ADDR variables
- added demo-krib.sh wrapper to drive new KRIB content creation 

NOTE:  as of testing, everything worked except KRIB content electing Master and building the cluster.   The belief is something changed in the latest Kubernetes kubeadm tooling - that needs resolved. 

