### PR TITLE
Fix render template error messages.

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -551,10 +551,12 @@ func (j *Job) RenderActions(rt *RequestTracker) ([]*models.JobAction, error) {
 	for _, r := range rds {
 		rr, err1 := r.write(addr)
 		if err1 != nil {
+			err.Code = http.StatusUnprocessableEntity
 			err.AddError(err1)
 		} else {
 			b, err2 := ioutil.ReadAll(rr)
 			if err2 != nil {
+				err.Code = http.StatusUnprocessableEntity
 				err.AddError(err2)
 			} else {
 				na := &models.JobAction{Name: r.name, Path: r.path, Content: string(b)}

--- a/frontend/jobs.go
+++ b/frontend/jobs.go
@@ -634,6 +634,7 @@ func (f *Frontend) InitJobApi() {
 				} else {
 					c.JSON(http.StatusBadRequest, models.NewError(c.Request.Method, http.StatusBadRequest, err.Error()))
 				}
+				return
 			}
 			c.JSON(http.StatusOK, actions)
 


### PR DESCRIPTION
Instead of:

Starting task fake-deploy:start:task1 on drp-000019.unspecified.domain.local
Failed to render actions: CLIENT_ERROR: json: cannot unmarshal object into Go value of type []*models.JobAction
Updated job for fake-deploy:start:task1 to incomplete

Now get:

Starting task fake-deploy:start:task1 on drp-000019.unspecified.domain.local
Failed to render actions: : template: :3:16: executing "task1" at <.Machine.Fred>: can't evaluate field Fred in type *backend.rMachine
Updated job for fake-deploy:start:task1 to incomplete