### PR TITLE
Tweak address cache for more proper operation.

### DIFF
--- a/backend/conncache.go
+++ b/backend/conncache.go
@@ -1,17 +1,23 @@
 package backend
 
 import (
-	"log"
+	"fmt"
 	"math/big"
 	"net"
 	"sort"
 	"sync"
 	"time"
+
+	"github.com/digitalrebar/logger"
 )
 
 type cacheLine struct {
 	local, remote net.IP
-	unused        bool
+	timeout       time.Time
+}
+
+func (c cacheLine) String() string {
+	return fmt.Sprintf("l: %s, r: %s: t:%s", c.local, c.remote, c.timeout)
 }
 
 func a2i(n net.IP) *big.Int {
@@ -23,19 +29,23 @@ func a2i(n net.IP) *big.Int {
 var addrCache = []cacheLine{}
 var addrCacheMux = &sync.RWMutex{}
 
-var connCacheTimeout = time.Minute
+// How long we will keep cache entries around for.
+var connCacheTimeout = 10 * time.Minute
 
 // AddToCache adds a new remote -> local IP address mapping to the
 // connection cache.  If the remote address is already in the cache,
-// its corresponding local address is updates and the mapping is
-// marked as used. Mappings that have not been accessed with LocalFor
-// or updated with AddToCache will be marked as unused within 60
-// seconds, and will be evicted if they are still unused within 60
-// more seconds.
-func AddToCache(local, remote net.IP) {
-	if local == nil || remote == nil {
+// its corresponding local address is updates and the timeout is bumped.
+// Mappings that have not been accessed with LocalFor
+// or updated with AddToCache will be evicted if not used for more than 10 minutes.
+func AddToCache(l logger.Logger, la, ra net.IP) {
+	if la == nil || ra == nil {
+		l.Errorf("addrCache: nil addr passed: local: %v, remote: %v", la, ra)
 		return
 	}
+	local, remote := net.IP(make([]byte, 16)), net.IP(make([]byte, 16))
+	copy(local, la.To16())
+	copy(remote, ra.To16())
+
 	addrCacheMux.Lock()
 	defer addrCacheMux.Unlock()
 	key := a2i(remote)
@@ -43,52 +53,61 @@ func AddToCache(local, remote net.IP) {
 		return a2i(addrCache[i].remote).Cmp(key) != 1
 	})
 	if idx == len(addrCache) {
-		addrCache = append(addrCache, cacheLine{local, remote, false})
+		l.Infof("addrCache: Adding local %s ->  remote %s", local, remote)
+		addrCache = append(addrCache, cacheLine{local, remote, time.Now().Add(connCacheTimeout)})
 		return
 	}
 	if addrCache[idx].remote.Equal(remote) {
 		addrCache[idx].local = local
-		addrCache[idx].unused = false
+		addrCache[idx].timeout = time.Now().Add(connCacheTimeout)
+		l.Debugf("addrCache: Renewing local %s -> remote %s", local, remote)
 		return
 	}
 	addrCache = append(addrCache, cacheLine{})
 	copy(addrCache[idx+1:], addrCache[idx:])
-	addrCache[idx] = cacheLine{local, remote, false}
+	l.Infof("addrCache: Adding local %s ->  remote %s", local, remote)
+	addrCache[idx] = cacheLine{local, remote, time.Now().Add(connCacheTimeout)}
 }
 
 // LocalFor returns the local IP address that has responded to TFTP or
-// HTTP requests for the given remote IP.  It also marks the mapping
-// as used, delaying its eviction from the cache.
-func LocalFor(remote net.IP) net.IP {
-	if remote == nil || remote.IsUnspecified() {
+// HTTP requests for the given remote IP.  It also bumps the timeout.
+func LocalFor(l logger.Logger, ra net.IP) net.IP {
+	if ra == nil || ra.IsUnspecified() {
 		return nil
 	}
 	addrCacheMux.RLock()
 	defer addrCacheMux.RUnlock()
+	remote := net.IP(make([]byte, 16))
+	copy(remote, ra.To16())
 	key := a2i(remote)
 	idx := sort.Search(len(addrCache), func(i int) bool {
 		return a2i(addrCache[i].remote).Cmp(key) != 1
 	})
 	if idx < len(addrCache) && addrCache[idx].remote.Equal(remote) {
-		addrCache[idx].unused = false
+		addrCache[idx].timeout = time.Now().Add(connCacheTimeout)
+		l.Debugf("addrCache: Remote %s talks through local %s", remote, addrCache[idx].local)
 		return addrCache[idx].local
 	}
 	return nil
 }
 
-func DefaultIP() net.IP {
+// DefaultIP figures out the IP address of the interface that has the
+// default route.  It is used as a fallback IP address when we don't
+// have --static-ip set and we cannot find a local -> remote mapping
+// in the cache.
+func DefaultIP(l logger.Logger) net.IP {
 	iface, gw, err := defaultIPByRoute()
 	if err != nil {
-		log.Printf("Error getting default route: %v", err)
+		l.Errorf("addrCache: Error getting default route: %v", err)
 		return nil
 	}
 	if iface == nil || gw == nil {
-		log.Printf("No default route on system.")
+		l.Warnf("addrCache: No default route on system.")
 		return nil
 	}
 	addrs, err := iface.Addrs()
 	if err != nil {
-		log.Printf("Error getting addresses on %s: %v", iface.Name, err)
+		l.Errorf("addrCache: Error getting addresses on %s: %v", iface.Name, err)
 		return nil
 	}
 	for _, addr := range addrs {
@@ -105,40 +124,32 @@ func init() {
 		// Garbage collection loop for the address cache.
 		for {
 			addrCacheMux.Lock()
-			t := connCacheTimeout
-			addrCacheMux.Unlock()
-
-			time.Sleep(t)
-
-			addrCacheMux.Lock()
 			toRemove := []int{}
+			deadline := time.Now()
 			for idx := range addrCache {
-				if addrCache[idx].unused {
+				if addrCache[idx].timeout.Before(deadline) {
 					toRemove = append(toRemove, idx)
-				} else {
-					addrCache[idx].unused = true
 				}
 			}
-			if len(toRemove) == 0 {
-				addrCacheMux.Unlock()
-				continue
-			}
-			lastAddr := len(addrCache)
-			lastIdx := len(toRemove) - 1
-			for i, idx := range toRemove {
-				if idx == lastAddr-1 {
-					continue
+			if len(toRemove) > 0 {
+				lastAddr := len(addrCache)
+				lastIdx := len(toRemove) - 1
+				for i, idx := range toRemove {
+					if idx == lastAddr-1 {
+						continue
+					}
+					var final int
+					if i != lastIdx {
+						final = toRemove[i+1]
+					} else {
+						final = lastAddr
+					}
+					copy(addrCache[idx-i:final], addrCache[idx+1:final])
 				}
-				var final int
-				if i != lastIdx {
-					final = toRemove[i+1]
-				} else {
-					final = lastAddr
-				}
-				copy(addrCache[idx-i:final], addrCache[idx+1:final])
+				addrCache = addrCache[:lastAddr-len(toRemove)]
 			}
-			addrCache = addrCache[:lastAddr-len(toRemove)]
 			addrCacheMux.Unlock()
+			time.Sleep(13 * time.Second)
 		}
 	}()
 }

--- a/backend/conncache_test.go
+++ b/backend/conncache_test.go
@@ -4,15 +4,17 @@ import (
 	"net"
 	"testing"
 	"time"
+
+	"github.com/digitalrebar/logger"
 )
 
 func TestConnCache(t *testing.T) {
-
+	l := logger.New(nil).Log("")
 	// Reset timeout to three seconds
 	addrCacheMux.Lock()
 	connCacheTimeout = time.Second * 5
 	addrCacheMux.Unlock()
-	defaultIP := DefaultIP()
+	defaultIP := DefaultIP(l)
 	t.Logf("Last-ditch fallback IP address: %s", defaultIP)
 
 	t.Log("Testing ConnCache - takes a minute")
@@ -22,9 +24,9 @@ func TestConnCache(t *testing.T) {
 	ip3 := net.ParseIP("3.3.3.3")
 
 	// Add no values
-	AddToCache(nil, nil)
-	AddToCache(ip1, nil)
-	AddToCache(nil, ip2)
+	AddToCache(l, nil, nil)
+	AddToCache(l, ip1, nil)
+	AddToCache(l, nil, ip2)
 
 	addrCacheMux.Lock()
 	if len(addrCache) != 0 {
@@ -32,57 +34,19 @@ func TestConnCache(t *testing.T) {
 	}
 	addrCacheMux.Unlock()
 
-	AddToCache(ip3, ip1)
-	AddToCache(ip2, ip1)
-	AddToCache(ip2, ip3)
+	AddToCache(l, ip3, ip1)
+	AddToCache(l, ip2, ip1)
+	AddToCache(l, ip2, ip3)
 
-	// Wait for cache to make unused - wait for minute timer to expire
-	addrCacheMux.Lock()
-	for len(addrCache) > 0 && !addrCache[0].unused {
-		addrCacheMux.Unlock()
-		time.Sleep(time.Second)
-		addrCacheMux.Lock()
-	}
-	if len(addrCache) == 0 {
-		t.Errorf("addrCache should not be empty!!\n")
-	}
-	addrCacheMux.Unlock()
-
-	v := LocalFor(ip1)
-	if !ip2.Equal(v) {
-		t.Errorf("Should have found %v, but got %v\n", ip2, v)
-	}
-
-	addrCacheMux.Lock()
-	if addrCache[1].unused {
-		t.Errorf("Cache should have been reset\n")
-	}
-	addrCacheMux.Unlock()
-
-	v = LocalFor(ip2)
-	if v != nil {
-		t.Errorf("Should not have found %v, and got %v\n", ip2, v)
-	}
-
-	addrCacheMux.Lock()
-	if !addrCache[0].unused {
-		t.Errorf("Second entry should be still unused\n")
-	}
-	addrCacheMux.Unlock()
-
-	AddToCache(ip2, ip3)
-
-	addrCacheMux.Lock()
-	if addrCache[0].unused {
-		t.Errorf("Second entry should now be not unused\n")
-	}
-	addrCacheMux.Unlock()
-
-	time.Sleep(time.Second * 15)
-
-	addrCacheMux.Lock()
+	time.Sleep(15 * time.Second)
+	addrCacheMux.RLock()
 	if len(addrCache) != 0 {
-		t.Errorf("Addr cache should be zero after draining\n")
+		t.Errorf("Cache not clean after 30 seconds (%s)", time.Now())
+		for _, line := range addrCache {
+			t.Errorf("CacheLine: %s", line)
+		}
+	} else {
+		t.Logf("Cache clean.")
 	}
-	addrCacheMux.Unlock()
+	addrCacheMux.RUnlock()
 }

--- a/backend/dataTracker.go
+++ b/backend/dataTracker.go
@@ -594,9 +594,10 @@ func (p *DataTracker) lockAll() (stores Stores, unlocker func()) {
 func (p *DataTracker) LocalIP(remote net.IP) string {
 	// If we are behind a NAT, always use Our Address
 	if p.ForceOurAddress && p.OurAddress != "" {
+		p.Debugf("addrCache: Forced to use static address %s", p.OurAddress)
 		return p.OurAddress
 	}
-	if localIP := LocalFor(remote); localIP != nil {
+	if localIP := LocalFor(p.Logger, remote); localIP != nil {
 		return localIP.String()
 	}
 	// Determining what this is needs to be made smarter, probably by
@@ -606,7 +607,7 @@ func (p *DataTracker) LocalIP(remote net.IP) string {
 	if p.OurAddress != "" {
 		return p.OurAddress
 	}
-	gwIp := DefaultIP()
+	gwIp := DefaultIP(p.Logger)
 	if gwIp == nil {
 		p.Warnf("Failed to find appropriate local IP to use for %s", remote)
 		p.Warnf("No --static-ip and no default gateway to use in its place")
@@ -614,7 +615,6 @@ func (p *DataTracker) LocalIP(remote net.IP) string {
 		return ""
 	}
 	p.Infof("Falling back to local address %s as default target for remote %s", gwIp, remote)
-	AddToCache(gwIp, remote)
 	return gwIp.String()
 }
 

--- a/cli/common_test.go
+++ b/cli/common_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitalrebar/logger"
 	"github.com/digitalrebar/provision/api"
 	"github.com/digitalrebar/provision/backend"
 	"github.com/digitalrebar/provision/embedded"
@@ -459,7 +460,10 @@ func TestMain(m *testing.M) {
 		myToken = session.Token()
 		session.Close()
 		session = nil
-		midlayer.ServeStatic("127.0.0.1:10003", backend.NewFS("test-data", nil), nil, backend.NewPublishers(nil))
+		midlayer.ServeStatic("127.0.0.1:10003",
+			backend.NewFS("test-data", nil),
+			logger.New(nil).Log(""),
+			backend.NewPublishers(nil))
 		ret = m.Run()
 	}
 

--- a/cli/test-data/output/TestLogsCli/logs.get/stdout.expect
+++ b/cli/test-data/output/TestLogsCli/logs.get/stdout.expect
@@ -3,7 +3,7 @@ RE:
   {
     "Data": \[\],
     "File": "(.*/)?github.com/digitalrebar/provision/frontend/(_obj/)?frontend.go",
-    "Group": 2,
+    "Group": .*,
     "Level": "audit",
     "Line": .*,
     "Message": "Authenticated rocketskates",
@@ -14,7 +14,7 @@ RE:
   {
     "Data": \[\],
     "File": "(.*/)?github.com/digitalrebar/provision/frontend/(_obj/)?frontend.go",
-    "Group": 3,
+    "Group": .*,
     "Level": "audit",
     "Line": .*,
     "Message": "Authenticated rocketskates",

--- a/frontend/info.go
+++ b/frontend/info.go
@@ -98,7 +98,7 @@ func (f *Frontend) InitInfoApi(drpid string) {
 				return
 			}
 			if a, _, e := net.SplitHostPort(c.Request.RemoteAddr); e == nil {
-				info.Address = backend.LocalFor(net.ParseIP(a))
+				info.Address = backend.LocalFor(f.l(c), net.ParseIP(a))
 			}
 			c.JSON(http.StatusOK, info)
 		})

--- a/frontend/users.go
+++ b/frontend/users.go
@@ -327,7 +327,7 @@ func (f *Frontend) InitUserApi(drpid string) {
 				info, _ := f.GetInfo(c, drpid)
 				if info != nil {
 					if a, _, e := net.SplitHostPort(c.Request.RemoteAddr); e == nil {
-						info.Address = backend.LocalFor(net.ParseIP(a))
+						info.Address = backend.LocalFor(f.l(c), net.ParseIP(a))
 					}
 				}
 				c.JSON(http.StatusOK, models.UserToken{Token: t, Info: *info})

--- a/midlayer/static.go
+++ b/midlayer/static.go
@@ -17,12 +17,14 @@ func ServeStatic(listenAt string, responder http.Handler, logger logger.Logger, 
 		Addr:    listenAt,
 		Handler: responder,
 		ConnState: func(n net.Conn, cs http.ConnState) {
-			laddr, lok := n.LocalAddr().(*net.TCPAddr)
-			raddr, rok := n.RemoteAddr().(*net.TCPAddr)
-			if lok && rok && cs == http.StateActive {
-				backend.AddToCache(laddr.IP, raddr.IP)
+			if cs == http.StateActive {
+				laddr, lok := n.LocalAddr().(*net.TCPAddr)
+				raddr, rok := n.RemoteAddr().(*net.TCPAddr)
+				if lok && rok {
+					l := logger.Fork()
+					backend.AddToCache(l, laddr.IP, raddr.IP)
+				}
 			}
-			return
 		},
 	}
 	go func() {

--- a/server/server.go
+++ b/server/server.go
@@ -301,12 +301,14 @@ func Server(c_opts *ProgOpts) {
 		Addr:      fmt.Sprintf(":%d", c_opts.ApiPort),
 		Handler:   fe.MgmtApi,
 		ConnState: func(n net.Conn, cs http.ConnState) {
-			laddr, lok := n.LocalAddr().(*net.TCPAddr)
-			raddr, rok := n.RemoteAddr().(*net.TCPAddr)
-			if lok && rok && cs == http.StateActive {
-				backend.AddToCache(laddr.IP, raddr.IP)
+			if cs == http.StateActive {
+				l := fe.Logger.Fork()
+				laddr, lok := n.LocalAddr().(*net.TCPAddr)
+				raddr, rok := n.RemoteAddr().(*net.TCPAddr)
+				if lok && rok && cs == http.StateActive {
+					backend.AddToCache(l, laddr.IP, raddr.IP)
+				}
 			}
-			return
 		},
 	}
 	services = append(services, srv)


### PR DESCRIPTION
First, logs have been threaded through the address cache, so we can
see what is being added to the local -> remote address cache at either
Debug or Trace log levels.

Second, close a potential hole that woul lead to deleting cache
entries too early by moving to a timeout-per-cache-line system instead
of an expired/non-expired bit, and increase the timeout to 10 minutes.

Third, close a potential race with what the kernel thinks each
connections local IP address should be by not asking for the local IP
address until the http connection state is Active, which means that
the client has sent us at least 1 byte.  The Linux kernel apparently
does not assign the local address until the handshake as completed,
and we were asking for the address before we checked to see that the
conn state was Active.