### PR TITLE
Add a chroot concept to the runner.

### DIFF
--- a/api/chroot_linux.go
+++ b/api/chroot_linux.go
@@ -1,0 +1,53 @@
+// +build linux
+
+package api
+
+import (
+	"os"
+	"os/exec"
+	"path"
+	"syscall"
+)
+
+func bindMount(newRoots string, srcFS ...string) error {
+	if len(srcFS) == 0 {
+		return nil
+	}
+	tgt := path.Join(newRoots, srcFS[0])
+	if err := os.MkdirAll(tgt, os.ModePerm); err != nil {
+		return err
+	}
+	if err := syscall.Mount(srcFS[0], tgt, "", syscall.MS_BIND, ""); err != nil {
+		return err
+	}
+	if err := bindMount(newRoots, srcFS[1:]...); err != nil {
+		syscall.Unmount(tgt, 0)
+		return err
+	}
+	return nil
+}
+
+func (r *TaskRunner) bindFSes() []string {
+	return []string{"/proc", "/sys", "/dev", "/dev/pts", r.agentDir}
+}
+
+func (r *TaskRunner) enterChroot(cmd *exec.Cmd) error {
+	if r.chrootDir == "" {
+		return nil
+	}
+	if err := bindMount(r.chrootDir, r.bindFSes()...); err != nil {
+		return err
+	}
+	cmd.SysProcAttr = &syscall.SysProcAttr{Chroot: r.chrootDir}
+	return nil
+}
+
+func (r *TaskRunner) exitChroot() {
+	if r.chrootDir == "" {
+		return
+	}
+	fses := r.bindFSes()
+	for i := len(fses) - 1; i > -1; i-- {
+		syscall.Unmount(path.Join(r.chrootDir, fses[i]), 0)
+	}
+}

--- a/api/chroot_other.go
+++ b/api/chroot_other.go
@@ -1,0 +1,18 @@
+// +build !linux
+
+package api
+
+import (
+	"fmt"
+	"os/exec"
+	"runtime"
+)
+
+func (r *TaskRunner) enterChroot(cmd *exec.Cmd) error {
+	if r.chrootDir != "" {
+		return fmt.Errorf("enterChroot not supported on %v", runtime.GOOS)
+	}
+	return nil
+}
+
+func (r *TaskRunner) exitChroot() {}

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -131,9 +131,8 @@ func (r *TaskRunner) Expand(action *models.JobAction, taskDir string) error {
 	// Write the Contents of this template to the passed Path
 	if !strings.HasPrefix(action.Path, "/") {
 		action.Path = path.Join(taskDir, path.Clean(action.Path))
-		if r.chrootDir != "" {
-			action.Path = path.Join(r.chrootDir, action.Path)
-		}
+	} else if r.chrootDir != "" {
+		action.Path = path.Join(r.chrootDir, action.Path)
 	}
 	r.Log("%s: Writing %s to %s", time.Now(), action.Name, action.Path)
 	if err := os.MkdirAll(filepath.Dir(action.Path), os.ModePerm); err != nil {

--- a/backend/machines.go
+++ b/backend/machines.go
@@ -489,6 +489,7 @@ func (n *Machine) Validate() {
 				}
 			case "action":
 				continue
+			case "chroot":
 			default:
 				n.Errorf("%s (at %d) is malformed", ent, i)
 			}

--- a/frontend/job_create.go
+++ b/frontend/job_create.go
@@ -283,6 +283,9 @@ func realCreateJob(f *Frontend,
 		// change to the machine because it is already in the target stage
 		// or bootenv.
 		switch st[0] {
+		case "chroot":
+			logMsg = fmt.Sprintf("Machine %s agent is being signalled to chroot to %s and continue",
+				b.Machine.String(), st[1])
 		case "stage":
 			if m.Stage == st[1] {
 				continue

--- a/models/machine.go
+++ b/models/machine.go
@@ -156,6 +156,7 @@ func (n *Machine) Validate() {
 				n.AddError(ValidName("Invalid Stage", parts[1]))
 			case "bootenv":
 				n.AddError(ValidName("Invalid BootEnv", parts[1]))
+			case "chroot":
 			case "action":
 				pparts := strings.SplitN(parts[1], ":", 2)
 				if len(pparts) == 2 {


### PR DESCRIPTION
In task lists, you can now have an entry of the format
"chroot:/path/to/root".  This will instruct the runner to expand all
templates and run all future tasks as of they were running in a
chrooted environment at "/path/to/root" until either:

* Another "chroot:/path/to/other-root" entry appears in the task list.

* The runner runs out of things to do.

* A task exits with the "exit" flag, which will negate any chroot and
  continue processing tasks outside the chroot.