### PR TITLE
Add Range to the allowed headers.

### DIFF
--- a/api/info_test.go
+++ b/api/info_test.go
@@ -51,6 +51,7 @@ func TestInfo(t *testing.T) {
 				"plugin-v2-safe-config",
 				"workflows",
 				"default-workflow",
+				"http-range-header",
 			},
 		},
 		expectErr: nil,

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
@@ -21,7 +21,8 @@ RE:
       "fsm-runner",
       "plugin-v2-safe-config",
       "workflows",
-      "default-workflow"
+      "default-workflow",
+      "http-range-header"
     \],
     "file_port": 10002,
     "id": "Fred",

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
@@ -21,7 +21,8 @@ RE:
       "fsm-runner",
       "plugin-v2-safe-config",
       "workflows",
-      "default-workflow"
+      "default-workflow",
+      "http-range-header"
     \],
     "file_port": 10002,
     "id": "Fred",

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -460,6 +460,7 @@ func NewFrontend(
 			"X-Return-Attributes",
 			"X-Log-Level",
 			"X-Log-Token",
+			"Range",
 		},
 		ExposeHeaders: []string{
 			"Content-Length",

--- a/frontend/info.go
+++ b/frontend/info.go
@@ -49,6 +49,7 @@ func (f *Frontend) GetInfo(c *gin.Context, drpid string) (*models.Info, *models.
 			"plugin-v2-safe-config",
 			"workflows",
 			"default-workflow",
+			"http-range-header",
 		},
 	}
 


### PR DESCRIPTION
Add an http-range-header feature flag.
Update unit test.