### PR TITLE
When idle waiting for new tasks in the runner,

### DIFF
--- a/api/jobs.go
+++ b/api/jobs.go
@@ -573,7 +573,8 @@ func (c *Client) Agent(m *models.Machine, exitOnNotRunnable, exitOnFailure, actu
 			// wait here for the task list or the current task to change on the machine
 			found, err := events.WaitFor(m,
 				OrItems(NotItem(EqualItem("CurrentTask", m.CurrentTask)),
-					NotItem(EqualItem("Tasks", m.Tasks))), 1*time.Hour)
+					NotItem(EqualItem("Tasks", m.Tasks)),
+					NotItem(EqualItem("Stage", m.Stage))), 1*time.Hour)
 			if err != nil {
 				res := &models.Error{
 					Type:  "AGENT_WAIT",


### PR DESCRIPTION
we should also look for a stage change.  In case
the admin chooses to make an empty task stage
as the start of a workflow, we should additionally
watch for a stage change and then continue the
process.