### PR TITLE
Put the bool vars back in content.  This should

### DIFF
--- a/cli/test-data/output/TestContentCli/contents.create.4c4e8ae2275d5c4ad58d3e7b5442a889/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.create.4c4e8ae2275d5c4ad58d3e7b5442a889/stdout.expect
@@ -4,10 +4,10 @@
   "meta": {
     "Description": "",
     "Name": "john",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentCli/contents.create.8bfd7703fd90aa488fd3d1ec45addaa0/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.create.8bfd7703fd90aa488fd3d1ec45addaa0/stdout.expect
@@ -4,10 +4,10 @@
   "meta": {
     "Description": "",
     "Name": "john",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentCli/contents.create.9e158a3d3b178f0103e2e0402e827273/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.create.9e158a3d3b178f0103e2e0402e827273/stdout.expect
@@ -6,10 +6,10 @@
   "meta": {
     "Description": "",
     "Name": "withProfile",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentCli/contents.create.https./github.com/digitalrebar/provision-content/releases/download/v1.3.0/drp-community-content.yaml/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.create.https./github.com/digitalrebar/provision-content/releases/download/v1.3.0/drp-community-content.yaml/stdout.expect
@@ -14,10 +14,10 @@ RE:
   "meta": {
     "Description": "Digital Rebar Provision Community Content",
     "Name": "drp-community-content",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "https://github.com/digitalrebar/provision-content",
     "Type": "dynamic",
     "Version": "v1.3.0-0-066c0d69eb5f1d7a33ba801978150040b61da725",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentCli/contents.create.test-data/content.yaml/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.create.test-data/content.yaml/stdout.expect
@@ -11,10 +11,10 @@ RE:
   "meta": {
     "Description": "Digital Rebar Provision Community Contrib",
     "Name": "drp-community-contrib",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "https://github.com/digitalrebar/provision-content",
     "Type": "dynamic",
     "Version": "stable.galthaus.7-strange-30b5a4603088a31f898ce1960f1f4475bda2630d",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentCli/contents.list.2/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.list.2/stdout.expect
@@ -21,11 +21,11 @@
     "meta": {
       "Description": "Writable backing store",
       "Name": "BackingStore",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "",
       "Type": "writable",
       "Version": "user",
-      "Writable": "true"
+      "Writable": true
     }
   },
   {
@@ -36,11 +36,11 @@
     "meta": {
       "Description": "Local Override Store",
       "Name": "LocalStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "local",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -49,11 +49,11 @@
     "meta": {
       "Description": "",
       "Name": "john",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "",
       "Type": "dynamic",
       "Version": "",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -64,11 +64,11 @@
     "meta": {
       "Description": "Initial Default Content",
       "Name": "DefaultStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "Unspecified",
       "Type": "default",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -79,11 +79,11 @@
     "meta": {
       "Description": "Test Plugin for DRP",
       "Name": "incrementer",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "Digital Rebar",
       "Type": "plugin",
       "Version": "Internal",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -95,11 +95,11 @@
     "meta": {
       "Description": "Default objects that must be present",
       "Name": "BasicStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "basic",
       "Version": "Unversioned",
-      "Writable": "false"
+      "Writable": false
     }
   }
 ]

--- a/cli/test-data/output/TestContentCli/contents.list.3/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.list.3/stdout.expect
@@ -21,11 +21,11 @@
     "meta": {
       "Description": "Writable backing store",
       "Name": "BackingStore",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "",
       "Type": "writable",
       "Version": "user",
-      "Writable": "true"
+      "Writable": true
     }
   },
   {
@@ -36,11 +36,11 @@
     "meta": {
       "Description": "Local Override Store",
       "Name": "LocalStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "local",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -51,11 +51,11 @@
     "meta": {
       "Description": "Initial Default Content",
       "Name": "DefaultStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "Unspecified",
       "Type": "default",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -66,11 +66,11 @@
     "meta": {
       "Description": "Test Plugin for DRP",
       "Name": "incrementer",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "Digital Rebar",
       "Type": "plugin",
       "Version": "Internal",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -82,11 +82,11 @@
     "meta": {
       "Description": "Default objects that must be present",
       "Name": "BasicStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "basic",
       "Version": "Unversioned",
-      "Writable": "false"
+      "Writable": false
     }
   }
 ]

--- a/cli/test-data/output/TestContentCli/contents.list.4/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.list.4/stdout.expect
@@ -21,11 +21,11 @@
     "meta": {
       "Description": "Writable backing store",
       "Name": "BackingStore",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "",
       "Type": "writable",
       "Version": "user",
-      "Writable": "true"
+      "Writable": true
     }
   },
   {
@@ -36,11 +36,11 @@
     "meta": {
       "Description": "Local Override Store",
       "Name": "LocalStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "local",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -49,11 +49,11 @@
     "meta": {
       "Description": "",
       "Name": "john",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "",
       "Type": "dynamic",
       "Version": "",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -64,11 +64,11 @@
     "meta": {
       "Description": "Initial Default Content",
       "Name": "DefaultStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "Unspecified",
       "Type": "default",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -79,11 +79,11 @@
     "meta": {
       "Description": "Test Plugin for DRP",
       "Name": "incrementer",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "Digital Rebar",
       "Type": "plugin",
       "Version": "Internal",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -95,11 +95,11 @@
     "meta": {
       "Description": "Default objects that must be present",
       "Name": "BasicStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "basic",
       "Version": "Unversioned",
-      "Writable": "false"
+      "Writable": false
     }
   }
 ]

--- a/cli/test-data/output/TestContentCli/contents.list.5/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.list.5/stdout.expect
@@ -21,11 +21,11 @@
     "meta": {
       "Description": "Writable backing store",
       "Name": "BackingStore",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "",
       "Type": "writable",
       "Version": "user",
-      "Writable": "true"
+      "Writable": true
     }
   },
   {
@@ -36,11 +36,11 @@
     "meta": {
       "Description": "Local Override Store",
       "Name": "LocalStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "local",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -51,11 +51,11 @@
     "meta": {
       "Description": "Initial Default Content",
       "Name": "DefaultStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "Unspecified",
       "Type": "default",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -66,11 +66,11 @@
     "meta": {
       "Description": "Test Plugin for DRP",
       "Name": "incrementer",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "Digital Rebar",
       "Type": "plugin",
       "Version": "Internal",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -82,11 +82,11 @@
     "meta": {
       "Description": "Default objects that must be present",
       "Name": "BasicStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "basic",
       "Version": "Unversioned",
-      "Writable": "false"
+      "Writable": false
     }
   }
 ]

--- a/cli/test-data/output/TestContentCli/contents.list/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.list/stdout.expect
@@ -21,11 +21,11 @@
     "meta": {
       "Description": "Writable backing store",
       "Name": "BackingStore",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "",
       "Type": "writable",
       "Version": "user",
-      "Writable": "true"
+      "Writable": true
     }
   },
   {
@@ -36,11 +36,11 @@
     "meta": {
       "Description": "Local Override Store",
       "Name": "LocalStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "local",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -51,11 +51,11 @@
     "meta": {
       "Description": "Initial Default Content",
       "Name": "DefaultStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "Unspecified",
       "Type": "default",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -66,11 +66,11 @@
     "meta": {
       "Description": "Test Plugin for DRP",
       "Name": "incrementer",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "Digital Rebar",
       "Type": "plugin",
       "Version": "Internal",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -82,11 +82,11 @@
     "meta": {
       "Description": "Default objects that must be present",
       "Name": "BasicStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "basic",
       "Version": "Unversioned",
-      "Writable": "false"
+      "Writable": false
     }
   }
 ]

--- a/cli/test-data/output/TestContentCli/contents.show.john.2/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.show.john.2/stdout.expect
@@ -2,11 +2,11 @@
   "meta": {
     "Description": "Fred Rules",
     "Name": "john",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   },
   "sections": {}
 }

--- a/cli/test-data/output/TestContentCli/contents.show.john.3/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.show.john.3/stdout.expect
@@ -2,11 +2,11 @@
   "meta": {
     "Description": "Fred Rules",
     "Name": "john",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   },
   "sections": {}
 }

--- a/cli/test-data/output/TestContentCli/contents.show.john/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.show.john/stdout.expect
@@ -2,11 +2,11 @@
   "meta": {
     "Description": "",
     "Name": "john",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   },
   "sections": {}
 }

--- a/cli/test-data/output/TestContentCli/contents.update.john.59209e8bace11a0f00a7428a38c870cf/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.update.john.59209e8bace11a0f00a7428a38c870cf/stdout.expect
@@ -4,10 +4,10 @@
   "meta": {
     "Description": "Fred Rules",
     "Name": "john",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentCli/contents.update.john.c98b16630cd831ca78e72866b3c83d3d/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.update.john.c98b16630cd831ca78e72866b3c83d3d/stdout.expect
@@ -4,10 +4,10 @@
   "meta": {
     "Description": "Fred Rules",
     "Name": "john",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentCli/contents.upload.4c4e8ae2275d5c4ad58d3e7b5442a889.2/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.upload.4c4e8ae2275d5c4ad58d3e7b5442a889.2/stdout.expect
@@ -4,10 +4,10 @@
   "meta": {
     "Description": "",
     "Name": "john",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentCli/contents.upload.4c4e8ae2275d5c4ad58d3e7b5442a889/stdout.expect
+++ b/cli/test-data/output/TestContentCli/contents.upload.4c4e8ae2275d5c4ad58d3e7b5442a889/stdout.expect
@@ -4,10 +4,10 @@
   "meta": {
     "Description": "",
     "Name": "john",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentsFunctionalCli/contents.create.84cca4062c8befaa5694bde7aa8f5680/stdout.expect
+++ b/cli/test-data/output/TestContentsFunctionalCli/contents.create.84cca4062c8befaa5694bde7aa8f5680/stdout.expect
@@ -6,10 +6,10 @@
   "meta": {
     "Description": "",
     "Name": "Pack1",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "0.1",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentsFunctionalCli/contents.list.2/stdout.expect
+++ b/cli/test-data/output/TestContentsFunctionalCli/contents.list.2/stdout.expect
@@ -21,11 +21,11 @@
     "meta": {
       "Description": "Writable backing store",
       "Name": "BackingStore",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "",
       "Type": "writable",
       "Version": "user",
-      "Writable": "true"
+      "Writable": true
     }
   },
   {
@@ -36,11 +36,11 @@
     "meta": {
       "Description": "Local Override Store",
       "Name": "LocalStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "local",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -51,11 +51,11 @@
     "meta": {
       "Description": "Initial Default Content",
       "Name": "DefaultStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "Unspecified",
       "Type": "default",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -66,11 +66,11 @@
     "meta": {
       "Description": "Test Plugin for DRP",
       "Name": "incrementer",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "Digital Rebar",
       "Type": "plugin",
       "Version": "Internal",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -82,11 +82,11 @@
     "meta": {
       "Description": "Default objects that must be present",
       "Name": "BasicStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "basic",
       "Version": "Unversioned",
-      "Writable": "false"
+      "Writable": false
     }
   }
 ]

--- a/cli/test-data/output/TestContentsFunctionalCli/contents.list/stdout.expect
+++ b/cli/test-data/output/TestContentsFunctionalCli/contents.list/stdout.expect
@@ -21,11 +21,11 @@
     "meta": {
       "Description": "Writable backing store",
       "Name": "BackingStore",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "",
       "Type": "writable",
       "Version": "user",
-      "Writable": "true"
+      "Writable": true
     }
   },
   {
@@ -36,11 +36,11 @@
     "meta": {
       "Description": "Local Override Store",
       "Name": "LocalStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "local",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -51,11 +51,11 @@
     "meta": {
       "Description": "Initial Default Content",
       "Name": "DefaultStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "Unspecified",
       "Type": "default",
       "Version": "user",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -66,11 +66,11 @@
     "meta": {
       "Description": "Test Plugin for DRP",
       "Name": "incrementer",
-      "Overwritable": "false",
+      "Overwritable": false,
       "Source": "Digital Rebar",
       "Type": "plugin",
       "Version": "Internal",
-      "Writable": "false"
+      "Writable": false
     }
   },
   {
@@ -82,11 +82,11 @@
     "meta": {
       "Description": "Default objects that must be present",
       "Name": "BasicStore",
-      "Overwritable": "true",
+      "Overwritable": true,
       "Source": "",
       "Type": "basic",
       "Version": "Unversioned",
-      "Writable": "false"
+      "Writable": false
     }
   }
 ]

--- a/cli/test-data/output/TestContentsFunctionalCli/contents.update.Pack1.523620b2ed16a29ed3b9015febae8d6b/stdout.expect
+++ b/cli/test-data/output/TestContentsFunctionalCli/contents.update.Pack1.523620b2ed16a29ed3b9015febae8d6b/stdout.expect
@@ -8,10 +8,10 @@
   "meta": {
     "Description": "",
     "Name": "Pack1",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "0.2",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/cli/test-data/output/TestContentsFunctionalCli/contents.update.Pack1.6b35a1afa1056a025874f230315ad6fe/stdout.expect
+++ b/cli/test-data/output/TestContentsFunctionalCli/contents.update.Pack1.6b35a1afa1056a025874f230315ad6fe/stdout.expect
@@ -6,10 +6,10 @@
   "meta": {
     "Description": "",
     "Name": "Pack1",
-    "Overwritable": "false",
+    "Overwritable": false,
     "Source": "",
     "Type": "dynamic",
     "Version": "0.3",
-    "Writable": "false"
+    "Writable": false
   }
 }

--- a/models/content.go
+++ b/models/content.go
@@ -11,9 +11,9 @@ type ContentMetaData struct {
 	Version     string
 
 	// Informational Fields
-	Writable     string
+	Writable     bool
 	Type         string
-	Overwritable string
+	Overwritable bool
 }
 
 //
@@ -187,28 +187,28 @@ func (c *ContentSummary) FromStore(src store.Store) {
 }
 
 // Return type, overwritable, writable
-func getExtraFields(n, t string) (string, string, string) {
-	writable := "false"
-	overwritable := "false"
+func getExtraFields(n, t string) (string, bool, bool) {
+	writable := false
+	overwritable := false
 	if t != "" {
 		if t == "default" {
-			overwritable = "true"
+			overwritable = true
 		}
 	} else {
 		t = "dynamic"
 	}
 	if n == "BackingStore" {
 		t = "writable"
-		writable = "true"
+		writable = true
 	} else if n == "LocalStore" {
 		t = "local"
-		overwritable = "true"
+		overwritable = true
 	} else if n == "BasicStore" {
 		t = "basic"
-		overwritable = "true"
+		overwritable = true
 	} else if n == "DefaultStore" {
 		t = "default"
-		overwritable = "true"
+		overwritable = true
 	}
 	return t, overwritable, writable
 }


### PR DESCRIPTION
enable backwards compat and the ToStore/FromStore
functions should protect us from bad behavior.

Addresses #819.