### PR TITLE
Move all Publish() and PublishEvent() calls to the RequestTracker.

### DIFF
--- a/backend/dataTracker.go
+++ b/backend/dataTracker.go
@@ -509,12 +509,6 @@ func (p *DataTracker) LogFor(s string) logger.Logger {
 	return p.Logger.Buffer().Log(s)
 }
 
-func (p *DataTracker) Publish(prefix, action, key string, ref interface{}) {
-	if p.publishers != nil {
-		p.publishers.Publish(prefix, action, key, ref)
-	}
-}
-
 func (dt *DataTracker) reportPath(s string) string {
 	return strings.TrimPrefix(s, dt.FileRoot)
 }

--- a/frontend/actions.go
+++ b/frontend/actions.go
@@ -171,7 +171,7 @@ func (f *Frontend) makeActionEndpoints(cmdSet string, obj models.Model, idKey st
 				return
 			}
 
-			f.pubs.Publish(cmdSet, cmd, id, ma)
+			rt.Publish(cmdSet, cmd, id, ma)
 			retval, runErr := f.pc.Actions.Run(rt, cmdSet, ma)
 			if runErr != nil {
 				be, ok := runErr.(*models.Error)

--- a/frontend/events.go
+++ b/frontend/events.go
@@ -37,7 +37,7 @@ func (f *Frontend) InitEventApi() {
 				return
 			}
 
-			if err := f.pubs.PublishEvent(&event); err != nil {
+			if err := f.rt(c).PublishEvent(&event); err != nil {
 				be, ok := err.(*models.Error)
 				if ok {
 					c.JSON(be.Code, be)

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -530,10 +530,6 @@ func NewFrontend(
 	})
 
 	pubs.Add(me)
-	me.Logger.Buffer().SetPublisher(func(l *logger.Line) {
-		pubs.Publish("log", l.Level.String(), l.Service, l)
-	})
-
 	return
 }
 

--- a/midlayer/messaging_server.go
+++ b/midlayer/messaging_server.go
@@ -52,7 +52,7 @@ func publishHandler(c *gin.Context, pc *PluginClient) {
 		return
 	}
 	resp := models.Error{Code: http.StatusOK}
-	if err := pc.pc.publishers.PublishEvent(&event); err != nil {
+	if err := pc.pc.Request().PublishEvent(&event); err != nil {
 		resp.Code = 409
 		resp.AddError(err)
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -239,6 +239,7 @@ func Server(c_opts *ProgOpts) {
 	fe.TftpPort = c_opts.TftpPort
 	fe.BinlPort = c_opts.BinlPort
 	fe.NoBinl = c_opts.DisableBINL
+	backend.SetLogPublisher(buf, publishers)
 
 	// Start the controller now that we have a frontend to front.
 	if err := pc.StartController(fe.ApiGroup); err != nil {


### PR DESCRIPTION
This allows us to lazily publish events when holding backend locks.
Lazily published events will be sent when the locks are released.