### PR TITLE
Make the job logger use a fixed buffer and timeouts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     - bsdtar
 sudo: false
 go:
-- 1.9
+- 1.10
 git:
   depth: 500
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ addons:
     - bsdtar
 sudo: false
 go:
-- 1.10
+- "1.10"
 git:
   depth: 500
 install:

--- a/cli/test-data/output/TestMachineFileImport/machines.update.a2d9b43a-b545-464b-8bc4-088daa7fa7c4.test-data/base/machines/bad.yaml/stderr.expect
+++ b/cli/test-data/output/TestMachineFileImport/machines.update.a2d9b43a-b545-464b-8bc4-088daa7fa7c4.test-data/base/machines/bad.yaml/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed machines:a2d9b43a-b545-464b-8bc4-088daa7fa7c4 object: Unable to unmarshal reference object: error converting YAML to JSON: yaml: line 1: mapping values are not allowed in this context
+Error: Failed to generate changed machines:a2d9b43a-b545-464b-8bc4-088daa7fa7c4 object: Unable to unmarshal reference object: error converting YAML to JSON: yaml: line 2: mapping values are not allowed in this context
 

--- a/cli/test-data/output/TestProfileFileImport/profiles.update.yamltest.test-data/base/profiles/bad.yaml/stderr.expect
+++ b/cli/test-data/output/TestProfileFileImport/profiles.update.yamltest.test-data/base/profiles/bad.yaml/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed profiles:yamltest object: Unable to unmarshal reference object: error converting YAML to JSON: yaml: line 1: mapping values are not allowed in this context
+Error: Failed to generate changed profiles:yamltest object: Unable to unmarshal reference object: error converting YAML to JSON: yaml: line 2: mapping values are not allowed in this context
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: e5158e4f5d9b79afe806f75dcd1798869ac7665113daae66d466ce0793c83bc2
-updated: 2018-02-20T12:03:13.950432409-06:00
+hash: 8e35b400bfbd2bb7ac39cc8da3634efefb9303bbc9aa5c466e9c61fa3b8d0191
+updated: 2018-05-01T14:59:55.808393722-05:00
 imports:
 - name: github.com/armon/go-metrics
   version: 7aa49fde808223f8dadfdbfd3a20ff6c19e5f9ec
@@ -140,6 +140,10 @@ imports:
   version: 37707fdb30a5b38865cfb95e5aab41707daec7fd
   subpackages:
   - unix
+- name: golang.org/x/tools
+  version: 5c8013c5617234a9515f1b1379aba7e03e846479
+  subpackages:
+  - cover
 - name: gopkg.in/go-playground/validator.v8
   version: 5f1438d3fca68893a817e4a66806cea46a9e4ebf
 - name: gopkg.in/mgo.v2
@@ -150,6 +154,6 @@ imports:
 - name: gopkg.in/olahol/melody.v1
   version: d521390733761fe1db13de575c253afd5c743085
 - name: gopkg.in/yaml.v2
-  version: d670f9405373e636a5a2765eea47fac0c9bc91a4
+  version: 5420a8b6744d3b0345ab293f6fcba19c978f1183
   repo: https://github.com/go-yaml/yaml
 testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -29,6 +29,9 @@ import:
 - package: gopkg.in/olahol/melody.v1
 - package: github.com/fsnotify/fsnotify
 - package: github.com/vishvananda/netlink
+- package: golang.org/x/tools
+  subpackages:
+  - cover
 - package: golang.org/x/net
   subpackages:
   - context

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -16,12 +16,12 @@ fi
 
 # Work out the GO version we are working with:
 GO_VERSION=$(go version | awk '{ print $3 }' | sed 's/go//')
-WANTED_VER=(1 8)
+WANTED_VER=(1 10)
 if ! [[ "$GO_VERSION" =~ ([0-9]+)\.([0-9]+) ]]; then
     echo "Cannot figure out what version of Go is installed"
     exit 1
 elif ! (( ${BASH_REMATCH[1]} > ${WANTED_VER[0]} || ${BASH_REMATCH[2]} >= ${WANTED_VER[1]} )); then
-    echo "Go Version needs to be 1.8 or higher: currently $GO_VERSION"
+    echo "Go Version needs to be 1.10 or higher: currently $GO_VERSION"
     exit -1
 fi
 

--- a/tools/mergeProfiles.go
+++ b/tools/mergeProfiles.go
@@ -1,0 +1,137 @@
+// gocovmerge takes the results from multiple `go test -coverprofile` runs and
+// merges them into one profile
+//
+// Copied from https://github.com/wadey/gocovmerge/blob/master/gocovmerge.go
+/*
+Copyright (c) 2015, Wade Simmons
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"sort"
+
+	"golang.org/x/tools/cover"
+)
+
+func mergeProfiles(p *cover.Profile, merge *cover.Profile) {
+	if p.Mode != merge.Mode {
+		log.Fatalf("cannot merge profiles with different modes")
+	}
+	// Since the blocks are sorted, we can keep track of where the last block
+	// was inserted and only look at the blocks after that as targets for merge
+	startIndex := 0
+	for _, b := range merge.Blocks {
+		startIndex = mergeProfileBlock(p, b, startIndex)
+	}
+}
+
+func mergeProfileBlock(p *cover.Profile, pb cover.ProfileBlock, startIndex int) int {
+	sortFunc := func(i int) bool {
+		pi := p.Blocks[i+startIndex]
+		return pi.StartLine >= pb.StartLine && (pi.StartLine != pb.StartLine || pi.StartCol >= pb.StartCol)
+	}
+
+	i := 0
+	if sortFunc(i) != true {
+		i = sort.Search(len(p.Blocks)-startIndex, sortFunc)
+	}
+	i += startIndex
+	if i < len(p.Blocks) && p.Blocks[i].StartLine == pb.StartLine && p.Blocks[i].StartCol == pb.StartCol {
+		if p.Blocks[i].EndLine != pb.EndLine || p.Blocks[i].EndCol != pb.EndCol {
+			log.Fatalf("OVERLAP MERGE: %v %v %v", p.FileName, p.Blocks[i], pb)
+		}
+		switch p.Mode {
+		case "set":
+			p.Blocks[i].Count |= pb.Count
+		case "count", "atomic":
+			p.Blocks[i].Count += pb.Count
+		default:
+			log.Fatalf("unsupported covermode: '%s'", p.Mode)
+		}
+	} else {
+		if i > 0 {
+			pa := p.Blocks[i-1]
+			if pa.EndLine >= pb.EndLine && (pa.EndLine != pb.EndLine || pa.EndCol > pb.EndCol) {
+				log.Fatalf("OVERLAP BEFORE: %v %v %v", p.FileName, pa, pb)
+			}
+		}
+		if i < len(p.Blocks)-1 {
+			pa := p.Blocks[i+1]
+			if pa.StartLine <= pb.StartLine && (pa.StartLine != pb.StartLine || pa.StartCol < pb.StartCol) {
+				log.Fatalf("OVERLAP AFTER: %v %v %v", p.FileName, pa, pb)
+			}
+		}
+		p.Blocks = append(p.Blocks, cover.ProfileBlock{})
+		copy(p.Blocks[i+1:], p.Blocks[i:])
+		p.Blocks[i] = pb
+	}
+	return i + 1
+}
+
+func addProfile(profiles []*cover.Profile, p *cover.Profile) []*cover.Profile {
+	i := sort.Search(len(profiles), func(i int) bool { return profiles[i].FileName >= p.FileName })
+	if i < len(profiles) && profiles[i].FileName == p.FileName {
+		mergeProfiles(profiles[i], p)
+	} else {
+		profiles = append(profiles, nil)
+		copy(profiles[i+1:], profiles[i:])
+		profiles[i] = p
+	}
+	return profiles
+}
+
+func dumpProfiles(profiles []*cover.Profile, out io.Writer) {
+	if len(profiles) == 0 {
+		return
+	}
+	fmt.Fprintf(out, "mode: %s\n", profiles[0].Mode)
+	for _, p := range profiles {
+		for _, b := range p.Blocks {
+			fmt.Fprintf(out, "%s:%d.%d,%d.%d %d %d\n", p.FileName, b.StartLine, b.StartCol, b.EndLine, b.EndCol, b.NumStmt, b.Count)
+		}
+	}
+}
+
+func main() {
+	flag.Parse()
+
+	var merged []*cover.Profile
+
+	for _, file := range flag.Args() {
+		profiles, err := cover.ParseProfiles(file)
+		if err != nil {
+			log.Fatalf("failed to parse profiles: %v", err)
+		}
+		for _, p := range profiles {
+			merged = addProfile(merged, p)
+		}
+	}
+
+	dumpProfiles(merged, os.Stdout)
+}

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -22,20 +22,13 @@ else
     PATH=`pwd`/bin/linux/amd64:$PATH
 fi
 
-for d in $(go list ./... 2>/dev/null | grep -v cmds | grep -v vendor | grep -v github.com/digitalrebar/provision/client  | grep -v github.com/digitalrebar/provision/genmodels) ; do
-    tdir=$PWD
-    dir=${d//github.com\/digitalrebar\/provision}
-    echo "----------- TESTING $dir -----------"
+i=0
+for d in $(go list ./... 2>/dev/null | grep -v cmds) ; do
+    echo "----------- TESTING $d -----------"
     rm -f test.bin
-    go test -o test.bin -c -race -covermode=atomic -coverpkg=$packages "$d"
-    if [ -e test.bin ] ; then
-        (cd .$dir; time "$tdir/test.bin" -test.coverprofile="$tdir/profile.out")
-        rm -f test.bin
-    fi
-
-    if [ -f profile.out ]; then
-        grep -h -v "^mode:" profile.out >> coverage.txt
-        rm profile.out
-    fi
+    time go test -race -covermode=atomic -coverpkg=$packages -coverprofile="profile$i.out" "$d" || FAILED=true
+    i=$((i+1))
 done
-
+go run tools/mergeProfiles.go profile*.out >coverage.txt
+rm profile*.out
+[[ $FAILED = true ]]

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -25,10 +25,12 @@ fi
 i=0
 for d in $(go list ./... 2>/dev/null | grep -v cmds) ; do
     echo "----------- TESTING $d -----------"
-    rm -f test.bin
     time go test -race -covermode=atomic -coverpkg=$packages -coverprofile="profile$i.out" "$d" || FAILED=true
     i=$((i+1))
 done
 go run tools/mergeProfiles.go profile*.out >coverage.txt
 rm profile*.out
-[[ $FAILED = true ]]
+if [[ $FAILED ]]; then
+    echo "FAILED"
+    exit 1
+fi


### PR DESCRIPTION
This will make the Agent much less chatty when talking to the API to
log job output.  It relies on go 1.10 ReadTimeout on files to make sure the
log output gets flushed every 64k or 1 second, whichever comes first.