### PR TITLE
To make docker builds work correctly in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ genmodels
 assets/isos/
 dr-provision.zip
 dr-provision.sha256
+dr-provision-hash.*
 server.key
 server.crt
 cmds/incrementer/content.go

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,12 @@ deploy:
   overwrite: true
   api_key:
     secure: qdX7rFhTWwwKCFNTAofzV+ln67fnn/ANDqfKcowjJAVWcv6cJ56Rg5Q9N0lL9y0wBzxRHM5yRCJKJGp432VC89l9ZWN2sSoNcZbQt/hLBAymP4F3KhGDQWFgKVo+JbzHvYCFuLm3pyyAZ8HrhOZZgv8vW76AXtFNhDmM7fB+LpkBHaFx/T2MiabAm1O2CLZJbk4AGq/Ach42FjGRSMxIIcsR3Ud82zrqjktgXm3jiv9t4aCghkiBh5JqisDhBVAFtfmAncgKhjBqMG5K4R2LpVhlFPLs9Y+kEE02/8c089gHPNYhDwZLbfyUF72lyuQ5H0sqSe/JGKUOgpGcSiafCy0gYGiLEH1vqxqkfdcGybS67dv09pPTos4ke0Nv+7feFFEzE6eplT1r2sDadIxFfp8e8mgW+NsbSY/Pgs7hGvi8K/qc2Zy/PRCZzAAOI3/QhpsxAowv+7TG27y1Z6SYTvqpJRL4Hr61P0UA8EUDeYTn5jdQKJss2kDB8QfNwyshDBR56rAlDZQoYuYl8w7hLLpUhdcQjnDQ3126f9EVDVgwYL43NIUehWoSU0Fq+5oGykn6bDY8QkPBUa3vpBrtRZmt3zF4OOlP8Kn9gc9Xr1+8ItBh3bXJFuHm4CN6JFCGS4aamEYQA/CK5x5WquA+ezyUbKVaKrfsBXGg5gKONZQ=
+  file_glob: true
   file:
   - dr-provision.zip
   - dr-provision.sha256
   - embedded/assets/swagger.json
+  - dr-provision-hash.*
   skip_cleanup: true
   on:
     repo: digitalrebar/provision

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM alpine:3.6
 
 ARG DRP_VERSION=stable
+ARG DRP_COMMIT=""
 
 # add glibc so we can run drp executables
 # credit: http://www.manorrock.com/blog/2016/08/30/docker_tip_6_create_a_base_alpine_glibc_image.html
@@ -48,6 +49,6 @@ WORKDIR ${INSTALLDIR}
 VOLUME ["drp-data"]
 # install provision and its deps
 RUN echo "DRP_VERSION=${DRP_VERSION}"
-RUN apk add --no-cache iproute2 bash ipmitool curl libarchive-tools p7zip && ./install.sh --isolated install --drp-version=${DRP_VERSION}
+RUN apk add --no-cache iproute2 bash ipmitool curl libarchive-tools p7zip && ./install.sh --isolated install --drp-version=${DRP_VERSION} --commit=${DRP_COMMIT}
 # run the api server so we can install sledgehammer image
 CMD ${drp}

--- a/hooks/build
+++ b/hooks/build
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-docker build --build-arg DRP_VERSION=$SOURCE_BRANCH -t $IMAGE_NAME .
+docker build --build-arg DRP_COMMIT=$SOURCE_COMMIT --build-arg DRP_VERSION=$SOURCE_BRANCH -t $IMAGE_NAME .

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -6,7 +6,7 @@ DEFAULT_DRP_VERSION=${DEFAULT_DRP_VERSION:-"stable"}
 
 usage() {
 cat <<EOFUSAGE
-Usage: $0 [--version=<Version to install>] [--nocontent]
+Usage: $0 [--version=<Version to install>] [--nocontent] [--commit=<githash>]
           [--isolate] [--ipaddr=<ip>] install | remove
 
 Options:
@@ -20,6 +20,8 @@ Options:
                             # will attepmto to discover the value if not specified
     --version=<string>      # Version identifier if downloading.  stable, tip, or
                             # specific version label.  Defaults to: $DEFAULT_DRP_VERSION
+    --commit=<string>       # github commit file to wait for.  Unset assumes the files
+                            # are in place
 
     install                 # Sets up an insolated or system 'production' enabled install.
     remove                  # Removes the system enabled install.  Requires no other flags
@@ -62,6 +64,9 @@ while (( $# > 0 )); do
             ;;
         --force)
             force=true
+            ;;
+        --commit)
+            COMMIT=${arg_data}
             ;;
         --upgrade)
             UPGRADE=true
@@ -220,6 +225,15 @@ case $(uname -s) in
         echo "No idea how to check sha256sums"
         exit 1;;
 esac
+
+if [[ $COMMIT != "" ]] ; then
+    set +e
+    while ! curl -sfL -o dr-provision-hash.$COMMIT https://github.com/digitalrebar/provision/releases/download/$DRP_VERSION/dr-provision-hash.$COMMIT ; do
+            echo "Waiting for dr-provision-hash.$COMMIT"
+            sleep 60
+    done
+    set -e
+fi
 
 case $1 in
      install)

--- a/tools/package.sh
+++ b/tools/package.sh
@@ -33,4 +33,6 @@ cp -a tools/install.sh "$tmpdir/tools"
 
 cp "$tmpdir/dr-provision.zip" .
 $shasum dr-provision.zip > dr-provision.sha256
+HASH=$(git rev-parse HEAD)
+echo $HASH > dr-provision-hash.$HASH
 rm -rf "$tmpdir"


### PR DESCRIPTION
docker-cloud which updates docker hub,
we need to have a delay for docker builds
until the zip is uploaded.  Add a delay
in install.sh option for a file to
show up.  Once the file shows up, we will
continue the install.