### PR TITLE
Get rid of separate index permissions.

### DIFF
--- a/api/info_test.go
+++ b/api/info_test.go
@@ -78,10 +78,6 @@ func TestInfo(t *testing.T) {
 					"list":   struct{}{},
 					"post":   struct{}{},
 				},
-				"indexes": map[string]struct{}{
-					"get":  struct{}{},
-					"list": struct{}{},
-				},
 				"info": map[string]struct{}{
 					"get": struct{}{},
 				},

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
@@ -53,10 +53,6 @@ RE:
         "list": {},
         "post": {}
       },
-      "indexes": {
-        "get": {},
-        "list": {}
-      },
       "info": {
         "get": {}
       },

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
@@ -53,10 +53,6 @@ RE:
         "list": {},
         "post": {}
       },
-      "indexes": {
-        "get": {},
-        "list": {}
-      },
       "info": {
         "get": {}
       },

--- a/frontend/indexes.go
+++ b/frontend/indexes.go
@@ -66,14 +66,12 @@ func (f *Frontend) InitIndexApi() {
 	//       500: ErrorResponse
 	f.ApiGroup.GET("/indexes",
 		func(c *gin.Context) {
-			if !f.assureSimpleAuth(c, "indexes", "list", "") {
-				return
-			}
 			res := map[string]map[string]index.Maker{}
 			for _, m := range models.All() {
 				bm := backend.ModelToBackend(m)
 				idxer, ok := bm.(Indexer)
-				if !ok {
+				if !ok ||
+					!f.getAuth(c).matchClaim(models.MakeRole("", m.Prefix(), "list", "").Compile()) {
 					continue
 				}
 				res[m.Prefix()] = idxer.Indexes()
@@ -95,7 +93,7 @@ func (f *Frontend) InitIndexApi() {
 	//       500: ErrorResponse
 	f.ApiGroup.GET("/indexes/:prefix",
 		func(c *gin.Context) {
-			if !f.assureSimpleAuth(c, "indexes", "get", "") {
+			if !f.assureSimpleAuth(c, c.Param("prefix"), "list", "") {
 				return
 			}
 			m, err := models.New(c.Param("prefix"))
@@ -138,7 +136,7 @@ func (f *Frontend) InitIndexApi() {
 	//       500: ErrorResponse
 	f.ApiGroup.GET("/indexes/:prefix/:param",
 		func(c *gin.Context) {
-			if !f.assureSimpleAuth(c, "indexes", "get", "") {
+			if !f.assureSimpleAuth(c, c.Param("prefix"), "list", "") {
 				return
 			}
 			prefix := c.Param("prefix")

--- a/models/role.go
+++ b/models/role.go
@@ -29,7 +29,6 @@ var (
 		"interfaces": "list, get",
 		"info":       "get",
 		"isos":       "list, get, post, delete",
-		"indexes":    "list, get",
 	}
 
 	addedActions = map[string]string{


### PR DESCRIPTION
Now, if you have rights to list a thing, you can also get its indexes.