### PR TITLE
Start adding support for nestable runners

### DIFF
--- a/api/event_stream.go
+++ b/api/event_stream.go
@@ -77,8 +77,13 @@ func EqualItem(field string, value interface{}) TestFunc {
 	}
 }
 
-func (c *Client) ws() (*websocket.Conn, error) {
-	ep, err := c.UrlFor("ws")
+func (c *Client) ws(parts ...string) (*websocket.Conn, error) {
+	if len(parts) == 0 {
+		parts = []string{"ws"}
+	} else {
+		parts = append(parts, "ws")
+	}
+	ep, err := c.UrlFor(parts...)
 	if err != nil {
 		return nil, err
 	}
@@ -163,8 +168,8 @@ func (es *EventStream) processEvents(running chan struct{}) {
 }
 
 // Events creates a new EventStream from the client.
-func (c *Client) Events() (*EventStream, error) {
-	conn, err := c.ws()
+func (c *Client) Events(parts ...string) (*EventStream, error) {
+	conn, err := c.ws(parts...)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/requestTracker.go
+++ b/backend/requestTracker.go
@@ -139,7 +139,7 @@ func (rt *RequestTracker) Find(prefix, key string) models.Model {
 func (rt *RequestTracker) FindByIndex(prefix string, idx index.Maker, key string) models.Model {
 	items, err := index.Sort(idx)(rt.Index(prefix))
 	if err != nil {
-		rt.Errorf("Error sorting %s: %c", prefix, err)
+		rt.Errorf("Error sorting %s: %v", prefix, err)
 		return nil
 	}
 	return items.Find(key)

--- a/backend/stage.go
+++ b/backend/stage.go
@@ -14,10 +14,9 @@ import (
 type Stage struct {
 	*models.Stage
 	validate
-	renderers       renderers
-	stageParamsTmpl *template.Template
-	rootTemplate    *template.Template
-	tmplMux         sync.Mutex
+	renderers    renderers
+	rootTemplate *template.Template
+	tmplMux      sync.Mutex
 }
 
 // SetReadOnly interface function to set the ReadOnly flag.

--- a/frontend/frontend.go
+++ b/frontend/frontend.go
@@ -463,9 +463,9 @@ func NewFrontend(
 	apiGroup.Use(me.userAuth())
 	me.ApiGroup = apiGroup
 
+	me.InitWebSocket()
 	me.InitIndexApi()
 	me.InitRoleApi()
-	me.InitWebSocket()
 	me.InitBootEnvApi()
 	me.InitStageApi()
 	me.InitIsoApi()


### PR DESCRIPTION
This adds server-side support for having multiple agents run on a
machine, but to only allow the most recently attached agent to recieve
events.

This is still a work in progress, more client side and server side
work is needed to make things robust.