### PR TITLE
Add some iPXE feature sanity testing.

### DIFF
--- a/midlayer/dhcp-tests/0000-basic-ipxe-discover/0000.logs-expect
+++ b/midlayer/dhcp-tests/0000-basic-ipxe-discover/0000.logs-expect
@@ -1,2 +1,3 @@
 Subnet sub1: MAC:52:54:be:1e:00:00 is in my range, attempting lease creation.
+Incoming iPXE request is sane
 xid 0xed2b0d78: Discovery handing out: 192.168.124.10 to 52:54:be:1e:00:00 via 192.168.124.1

--- a/midlayer/dhcp-tests/0000-basic-ipxe-discover/0001.logs-expect
+++ b/midlayer/dhcp-tests/0000-basic-ipxe-discover/0001.logs-expect
@@ -1,2 +1,3 @@
 Found our lease for strat: MAC token 52:54:be:1e:00:00, will use it
+Incoming iPXE request is sane
 xid 0xed2b0d78: Request handing out: 192.168.124.10 to 52:54:be:1e:00:00 via 192.168.124.1

--- a/midlayer/dhcp.go
+++ b/midlayer/dhcp.go
@@ -179,6 +179,178 @@ func (dhr *DhcpRequest) listenOn(testAddr net.IP) bool {
 	return false
 }
 
+//option:code:175 val:“177,5,1,128,134,16,14,33,1,1,16,1,2,39,1,1,235,3,1,0,0,23,1,1,21,1,1,19,1,1”
+type ipxeOpts struct {
+	// base options
+	prio    int8 // code 1 = int8
+	keepsan bool // code 8 = uint8
+	skipsan bool // code 9 = uint8
+	// feature indicators
+	pxeext    byte // code 16 = uint8
+	biosdrive byte // code 189 = unsigned integer 8;
+	iscsi     bool // code 17 = uint8
+	aoe       bool // code 18 = uint8
+	http      bool // code 19 = uint8
+	https     bool // code 20 = uint8
+	tftp      bool // code 21 = uint8
+	ftp       bool // code 22 = uint8
+	dns       bool // code 23 = uint8
+	bzimage   bool // code 24 = uint8
+	multiboot bool // code 25 = uint8
+	slam      bool // code 26 = uint8
+	srp       bool // code 27 = uint8
+	nbi       bool // code 32 = uint8
+	pxe       bool // code 33 = uint8
+	elf       bool // code 34 = uint8
+	comboot   bool // code 35 = uint8
+	efi       bool // code 36 = uint8
+	fcoe      bool // code 37 = uint8
+	vlan      bool // code 38 = uint8
+	menu      bool // code 39 = uint8
+	sdi       bool // code 40 = uint8
+	nfs       bool // code 41 = uint8
+	nopxedhcp bool // code 176 = uint 8;
+	// strings
+	syslogs           string // code 85 = string;
+	cert              string // code 91 = string;
+	privkey           string // code 92 = string;
+	crosscert         string // code 93 = string;
+	busid             string // code 177 = string;
+	sanfilename       string // code 188 = string;
+	username          string // code 190 = string;
+	password          string // code 191 = string;
+	reverseusername   string // code 192 = string;
+	reversepassword   string // code 193 = string;
+	version           string // code 235 = string;
+	iscsiinitiatoriqn string // code 203 = string;
+}
+
+func (dhr *DhcpRequest) ipxeIsSane(arch uint) bool {
+	opts := parseIpxeOpts(dhr)
+	if !(opts.http && opts.bzimage) {
+		dhr.Warnf("Incoming iPXE does not support http or bzImage")
+		return false
+	}
+	if arch == 0 && !opts.pxe {
+		dhr.Errorf("Incoming iPXE for arch %d does not support pxe. This should not happen", arch)
+		return false
+	}
+	if arch != 0 && !opts.efi {
+		dhr.Errorf("Incoming iPXE for arch %d does not support efi. This should not happen", arch)
+		return false
+	}
+	dhr.Infof("Incoming iPXE request is sane")
+	return true
+}
+
+func btob(b []byte) bool {
+	return b[0] != 0
+}
+
+func parseIpxeOpts(dhr *DhcpRequest) (res ipxeOpts) {
+	opts := dhr.pktOpts[175]
+	res = ipxeOpts{}
+	if opts == nil || len(opts) == 0 {
+		return res
+	}
+	for len(opts) > 2 {
+		code := opts[0]
+		codeLen := int(opts[1])
+		if len(opts[2:]) < codeLen {
+			return
+		}
+		opts = opts[2:]
+		val := opts[:codeLen]
+		dhr.Debugf("iPXE opt %d (len%d): %v", code, codeLen, val)
+		opts = opts[codeLen:]
+		switch code {
+		// base first
+		case 1:
+			res.prio = int8(val[0])
+		// byte vals
+		case 16:
+			res.pxeext = val[0]
+		case 189:
+			res.biosdrive = val[0]
+			// boolean values
+		case 176:
+			res.nopxedhcp = btob(val)
+		case 8:
+			res.keepsan = btob(val)
+		case 9:
+			res.skipsan = btob(val)
+		case 17:
+			res.iscsi = btob(val)
+		case 18:
+			res.aoe = btob(val)
+		case 19:
+			res.http = btob(val)
+		case 20:
+			res.https = btob(val)
+		case 21:
+			res.tftp = btob(val)
+		case 22:
+			res.ftp = btob(val)
+		case 23:
+			res.dns = btob(val)
+		case 24:
+			res.bzimage = btob(val)
+		case 25:
+			res.multiboot = btob(val)
+		case 26:
+			res.slam = btob(val)
+		case 27:
+			res.srp = btob(val)
+		case 32:
+			res.nbi = btob(val)
+		case 33:
+			res.pxe = btob(val)
+		case 34:
+			res.elf = btob(val)
+		case 35:
+			res.comboot = btob(val)
+		case 36:
+			res.efi = btob(val)
+		case 37:
+			res.fcoe = btob(val)
+		case 38:
+			res.vlan = btob(val)
+		case 39:
+			res.menu = btob(val)
+		case 40:
+			res.sdi = btob(val)
+		case 41:
+			res.nfs = btob(val)
+			// string values
+		case 85:
+			res.syslogs = string(val)
+		case 91:
+			res.cert = string(val)
+		case 92:
+			res.privkey = string(val)
+		case 93:
+			res.crosscert = string(val)
+		case 177:
+			res.busid = string(val)
+		case 188:
+			res.sanfilename = string(val)
+		case 190:
+			res.username = string(val)
+		case 191:
+			res.password = string(val)
+		case 192:
+			res.reverseusername = string(val)
+		case 193:
+			res.reversepassword = string(val)
+		case 203:
+			res.iscsiinitiatoriqn = string(val)
+		case 235:
+			res.version = string(val)
+		}
+	}
+	return res
+}
+
 // coalesceOptions is responsible for building the options we will
 // reply with, as well as figuring out whether or not we should offer
 // PXE and TFTP file name options in the outgoing packet.
@@ -336,10 +508,15 @@ func (dhr *DhcpRequest) coalesceOptions(
 	// Fill out default options for BootFileName and TFTPServerName
 	if _, ok := dhr.outOpts[dhcp.OptionBootFileName]; !ok {
 		fname := ""
-		if val, ok := dhr.pktOpts[dhcp.OptionUserClass]; ok && string(val) == "iPXE" {
+		var arch uint
+		if val, ok := dhr.pktOpts[dhcp.OptionClientArchitecture]; ok {
+			arch = uint(val[0])<<8 + uint(val[1])
+		}
+		if val, ok := dhr.pktOpts[dhcp.OptionUserClass]; ok &&
+			string(val) == "iPXE" &&
+			dhr.ipxeIsSane(arch) {
 			fname = "default.ipxe"
-		} else if val, ok := dhr.pktOpts[dhcp.OptionClientArchitecture]; ok {
-			arch := uint(val[0])<<8 + uint(val[1])
+		} else {
 			switch arch {
 			case 0:
 				fname = "lpxelinux.0"


### PR DESCRIPTION
The ipxe baked into virtualbox cannot load bzImages for whatever
probably insane reason.  Have our DHCP server be smart enough to
detect when the remote iPXE is too stupid for us to use and fall back
the non-iPXE set of choices.