### PR TITLE
Add 'note' to use latest doc to ToC and QuickStart

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,6 +20,8 @@ Simply, Digital Rebar Provisioner acts as a Cobbler Replacement - with additiona
    :alt: Digital Rebar Provision
    :target: https://github.com/digitalrebar/provision
 
+.. note::  We HIGHLY recommend using the ``latest`` version of the documentation, as it contains the most up to date information.  Use the version selector in the lower     right corner of your browser.
+
 .. _rs_community:
 
 Community Resources

--- a/doc/quickstart.rst
+++ b/doc/quickstart.rst
@@ -6,6 +6,8 @@
 
 .. _rs_quickstart:
 
+.. note::  We HIGHLY recommend using the ``latest`` version of the documentation, as it contains the most up to date information.  Use the version selector in the lower     right corner of your browser.
+
 Quick Start
 ~~~~~~~~~~~
 


### PR DESCRIPTION
- added note to README.rst to suggest use `latest` version
- added also to the QuickStart as it's a heavily traffic/referenced link

This will be tagged stable in v3.7.0 release - allowing people who land on `stable` version to see the note about updated docs in `latest` version
