### PR TITLE
Deadlock test another fix and dry code

### DIFF
--- a/api/contents_test.go
+++ b/api/contents_test.go
@@ -94,7 +94,7 @@ meta:
   Meta: {}
   Name: BackingStore
   Overwritable: false
-  Source: Unknown
+  Source: ""
   Type: writable
   Version: user
   Writable: true

--- a/frontend/websocket.go
+++ b/frontend/websocket.go
@@ -55,7 +55,7 @@ func (f *Frontend) filterFunction(emap []string, claim interface{}, e *models.Ev
 
 	// Make sure we are authorized to see this event.
 	if matched {
-		matched = f.assureAuthWithClaim(nil, claim, e.Type, e.Action, e.Key)
+		matched = f.assureClaimMatch(nil, claim, e.Type, e.Action, e.Key)
 	}
 	return matched
 }


### PR DESCRIPTION
This PR adds a unit test that would deadlock like the one @sygibson and Romain Lafontaine were seeing.  

This also adds an fix (in addition to what @VictorLowther already checked in) to not take locks inside the websocket filter function. (The cause of the deadlock in the first place, bad Greg!).

DRY up the contents code to us existing routines in the models layer instead of duplicating code in the frontend. 