### PR TITLE
Make NextServer handling identical in Reservations and Subnets.

### DIFF
--- a/backend/reservation.go
+++ b/backend/reservation.go
@@ -182,9 +182,8 @@ func (r *Reservation) OnCreate() error {
 
 func (r *Reservation) Validate() {
 	validateIP4(r, r.Addr)
-	validateMaybeZeroIP4(r, r.NextServer)
-	if len(r.NextServer) == 0 || r.NextServer.IsUnspecified() {
-		r.NextServer = nil
+	if r.NextServer != nil {
+		validateMaybeZeroIP4(r, r.NextServer)
 	}
 	if r.Token == "" {
 		r.Errorf("Reservation Token cannot be empty!")

--- a/backend/subnet.go
+++ b/backend/subnet.go
@@ -513,7 +513,9 @@ func (s *Subnet) Validate() {
 	if s.Strategy == "" {
 		s.Errorf("Strategy must have a value")
 	}
-
+	if s.NextServer != nil {
+		validateMaybeZeroIP4(s, s.NextServer)
+	}
 	// Build mask and broadcast for always
 	mask := net.IP([]byte(net.IP(subnet.Mask).To4()))
 	bcastBits := binary.BigEndian.Uint32(subnet.IP) | ^binary.BigEndian.Uint32(mask)

--- a/doc/operation.rst
+++ b/doc/operation.rst
@@ -209,7 +209,10 @@ It might be necessary to create a new subnet from an existing one.  To do this, 
 Creating a new Subnet
 ---------------------
 
-A new subnet can be created from a JSON specification.  It is necessary to use all of the following JSON keys to successfully create a new Subnet
+A new subnet can be created from a JSON specification.  It is
+necessary to use all of the following JSON keys to successfully create
+a new Subnet that can be immediately used to manage machines -- the rest
+of the keys will be autofilled with reasonable defaults.
 
   ::
 
@@ -219,25 +222,16 @@ A new subnet can be created from a JSON specification.  It is necessary to use a
       "Subnet": "10.10.16.10/24",
       "ActiveStart": "10.10.16.100",
       "ActiveEnd": "10.10.16.254",
-      "NextServer": "10.10.16.10",
       "ActiveLeaseTime": 60,
-      "Available": true,
       "Enabled": true,
-      "Proxy": false,
-      "ReadOnly": false,
       "ReservedLeaseTime": 7200,
       "Strategy": "MAC",
-      "Validated": true,
-      "OnlyReservations": false,
-      "Pickers": [ "hint", "nextFree", "mostExpired" ],
       "Options": [
-        { "Code": 1, "Value": "255.255.255.0", "Description": "Netmask" },
         { "Code": 3, "Value": "10.10.16.1", "Description": "Default Gateway" },
         { "Code": 6, "Value": "8.8.8.8", "Description": "DNS Servers" },
-        { "Code": 15, "Value": "example.com", "Description": "Domain Name" },
-        { "Code": 28, "Value": "10.10.16.255", "Description": "Broadcast Address" }
+        { "Code": 15, "Value": "example.com", "Description": "Domain Name" }
       ]
-    } ' > /tmp/local_subnet.json 
+    } ' > /tmp/local_subnet.json
 
     drpcli subnets create -< /tmp/local_subnet.json
 
@@ -250,7 +244,7 @@ For complete documentation and information you can find the DHCP Options officia
 Updating a Subnet
 -----------------
 
-From time to time, you may need to modify an existing Subnet definition.  Depending on your changes, you have a couple of options. 
+From time to time, you may need to modify an existing Subnet definition.  Depending on your changes, you have a couple of options.
 
 Set the NTP Server pool via DHCP Option 42 for subnet "local_subnet":
   ::

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -128,9 +128,20 @@ The ``uploadiso`` command will fetch the ISO image as specified in the BootEnv J
 Configure a Subnet
 ------------------
 
-A Subnet defines a network boundary that the DRP Endpoint will answer DHCP queries for.  In this quickstart, we assume you will use the local network interface as a subnet definition, and that your Machines are all booted from the local subnet (layer 2 boundary).  More advanced usage is certainly possible (including use of external DHCP servers, using DRP Endpoint as a DHCP Proxy, etc.).  A Subnet specification includes all of the necessary DHCP boot options to correctly PXE boot a Machine.
+A Subnet defines a network boundary that the DRP Endpoint will answer
+DHCP queries for.  In this quickstart, we assume you will use the
+local network interface as a subnet definition, and that your Machines
+are all booted from the local subnet (layer 2 boundary).  More
+advanced usage is certainly possible (including use of external DHCP
+servers, using DRP Endpoint as a DHCP Proxy, etc.).  A Subnet
+specification includes all of the necessary DHCP boot options to
+correctly PXE boot a Machine.
 
-To create a Subnet from command line we must create a JSON blob that contains the Subnet and DHCP definitions.  Below is a sample you can use.  Please insure you modify the network parameters accordingly.  ``NextServer`` should be set to the DRP Endpoint IP Address (NOT the DNS hostname).  Insure you change the network parameters according to your environment.
+To create a Subnet from command line we must create a JSON blob that
+contains the Subnet and DHCP definitions.  Below is a sample you can
+use.  Please insure you modify the network parameters accordingly.
+Insure you change the network parameters according to your
+environment.
 
   ::
 
@@ -139,23 +150,14 @@ To create a Subnet from command line we must create a JSON blob that contains th
       "Subnet": "10.10.16.10/24",
       "ActiveStart": "10.10.16.100",
       "ActiveEnd": "10.10.16.254",
-      "NextServer": "10.10.16.10",
       "ActiveLeaseTime": 60,
-      "Available": true,
       "Enabled": true,
-      "Proxy": false,
-      "ReadOnly": false,
       "ReservedLeaseTime": 7200,
       "Strategy": "MAC",
-      "Validated": true,
-      "OnlyReservations": false,
-      "Pickers": [ "hint", "nextFree", "mostExpired" ],
       "Options": [
-        { "Code": 1, "Value": "255.255.255.0", "Description": "Netmask" },
         { "Code": 3, "Value": "10.10.16.1", "Description": "Default Gateway" },
         { "Code": 6, "Value": "8.8.8.8", "Description": "DNS Servers" },
-        { "Code": 15, "Value": "example.com", "Description": "Domain Name" },
-        { "Code": 28, "Value": "10.10.16.255", "Description": "Broadcast Address" }
+        { "Code": 15, "Value": "example.com", "Description": "Domain Name" }
       ]
     }' > /tmp/local_subnet.json
 

--- a/midlayer/common_test.go
+++ b/midlayer/common_test.go
@@ -67,24 +67,7 @@ func TestMain(m *testing.M) {
 	rt := dataTracker.Request(l, "subnets")
 	rt.Do(func(d backend.Stores) {
 		subs := []*models.Subnet{
-			&models.Subnet{
-				Name:              "sub2",
-				Enabled:           true,
-				Subnet:            "172.17.0.8/24",
-				NextServer:        net.IPv4(172, 17, 0, 8),
-				ActiveStart:       net.IPv4(172, 17, 0, 10),
-				ActiveEnd:         net.IPv4(172, 17, 0, 15),
-				ReservedLeaseTime: 7200,
-				ActiveLeaseTime:   60,
-				Strategy:          "MAC",
-				Options: []models.DhcpOption{
-					{Code: 1, Value: "255.255.0.0"},
-					{Code: 3, Value: "172.17.0.1"},
-					{Code: 6, Value: "172.17.0.1"},
-					{Code: 15, Value: "sub2.com"},
-					{Code: 28, Value: "172.17.0.255"},
-				},
-			},
+			// Normal DHCP network.
 			&models.Subnet{
 				Name:              "sub1",
 				Enabled:           true,
@@ -95,28 +78,40 @@ func TestMain(m *testing.M) {
 				ActiveLeaseTime:   60,
 				Strategy:          "MAC",
 				Options: []models.DhcpOption{
-					{Code: 1, Value: "255.255.0.0"},
 					{Code: 3, Value: "192.168.124.1"},
 					{Code: 6, Value: "192.168.124.1"},
 					{Code: 15, Value: "sub1.com"},
-					{Code: 28, Value: "192.168.124.255"},
 				},
 			},
+			// DHCP via a gateway
+			&models.Subnet{
+				Name:              "sub2",
+				Enabled:           true,
+				Subnet:            "172.17.0.8/24",
+				ActiveStart:       net.IPv4(172, 17, 0, 10),
+				ActiveEnd:         net.IPv4(172, 17, 0, 15),
+				ReservedLeaseTime: 7200,
+				ActiveLeaseTime:   60,
+				Strategy:          "MAC",
+				Options: []models.DhcpOption{
+					{Code: 3, Value: "172.17.0.1"},
+					{Code: 6, Value: "172.17.0.1"},
+					{Code: 15, Value: "sub2.com"},
+				},
+			},
+			// ProxyDHCP network.
 			&models.Subnet{
 				Name:              "sub3",
 				Enabled:           true,
 				Proxy:             true,
 				Subnet:            "10.0.0.0/8",
-				NextServer:        net.IPv4(10, 0, 0, 10),
 				ReservedLeaseTime: 7200,
 				ActiveLeaseTime:   60,
 				Strategy:          "MAC",
 				Options: []models.DhcpOption{
-					{Code: 1, Value: "255.0.0.0"},
 					{Code: 3, Value: "10.0.0.1"},
 					{Code: 6, Value: "10.0.0.1"},
 					{Code: 15, Value: "sub1.com"},
-					{Code: 28, Value: "10.255.255.255"},
 				},
 			},
 		}

--- a/midlayer/dhcp.go
+++ b/midlayer/dhcp.go
@@ -227,11 +227,11 @@ func (dhr *DhcpRequest) coalesceOptions(
 			}
 			dhr.outOpts[dhcp.OptionCode(c)] = v
 		}
-		if s.NextServer.IsGlobalUnicast() {
+		if s.NextServer != nil && s.NextServer.IsGlobalUnicast() {
 			dhr.nextServer = s.NextServer
 		}
 	}
-	if r != nil && r.NextServer.IsGlobalUnicast() {
+	if r != nil && r.NextServer != nil && r.NextServer.IsGlobalUnicast() {
 		dhr.nextServer = r.NextServer
 	}
 	if nextServer := dhr.nextServer.To4(); nextServer != nil && !nextServer.IsUnspecified() {

--- a/models/reservation.go
+++ b/models/reservation.go
@@ -22,7 +22,9 @@ type Reservation struct {
 	//
 	// required: true
 	Token string
-	// NextServer is the address the server should contact next.
+	// NextServer is the address the server should contact next. You
+	// should only set this if you want to talk to a DHCP or TFTP server
+	// other than the one provided by dr-provision.
 	//
 	// required: false
 	// swagger:strfmt ipv4

--- a/models/subnet.go
+++ b/models/subnet.go
@@ -45,7 +45,9 @@ type Subnet struct {
 	// required: true
 	// pattern: ^([0-9]+\.){3}[0-9]+/[0-9]+$
 	Subnet string
-	// NextServer is the address of the next server
+	// NextServer is the address of the next server in the DHCP/TFTP/PXE
+	// chain.  You should only set this if you want to transfer control
+	// to a different DHCP or TFTP server.
 	//
 	// required: true
 	// swagger:strfmt ipv4


### PR DESCRIPTION
Also update the documentation and comments to node that you only need
to set NextServer if you are transferring TFTP or DHCP control away
from dr-provision.  While we are at it, remove other subnet fields and options that will automatically be filled with sane defaults or that can be dynamically determined at runtime