### PR TITLE
WIP Apple BSDP protocol support

### DIFF
--- a/backend/bootenv.go
+++ b/backend/bootenv.go
@@ -130,7 +130,7 @@ func (b *BootEnv) Backend() store.Store {
 	return b.rt.backend(b)
 }
 
-func (b *BootEnv) pathFor(f string) string {
+func (b *BootEnv) PathFor(f string) string {
 	res := b.OS.Name
 	if strings.HasSuffix(b.Name, "-install") {
 		res = path.Join(res, "install")
@@ -175,12 +175,12 @@ func (b *BootEnv) fillInstallRepo() {
 		b.rt.Infof("BootEnv %s: Using repo %s as an install source", b.Name, r.Tag)
 		b.kernelVerified = true
 		b.installRepo = r
-		pf := b.pathFor("")
+		pf := b.PathFor("")
 		fileRoot := b.rt.dt.FileRoot
 		l := b.rt.Logger
 		b.pathLookaside = func(p string) (io.Reader, error) {
 			// Always use local copy if available
-			if _, err := os.Stat(path.Join(fileRoot, b.pathFor(""))); err == nil || b.installRepo == nil {
+			if _, err := os.Stat(path.Join(fileRoot, b.PathFor(""))); err == nil || b.installRepo == nil {
 				return nil, nil
 			}
 			tgtUri := strings.TrimSuffix(b.installRepo.URL, "/") + strings.TrimPrefix(p, pf)
@@ -212,12 +212,12 @@ func (b *BootEnv) fillInstallRepo() {
 
 func (b *BootEnv) AddDynamicTree() {
 	if b.pathLookaside != nil {
-		b.rt.dt.FS.AddDynamicTree(b.pathFor(""), b.pathLookaside)
+		b.rt.dt.FS.AddDynamicTree(b.PathFor(""), b.pathLookaside)
 	}
 }
 
 func (b *BootEnv) localPathFor(f string) string {
-	return path.Join(b.rt.dt.FileRoot, b.pathFor(f))
+	return path.Join(b.rt.dt.FileRoot, b.PathFor(f))
 }
 
 func (b *BootEnv) genRoot(commonRoot *template.Template, e models.ErrorAdder) *template.Template {
@@ -512,7 +512,7 @@ func (b *BootEnv) AfterDelete() {
 			index.Sort(b.Indexes()["OsName"]),
 			index.Eq(b.OS.Name))(&(b.rt.stores("bootenvs").Index))
 		if idxerr == nil && idx.Count() == 0 {
-			b.rt.dt.FS.DelDynamicTree(b.pathFor(""))
+			b.rt.dt.FS.DelDynamicTree(b.PathFor(""))
 		}
 	}
 }

--- a/backend/bootenv.go
+++ b/backend/bootenv.go
@@ -367,7 +367,7 @@ func (b *BootEnv) Validate() {
 			seenIPXE = true
 		}
 	}
-	if !(seenPxeLinux || seenIPXE) && b.Kernel != "" {
+	if !(seenPxeLinux || seenIPXE) && b.Kernel != "" && b.Meta["KernelIsLoader"] != "true" {
 		b.Errorf("bootenv: Missing elilo or pxelinux template")
 	}
 	// Make sure the ISO for this bootenv has been exploded locally so that

--- a/backend/renderData.go
+++ b/backend/renderData.go
@@ -197,7 +197,7 @@ type rBootEnv struct {
 //    tftp: Will expand to the path the file can be accessed at via TFTP.
 //    disk: Will expand to the path of the file inside the provisioner container.
 func (b *rBootEnv) PathFor(proto, f string) string {
-	tail := b.pathFor(f)
+	tail := b.BootEnv.PathFor(f)
 	switch proto {
 	case "tftp":
 		return strings.TrimPrefix(tail, "/")

--- a/cli/appleNBI.go
+++ b/cli/appleNBI.go
@@ -1,0 +1,124 @@
+package cli
+
+import (
+	"archive/tar"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+
+	"github.com/digitalrebar/provision/api"
+	"github.com/digitalrebar/provision/models"
+	"github.com/groob/plist"
+	gzip "github.com/klauspost/pgzip"
+	"github.com/spf13/cobra"
+)
+
+// Args will have been validated by the time this gets called.
+// args[0] will have a valid path that contains an
+// NBImageInfo.plist file.
+func genEnvAndArchiveFromAppleNBI(c *cobra.Command, args []string) error {
+	pListFile := path.Join(args[0], "NBImageInfo.plist")
+	info, err := os.Open(pListFile)
+	if err != nil {
+		return err
+	}
+	defer info.Close()
+	bsdpInfo := &models.BsdpBootOption{}
+	dec := plist.NewXMLDecoder(info)
+	if err := dec.Decode(bsdpInfo); err != nil {
+		return err
+	}
+	env := &models.BootEnv{}
+	env.Fill()
+	osName := bsdpInfo.OSName() + "-" +
+		bsdpInfo.OSVersion + "-" +
+		bsdpInfo.InstallType()
+	env.Name = osName + "-install"
+	env.OS.Name = osName
+	if _, err := os.Stat(path.Join(args[0], "i386", bsdpInfo.Booter)); err != nil {
+		return fmt.Errorf("NBI missing Booter i386/%s: %v", bsdpInfo.Booter, err)
+	}
+	if _, err := os.Stat(path.Join(args[0], bsdpInfo.RootPath)); err != nil {
+		return fmt.Errorf("NBI missing RootPath %s: %v", bsdpInfo.RootPath, err)
+	}
+	env.Kernel = path.Join("i386", bsdpInfo.Booter)
+	env.OS.IsoFile = osName + ".tar.gz"
+	env.Meta["AppleBsdp"] = bsdpInfo.String()
+	env.Meta["KernelIsLoader"] = "true"
+	log.Printf("Creating bootenv archive %s.tar.gz (this may take awhile)", osName)
+	outArchive, err := os.Create(osName + ".tar.gz")
+	if err != nil {
+		return fmt.Errorf("Error creating new archive %s.tar.gz: %v", osName, err)
+	}
+	defer outArchive.Close()
+	gzWrite, err := gzip.NewWriterLevel(outArchive, gzip.BestCompression)
+	if err != nil {
+		return fmt.Errorf("Error creating gzip Writer: %v", err)
+	}
+	defer gzWrite.Close()
+	gzWrite.SetConcurrency(1<<20, runtime.NumCPU()*2)
+	tarWrite := tar.NewWriter(gzWrite)
+	defer tarWrite.Close()
+	err = filepath.Walk(args[0], func(item string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		header, err := tar.FileInfoHeader(info, item)
+		if err != nil {
+			return err
+		}
+		if header.Typeflag == tar.TypeSymlink {
+			header.Linkname, _ = os.Readlink(item)
+			if !filepath.IsAbs(header.Linkname) {
+				header.Linkname = path.Join(path.Dir(item), header.Linkname)
+			}
+			header.Linkname, err = filepath.Rel(path.Dir(item), header.Linkname)
+			if err != nil {
+				return err
+			}
+		}
+		header.Name, err = filepath.Rel(args[0], item)
+		if err != nil {
+			return err
+		}
+		if header.Name == "" || header.Name == "." {
+			return nil
+		}
+		if err := tarWrite.WriteHeader(header); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+		f, err := os.Open(item)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+		if _, err := io.Copy(tarWrite, f); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("Error creating drp boot archive: %v", err)
+	}
+	log.Printf("Creating bootenv %s.yaml", osName)
+	outEnv, err := os.Create(osName + ".yaml")
+	if err != nil {
+		return fmt.Errorf("Errorf creating %s.yaml: %v", osName, err)
+	}
+	defer outEnv.Close()
+	buf, err := api.Pretty("yaml", env)
+	if err != nil {
+		return fmt.Errorf("Error marshalling new BootEnv: %v", err)
+	}
+	if _, err := outEnv.Write(buf); err != nil {
+		return fmt.Errorf("Error writing new BootEnv: %v", err)
+	}
+	return nil
+}

--- a/cli/bootenv.go
+++ b/cli/bootenv.go
@@ -111,5 +111,33 @@ It will attempt to perform a direct copy without saving the ISO locally.`,
 			}
 		},
 	})
+	op.addCommand(&cobra.Command{
+		Use:   "fromAppleNBI [path]",
+		Short: "This will attempt to translate an Apple .nbi directory into a bootenv and an archive.",
+		Long: `This command translates an Apple .nbi directory into a bootenv .yaml file
+that contains apropriate metadata to be handled by the dr-provision NBSP DHCP
+handler, and a .tar.gz file that contains the contents of the .nbi directory.
+
+The .nbi directory must have been produced by the Apple System Image Utility
+or equivalent tooling, and must contain a valid NBImageInfo.plist file.
+The .yaml file containig the bootenv will be named <os>-<version>.yaml,
+and the .tar.gz file will contain the contents of the .nbi directory.
+
+Both created files will be left in the current working directory.`,
+		Args: func(c *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("%v requires 1 argument", c.UseLine())
+			}
+			sb, err := os.Stat(path.Join(args[0], "NBImageInfo.plist"))
+			if err != nil {
+				return fmt.Errorf("Cannot find NBImageInfo.plist in %s: %v", args[0], err)
+			}
+			if !sb.Mode().IsRegular() {
+				return fmt.Errorf("%s is not a normal file", path.Join(args[0], "NBImageInfo.plist"))
+			}
+			return nil
+		},
+		RunE: genEnvAndArchiveFromAppleNBI,
+	})
 	op.command(app)
 }

--- a/cli/test-data/output/TestBootEnvCli/bootenvs.install.bootenvs/fredhammer.yml.3/stderr.expect
+++ b/cli/test-data/output/TestBootEnvCli/bootenvs.install.bootenvs/fredhammer.yml.3/stderr.expect
@@ -1,1 +1,1 @@
-Error: CLIENT_ERROR: bootenvs: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.BootEnv
+Error: CLIENT_ERROR: bootenvs: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type models.BootEnv

--- a/cli/test-data/output/TestBootEnvCli/bootenvs.update.john.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestBootEnvCli/bootenvs.update.john.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed bootenvs:john object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed bootenvs:john object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestBootEnvCli/bootenvs/stdout.expect
+++ b/cli/test-data/output/TestBootEnvCli/bootenvs/stdout.expect
@@ -4,20 +4,21 @@ Usage:
   drpcli bootenvs [command]
 
 Available Commands:
-  action      Display the action for this bootenv
-  actions     Display actions for this bootenv
-  create      Create a new bootenv with the passed-in JSON or string key
-  destroy     Destroy bootenv by id
-  exists      See if a bootenvs exists by id
-  indexes     Get indexes for bootenvs
-  install     Install a bootenv along with everything it requires
-  list        List all bootenvs
-  meta        Gets metadata for the bootenv
-  runaction   Run action on object from plugin
-  show        Show a single bootenvs by id
-  update      Unsafely update bootenv by id with the passed-in JSON
-  uploadiso   This will attempt to upload the ISO from the specified ISO URL.
-  wait        Wait for a bootenv's field to become a value within a number of seconds
+  action       Display the action for this bootenv
+  actions      Display actions for this bootenv
+  create       Create a new bootenv with the passed-in JSON or string key
+  destroy      Destroy bootenv by id
+  exists       See if a bootenvs exists by id
+  fromAppleNBI This will attempt to translate an Apple .nbi directory into a bootenv and an archive.
+  indexes      Get indexes for bootenvs
+  install      Install a bootenv along with everything it requires
+  list         List all bootenvs
+  meta         Gets metadata for the bootenv
+  runaction    Run action on object from plugin
+  show         Show a single bootenvs by id
+  update       Unsafely update bootenv by id with the passed-in JSON
+  uploadiso    This will attempt to upload the ISO from the specified ISO URL.
+  wait         Wait for a bootenv's field to become a value within a number of seconds
 
 Flags:
   -h, --help   help for bootenvs

--- a/cli/test-data/output/TestContentCli/contents.create.348f85563278f65434960e4c279ccb57/stderr.expect
+++ b/cli/test-data/output/TestContentCli/contents.create.348f85563278f65434960e4c279ccb57/stderr.expect
@@ -1,1 +1,1 @@
-Error: Error parsing layer: error unmarshaling JSON: json: cannot unmarshal array into Go value of type models.Content
+Error: Error parsing layer: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type models.Content

--- a/cli/test-data/output/TestContentCli/contents.update.john.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestContentCli/contents.update.john.asdgasdg/stderr.expect
@@ -1,1 +1,1 @@
-Error: Error parsing layer: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.Content
+Error: Error parsing layer: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type models.Content

--- a/cli/test-data/output/TestContentsFunctionalCli/contents.create.caec0e7d1b4b772a78e6dece471da19b/stderr.expect
+++ b/cli/test-data/output/TestContentsFunctionalCli/contents.create.caec0e7d1b4b772a78e6dece471da19b/stderr.expect
@@ -1,1 +1,1 @@
-Error: Failed to load backing objects from cache: Unable to load profiles: error unmarshaling JSON: json: cannot unmarshal number into Go struct field Profile.Params of type map[string]interface {}
+Error: Failed to load backing objects from cache: Unable to load profiles: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go struct field Profile.Params of type map[string]interface {}

--- a/cli/test-data/output/TestContentsFunctionalCli/contents.update.Pack1.7e2795c1d3dd2c0dfc2149a79191333b/stderr.expect
+++ b/cli/test-data/output/TestContentsFunctionalCli/contents.update.Pack1.7e2795c1d3dd2c0dfc2149a79191333b/stderr.expect
@@ -1,3 +1,3 @@
 Error: PUT: contents/Pack1
-  Unable to load profiles: error unmarshaling JSON: json: cannot unmarshal number into Go struct field Profile.Params of type map[string]interface {}
+  Unable to load profiles: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal number into Go struct field Profile.Params of type map[string]interface {}
   Profile p1-prof (at 0) does not exist

--- a/cli/test-data/output/TestEventsCli/events.post.dquotee1dquote/stderr.expect
+++ b/cli/test-data/output/TestEventsCli/events.post.dquotee1dquote/stderr.expect
@@ -1,2 +1,2 @@
-Error: Invalid event: error unmarshaling JSON: json: cannot unmarshal string into Go value of type models.Event
+Error: Invalid event: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type models.Event
 

--- a/cli/test-data/output/TestJobCli/jobs.update.00000000-0000-0000-0000-000000000001.2613e56daa4b9dcd02c9e93badc4aa5b/stderr.expect
+++ b/cli/test-data/output/TestJobCli/jobs.update.00000000-0000-0000-0000-000000000001.2613e56daa4b9dcd02c9e93badc4aa5b/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed jobs:00000000-0000-0000-0000-000000000001 object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal array into Go value of type map[string]interface {}
+Error: Failed to generate changed jobs:00000000-0000-0000-0000-000000000001 object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal array into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestMachineCli/machines.runaction.3e7031fe-3062-45f1-835c-92541bc9cbd3.increment.576c47cb28f5c9217182dd4ccc70e8a2/stderr.expect
+++ b/cli/test-data/output/TestMachineCli/machines.runaction.3e7031fe-3062-45f1-835c-92541bc9cbd3.increment.576c47cb28f5c9217182dd4ccc70e8a2/stderr.expect
@@ -1,4 +1,4 @@
-Error: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 Usage:
   drpcli machines runaction [id] [command] [- | JSON or YAML Map of objects | pairs of string objects] [flags]
 

--- a/cli/test-data/output/TestMachineCli/machines.runaction.3e7031fe-3062-45f1-835c-92541bc9cbd3.increment.fred/stderr.expect
+++ b/cli/test-data/output/TestMachineCli/machines.runaction.3e7031fe-3062-45f1-835c-92541bc9cbd3.increment.fred/stderr.expect
@@ -1,4 +1,4 @@
-Error: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 Usage:
   drpcli machines runaction [id] [command] [- | JSON or YAML Map of objects | pairs of string objects] [flags]
 

--- a/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestMachineCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed machines:3e7031fe-3062-45f1-835c-92541bc9cbd3 object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed machines:3e7031fe-3062-45f1-835c-92541bc9cbd3 object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestParamCli/params.update.john.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestParamCli/params.update.john.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed params:john object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed params:john object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestPluginCli/plugins.update.i-woman.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestPluginCli/plugins.update.i-woman.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed plugins:i-woman object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed plugins:i-woman object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestPrefsCli/prefs.set.dedc382c32100c7b987f2098da769fe4/stderr.expect
+++ b/cli/test-data/output/TestPrefsCli/prefs.set.dedc382c32100c7b987f2098da769fe4/stderr.expect
@@ -1,4 +1,4 @@
-Error: Invalid prefs: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]string
+Error: Invalid prefs: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]string
 
 Usage:
   drpcli prefs set [- | JSON or YAML Map of strings | pairs of string args] [flags]

--- a/cli/test-data/output/TestPrefsCli/prefs.set.john/stderr.expect
+++ b/cli/test-data/output/TestPrefsCli/prefs.set.john/stderr.expect
@@ -1,4 +1,4 @@
-Error: Invalid prefs: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]string
+Error: Invalid prefs: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]string
 
 Usage:
   drpcli prefs set [- | JSON or YAML Map of strings | pairs of string args] [flags]

--- a/cli/test-data/output/TestProfileCli/profiles.update.john.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestProfileCli/profiles.update.john.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed profiles:john object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed profiles:john object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestReservationCli/reservations.update.192.168.100.100.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestReservationCli/reservations.update.192.168.100.100.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed reservations:192.168.100.100 object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed reservations:192.168.100.100 object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestStageCli/stages.update.john.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestStageCli/stages.update.john.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed stages:john object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed stages:john object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestSubnetCli/subnets.update.john.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestSubnetCli/subnets.update.john.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed subnets:john object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed subnets:john object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestTaskCli/tasks.update.john.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestTaskCli/tasks.update.john.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed tasks:john object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed tasks:john object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestTemplateCli/templates.update.john.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestTemplateCli/templates.update.john.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed templates:john object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed templates:john object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/cli/test-data/output/TestUserCli/users.update.john.asdgasdg/stderr.expect
+++ b/cli/test-data/output/TestUserCli/users.update.john.asdgasdg/stderr.expect
@@ -1,2 +1,2 @@
-Error: Failed to generate changed users:john object: Unable to unmarshal reference object: error unmarshaling JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
+Error: Failed to generate changed users:john object: Unable to unmarshal reference object: error unmarshaling JSON: while decoding JSON: json: cannot unmarshal string into Go value of type map[string]interface {}
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 26e1fa1043f1e952e09a9043e3b82a48680bdc78ee7e8c0e907d1a3380590152
-updated: 2018-08-02T16:51:44.649917-05:00
+hash: fead7446b0d4bb4471f9882d64cb70a7ebf194bf35f5a942d3f1047431ffcf2a
+updated: 2018-08-03T09:20:24.668457024-05:00
 imports:
 - name: github.com/aokoli/goutils
   version: 3391d3790d23d03408670993e957e8f408993c34
@@ -55,11 +55,11 @@ imports:
   - json
   - render
 - name: github.com/golang/protobuf
-  version: 560bdb64431cc123098c2db67f16053a923a0688
+  version: f5983d50c82d70eaa88c17080245cc871558081f
   subpackages:
   - proto
 - name: github.com/google/certificate-transparency-go
-  version: 95d2963cb3a78dbb9ad900f5025b192ecaa4bebb
+  version: 3d9ebf85105f5bf34dc43cc6d821475356aa1645
   subpackages:
   - asn1
   - tls
@@ -72,7 +72,7 @@ imports:
 - name: github.com/groob/plist
   version: dd56909aee38bb3860460e3e1ca8a4270c04ce15
 - name: github.com/hashicorp/consul
-  version: ec755b4ba7cdbee391b51750238250948774e741
+  version: 0a25e11aa8268d11aa26ae8c908c308f88024487
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
@@ -100,7 +100,7 @@ imports:
 - name: github.com/json-iterator/go
   version: 10a568c51178f31e41456cedaac7838e0f4f7360
 - name: github.com/klauspost/compress
-  version: b939724e787a27c0005cabe3f78e7ed7987ac74f
+  version: b50017755d442260d792c34c7c43216d9ba7ffc7
   subpackages:
   - flate
 - name: github.com/klauspost/cpuid
@@ -110,7 +110,7 @@ imports:
 - name: github.com/klauspost/pgzip
   version: c4ad2ed77aece7b3270909769a30a3fcea262a66
 - name: github.com/krolaw/dhcp4
-  version: 4abfceffa76a675ea43d133e49aad64c821d32bf
+  version: 054a8f9eea918b9693b7b24ab027788e5a6182da
   subpackages:
   - conn
 - name: github.com/Masterminds/semver
@@ -124,7 +124,7 @@ imports:
   subpackages:
   - pbutil
 - name: github.com/mitchellh/go-homedir
-  version: 3864e76763d94a6df2f9960b16a20a33da9f9a66
+  version: 58046073cbffe2f25d425fe1331102f55cf719de
 - name: github.com/mitchellh/mapstructure
   version: f15292f7a699fcc1a38a80977f80a046874ba8ac
 - name: github.com/modern-go/concurrent
@@ -148,7 +148,7 @@ imports:
   subpackages:
   - go
 - name: github.com/prometheus/common
-  version: 7600349dcfe1abd18d72d3a1770870d9800a7801
+  version: c7de2306084e37d54b8be01f3541a8464345e9a5
   subpackages:
   - expfmt
   - internal/bitbucket.org/ww/goautoneg
@@ -199,7 +199,7 @@ imports:
 - name: github.com/xeipuuv/gojsonschema
   version: b84684d0e066369f2a7a8a525f3080909ed4ea6b
 - name: golang.org/x/crypto
-  version: c126467f60eb25f8f27e5a981f32a87e3965053f
+  version: 56440b844dfe139a8ac053f4ecac0b20b79058f4
   subpackages:
   - cryptobyte
   - cryptobyte/asn1
@@ -220,7 +220,7 @@ imports:
   - scrypt
   - sign
 - name: golang.org/x/net
-  version: 49c15d80dfbc983ea25246ee959d970efe09ec09
+  version: f4c29de78a2a91c00474a2e689954305c350adf9
   subpackages:
   - bpf
   - context
@@ -231,11 +231,11 @@ imports:
   - ipv6
   - route
 - name: golang.org/x/sys
-  version: bd9dbc187b6e1dacfdd2722a87e83093c2d7bd6e
+  version: 0ffbfd41fbef8ffcf9b62b0b0aa3a5873ed7a4fe
   subpackages:
   - unix
 - name: golang.org/x/tools
-  version: 33176b2029f9538e722efa4a005f7aa00cf60010
+  version: 82515cf89538b3e8a206be74377c01dee420b76d
   subpackages:
   - cover
 - name: gopkg.in/go-playground/validator.v8

--- a/glide.lock
+++ b/glide.lock
@@ -67,6 +67,8 @@ imports:
   version: dec09d789f3dba190787f8b4454c7d3c936fed9e
 - name: github.com/gorilla/websocket
   version: a69d9f6de432e2c6b296a947d8a5ee88f68522cf
+- name: github.com/groob/plist
+  version: dd56909aee38bb3860460e3e1ca8a4270c04ce15
 - name: github.com/hashicorp/consul
   version: a0b974620c29ec9372fa0583b4f1d0f0315062c8
   subpackages:

--- a/glide.lock
+++ b/glide.lock
@@ -3,14 +3,16 @@ updated: 2018-08-02T16:51:44.649917-05:00
 imports:
 - name: github.com/aokoli/goutils
   version: 3391d3790d23d03408670993e957e8f408993c34
+- name: github.com/armon/go-metrics
+  version: 3c58d8115a78a6879e5df75ae900846768d36895
 - name: github.com/beorn7/perks
   version: 3a771d992973f24aa725d07868b467d1ddfceafb
   subpackages:
   - quantile
 - name: github.com/boltdb/bolt
-  version: 2f1ce7a837dcb8da3ec595b1dac9d0632f0f99e8
+  version: fd01fc79c553a8e99d512a07e8e0c63d4a3ccfc5
 - name: github.com/cloudflare/cfssl
-  version: 1e95aeec7a46dc043d099d6fb887a31cdb0a5999
+  version: 80d5f5b4cfe73f5a918b851f03d468eb28499131
   subpackages:
   - crypto/pkcs7
   - csr
@@ -19,11 +21,11 @@ imports:
   - helpers/derhelpers
   - log
 - name: github.com/cpuguy83/go-md2man
-  version: 48d8747a2ca13185e7cc8efe6e9fc196a83f71a5
+  version: 691ee98543af2f262f35fbb54bdd42f00b9b9cc5
   subpackages:
   - md2man
 - name: github.com/dgrijalva/jwt-go
-  version: a539ee1a749a2b895533f979515ac7e6e0f5b650
+  version: 0b96aaa707760d6ab28d9b9d1913ff5993328bae
 - name: github.com/digitalrebar/logger
   version: b457bcdb411872e1b719c8d9e1bf3cd669e480ee
 - name: github.com/digitalrebar/pinger
@@ -31,33 +33,33 @@ imports:
 - name: github.com/digitalrebar/store
   version: 99f93481f3bc95a3fdbcd028778c0ddc9d826932
 - name: github.com/elazarl/go-bindata-assetfs
-  version: 30f82fa23fd844bd5bb1e5f216db87fd77b5eb43
+  version: 38087fe4dafb822e541b3f7955075cc1c30bd294
 - name: github.com/elithrar/simple-scrypt
-  version: 2325946f714c95de4a6088202c402fbdfa64163b
+  version: 28a8a89db0e1201d1b61b8ee90597fd7d035c0d5
 - name: github.com/fsnotify/fsnotify
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
 - name: github.com/ghodss/yaml
-  version: 0ca9ea5df5451ffdf184b4428c902747c2c11cd7
+  version: e9ed3c6dfb39bb1a32197cb10d527906fe4da4b6
 - name: github.com/gin-contrib/cors
-  version: 88488351b0df049b2d3d65cab583c6bed894abb2
+  version: 6f0a820f94bea07359ec77c26855ca8cf6762739
 - name: github.com/gin-contrib/gzip
   version: 4fbfcc6122759afed2efbc762c4c41164a403951
 - name: github.com/gin-contrib/location
-  version: 3e26b9c1187f298ae3669e41d1b696d256113f66
+  version: 911ef8299476b8a48e11ec0c26f2a0810345b690
 - name: github.com/gin-contrib/sse
   version: 22d885f9ecc78bf4ee5d72b937e4bbcdc58e8cae
 - name: github.com/gin-gonic/gin
-  version: 8902826696c1dad024e1c8ba4f903aa61a25c839
+  version: 220e8d34538f5dfdcc299dda79bf83cf52e633f6
   subpackages:
   - binding
   - json
   - render
 - name: github.com/golang/protobuf
-  version: ab9f9a6dab164b7d1246e0e688b0ab7b94d8553e
+  version: 560bdb64431cc123098c2db67f16053a923a0688
   subpackages:
   - proto
 - name: github.com/google/certificate-transparency-go
-  version: 7c2badeed51ed57d7316a12fb96b2aa372ad9242
+  version: 95d2963cb3a78dbb9ad900f5025b192ecaa4bebb
   subpackages:
   - asn1
   - tls
@@ -66,19 +68,25 @@ imports:
 - name: github.com/google/uuid
   version: dec09d789f3dba190787f8b4454c7d3c936fed9e
 - name: github.com/gorilla/websocket
-  version: a69d9f6de432e2c6b296a947d8a5ee88f68522cf
+  version: 5ed622c449da6d44c3c8329331ff47a9e5844f71
 - name: github.com/groob/plist
   version: dd56909aee38bb3860460e3e1ca8a4270c04ce15
 - name: github.com/hashicorp/consul
-  version: a0b974620c29ec9372fa0583b4f1d0f0315062c8
+  version: ec755b4ba7cdbee391b51750238250948774e741
   subpackages:
   - api
 - name: github.com/hashicorp/go-cleanhttp
-  version: 3573b8b52aa7b37b9358d966a898feb387f62437
+  version: d5fe4b57a186c716b0e00b8c301cbd9b4182694d
+- name: github.com/hashicorp/go-immutable-radix
+  version: 7f3cd4390caab3250a57f30efdb2a65dd7649ecf
 - name: github.com/hashicorp/go-rootcerts
   version: 6bb64b370b90e7ef1fa532be9e591a81c3493e00
+- name: github.com/hashicorp/golang-lru
+  version: 0fb14efe8c47ae851c0034ed7a448854d3d34cf3
+  subpackages:
+  - simplelru
 - name: github.com/hashicorp/serf
-  version: b84a66cc5575994cb672940d244a2404141688c0
+  version: 984a73625de3138f44deb38d00878fab39eb6447
   subpackages:
   - coordinate
 - name: github.com/huandu/xstrings
@@ -88,11 +96,21 @@ imports:
 - name: github.com/inconshreveable/mousetrap
   version: 76626ae9c91c4f2a10f34cad8ce83ea42c93bb75
 - name: github.com/jessevdk/go-flags
-  version: 6cf8f02b4ae8ba723ddc64dcfd403e530c06d927
+  version: 1c38ed7ad0cc3d9e66649ac398c30e45f395c4eb
 - name: github.com/json-iterator/go
-  version: 2dc0031b26575ddf5dab09ab7795105a05575473
+  version: 10a568c51178f31e41456cedaac7838e0f4f7360
+- name: github.com/klauspost/compress
+  version: b939724e787a27c0005cabe3f78e7ed7987ac74f
+  subpackages:
+  - flate
+- name: github.com/klauspost/cpuid
+  version: e7e905edc00ea8827e58662220139109efea09db
+- name: github.com/klauspost/crc32
+  version: bab58d77464aa9cf4e84200c3276da0831fe0c03
+- name: github.com/klauspost/pgzip
+  version: c4ad2ed77aece7b3270909769a30a3fcea262a66
 - name: github.com/krolaw/dhcp4
-  version: 4de04cc59d6e4223583ec8117238e4d57e8b176d
+  version: 4abfceffa76a675ea43d133e49aad64c821d32bf
   subpackages:
   - conn
 - name: github.com/Masterminds/semver
@@ -100,27 +118,33 @@ imports:
 - name: github.com/Masterminds/sprig
   version: 77bb58b7f5e10889a1195c21b9e7a96ee166f199
 - name: github.com/mattn/go-isatty
-  version: fc9e8d8ef48496124e79ae0df75490096eccf6fe
+  version: 6ca4dbf54d38eea1a992b3c722a76a5d1c4cb25c
 - name: github.com/matttproud/golang_protobuf_extensions
   version: c12348ce28de40eed0136aa2b644d0ee0650e56c
   subpackages:
   - pbutil
 - name: github.com/mitchellh/go-homedir
-  version: b8bc1bf767474819792c23f32d8286a45736f1c6
+  version: 3864e76763d94a6df2f9960b16a20a33da9f9a66
+- name: github.com/mitchellh/mapstructure
+  version: f15292f7a699fcc1a38a80977f80a046874ba8ac
+- name: github.com/modern-go/concurrent
+  version: bacd9c7ef1dd9b15be4a9909b8ac7a4e313eec94
+- name: github.com/modern-go/reflect2
+  version: 94122c33edd36123c84d5368cfb2b69df93a0ec8
 - name: github.com/pborman/uuid
-  version: e790cca94e6cc75c7064b1332e63811d4aae1a53
+  version: c65b2f87fee37d1c7854c9164a450713c28d50cd
 - name: github.com/pin/tftp
   version: d715325c1fc1f1a22a8272a60dc6783a5ab093ba
   subpackages:
   - netascii
 - name: github.com/prometheus/client_golang
-  version: faf4ec335fe01ae5a6a0eaa34a5a9333bfbd1a30
+  version: bcbbc08eb2ddff3af83bbf11e7ec13b4fd730b6e
   subpackages:
   - prometheus
   - prometheus/promhttp
   - promhttp
 - name: github.com/prometheus/client_model
-  version: 99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c
+  version: 5c3871d89910bfb32f5fcab2aa4b9ec68e65a99f
   subpackages:
   - go
 - name: github.com/prometheus/common
@@ -130,7 +154,7 @@ imports:
   - internal/bitbucket.org/ww/goautoneg
   - model
 - name: github.com/prometheus/procfs
-  version: 7d6f385de8bea29190f15ba9931442a0eaef9af7
+  version: 05ee40e3a273f7245e8777337fc7b46e533a9a92
   subpackages:
   - internal/util
   - nfs
@@ -145,15 +169,15 @@ imports:
 - name: github.com/russross/blackfriday
   version: 11635eb403ff09dbc3a6b5a007ab5ab09151c229
 - name: github.com/spf13/cobra
-  version: ef82de70bb3f60c65fb8eebacbb2d122ef517385
+  version: 7c4570c3ebeb8129a1f7456d0908a8b676b6f9f1
   subpackages:
   - doc
 - name: github.com/spf13/pflag
-  version: 583c0c0531f06d5278b7d917446061adc344b5cd
+  version: 3ebe029320b2676d667ae88da602a5f854788a8a
 - name: github.com/tylerb/graceful
   version: d72b0151351a13d0421b763b88f791469c4f5dc7
 - name: github.com/ugorji/go
-  version: 8c0409fcbb70099c748d71f714529204975f6c3f
+  version: 0e8ffdb13c81bdb48fa80a963cf83f10a0f5a496
   subpackages:
   - codec
 - name: github.com/VictorLowther/godmi
@@ -163,19 +187,19 @@ imports:
   subpackages:
   - utils
 - name: github.com/vishvananda/netlink
-  version: f67b75edbf5e3bb7dfe70bb788610693a71be3d1
+  version: 9eab41933428cf408de91867a0719b5aa8686efa
   subpackages:
   - nl
 - name: github.com/vishvananda/netns
-  version: be1fbeda19366dea804f00efff2dd73a1642fdcc
+  version: 13995c7128ccc8e51e9a6bd2b551020a27180abd
 - name: github.com/xeipuuv/gojsonpointer
-  version: 6fe8760cad3569743d51ddbb243b26f8456742dc
+  version: 4e3ac2762d5f479393488629ee9370b50873b3a6
 - name: github.com/xeipuuv/gojsonreference
-  version: e02fc20de94c78484cd5ffb007f8af96be030a45
+  version: bd5ef7bd5415a7ac448318e64f11a24cd21e594b
 - name: github.com/xeipuuv/gojsonschema
-  version: 0c8571ac0ce161a5feb57375a9cdf148c98c0f70
+  version: b84684d0e066369f2a7a8a525f3080909ed4ea6b
 - name: golang.org/x/crypto
-  version: a49355c7e3f8fe157a85be2f77e6e269a0f89602
+  version: c126467f60eb25f8f27e5a981f32a87e3965053f
   subpackages:
   - cryptobyte
   - cryptobyte/asn1
@@ -196,7 +220,7 @@ imports:
   - scrypt
   - sign
 - name: golang.org/x/net
-  version: 66aacef3dd8a676686c7ae3716979581e8b03c47
+  version: 49c15d80dfbc983ea25246ee959d970efe09ec09
   subpackages:
   - bpf
   - context
@@ -207,11 +231,11 @@ imports:
   - ipv6
   - route
 - name: golang.org/x/sys
-  version: 2d6f6f883a06fc0d5f4b14a81e4c28705ea64c15
+  version: bd9dbc187b6e1dacfdd2722a87e83093c2d7bd6e
   subpackages:
   - unix
 - name: golang.org/x/tools
-  version: 48418e5732e1b1e2a10207c8007a5f959e422f20
+  version: 33176b2029f9538e722efa4a005f7aa00cf60010
   subpackages:
   - cover
 - name: gopkg.in/go-playground/validator.v8

--- a/glide.yaml
+++ b/glide.yaml
@@ -47,4 +47,6 @@ import:
 - package: github.com/prometheus/client_golang/prometheus
   subpackages:
   - promhttp
+- package: github.com/groob/plist
+- package: github.com/klauspost/pgzip
 

--- a/ipxe/build_iso.sh
+++ b/ipxe/build_iso.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+set -e
+(cd docker && docker build -t ipxebuild .)
+[ -d ipxe ] || git clone git://git.ipxe.org/ipxe.git
+# Work around a bug in building host utils in ipxe
+sed -i -e '/^HOST_CFLAGS/ s/\$(WORKAROUND_CFLAGS)//' ipxe/src/Makefile.housekeeping
+if [[ ! -f $1 ]]; then
+    echo "First argument must be the path to an .ipxe script"
+    echo "which will be embedded into the generated ISO image"
+    echo "as the default script to run."
+    exit 1
+fi
+docker run \
+       -v $PWD/ipxe:/src/ipxe:rw \
+       -v "$1:/src/embed.ipxe:ro" \
+       ipxebuild /bin/build_ipxe.sh "bios_iso"
+echo "Finished ISO is at ipxe/bin/ipxe.iso"

--- a/ipxe/docker/Dockerfile
+++ b/ipxe/docker/Dockerfile
@@ -2,8 +2,8 @@ FROM ubuntu:latest
 MAINTAINER Rackn Team <eng@rackn.com>
 ENV DEBIAN_FRONTEND noninteractive
 ENV LC_ALL=C
-RUN apt-get -y update
-RUN apt-get -y --no-install-recommends install build-essential gcc-aarch64-linux-gnu git liblzma-dev
+RUN apt-get -y update && \
+    apt-get -y --no-install-recommends install build-essential gcc-aarch64-linux-gnu git liblzma-dev genisoimage
 COPY build_ipxe.sh /bin/build_ipxe.sh
 COPY undionly /src/undionly
 COPY snponly_x86_64 /src/snponly_x86_64

--- a/ipxe/docker/build_ipxe.sh
+++ b/ipxe/docker/build_ipxe.sh
@@ -23,6 +23,19 @@ case $1 in
         make util/elf2efi64
         make CROSS_COMPILE=aarch64-linux-gnu- -s -j8 bin-arm64-efi/snponly.efi
         cp bin-arm64-efi/snponly.efi ../bin/ipxe-arm64.efi;;
+    "bios_iso")
+        if [[ ! -f /src/embed.ipxe ]]; then
+            echo "Missing /src/embed.ipxe"
+            echo "Please make sure it is mounted in the Docker container by passing the arguments:"
+            echo
+            echo "-v /path/to/your.ipxe:/src/embed.ipxe:ro"
+            echo
+            echo "as part of the Docker command line."
+            exit 1
+        fi
+        cp /src/undionly/*.h config/local/
+        make -s -j8 bin/ipxe.iso EMBED=/src/embed.ipxe
+        cp bin/ipxe.iso ../bin/ipxe.iso;;
     *)
         echo "Cannot compile ipxe for $1"
         exit 1;;

--- a/ipxe/embed_default.ipxe
+++ b/ipxe/embed_default.ipxe
@@ -1,0 +1,2 @@
+#!ipxe
+autoboot

--- a/midlayer/abp.go
+++ b/midlayer/abp.go
@@ -1,0 +1,264 @@
+package midlayer
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"strings"
+
+	dhcp "github.com/krolaw/dhcp4"
+)
+
+const (
+	bsdpOS9       = 0
+	bsdpOSX       = 1
+	bsdpOSXServer = 2
+	bsdpDiags     = 3
+	bsdpList      = 1
+	bsdpSelect    = 2
+	bsdpFail      = 3
+)
+
+type bsdpBootOption struct {
+	Install        bool
+	ImgType        byte
+	Index          uint16
+	Name           string
+	Loader, RootFS string
+}
+
+func (bo *bsdpBootOption) String() string {
+	res := []string{}
+	switch bo.Install {
+	case true:
+		res = append(res, "install")
+	case false:
+		res = append(res, "netboot")
+	}
+	switch bo.ImgType {
+	case bsdpOS9:
+		res = append(res, "os9")
+	case bsdpOSX:
+		res = append(res, "osx")
+	case bsdpOSXServer:
+		res = append(res, "osxsrv")
+	case bsdpDiags:
+		res = append(res, "diags")
+	}
+	res = append(res, fmt.Sprintf("%d", bo.Index))
+	res = append(res, bo.Name)
+	return strings.Join(res, ":")
+}
+
+func (bo *bsdpBootOption) FromOption(buf []byte) {
+	bo.Install = buf[0]&0x80 > 0
+	bo.ImgType = buf[0] | 0x7f
+	bo.Index = uint16(buf[2])<<8 + uint16(buf[3])
+	if len(buf) > 5 {
+		bo.Name = string(buf[5:])
+	}
+}
+
+func (bo *bsdpBootOption) ToID() []byte {
+	res := make([]byte, 4)
+	res[0] = bo.ImgType
+	if bo.Install {
+		res[0] += 0x80
+	}
+	res[2] = byte(bo.Index >> 8)
+	res[3] = byte(bo.Index)
+	return res
+}
+
+func (bo *bsdpBootOption) ToOption() []byte {
+	res := bo.ToID()
+	if len(bo.Name) == 0 {
+		return res
+	}
+	if len(bo.Name) < 255 {
+		res = append(res, byte(len(bo.Name)))
+		res = append(res, bo.Name[:]...)
+		return res
+	}
+	res = append(res, 255)
+	res = append(res, bo.Name[:255]...)
+	return res
+}
+
+type bsdpBootOptions []*bsdpBootOption
+
+func (bos bsdpBootOptions) ToOptions(budget int) []byte {
+	res := []byte{0x09, 0x00}
+	for i := range bos {
+		buf := bos[i].ToOption()
+		if len(buf)+len(res) > budget {
+			break
+		}
+		res = append(res, buf...)
+	}
+	res[1] = byte(len(res) - 2)
+	return res
+}
+
+func fillBsdpBootOptions(buf []byte) bsdpBootOptions {
+	res := bsdpBootOptions{}
+	for len(buf) > 4 {
+		oLen := buf[4] + 5
+		val := buf[:oLen]
+		buf = buf[oLen:]
+		bo := &bsdpBootOption{}
+		bo.FromOption(val)
+		res = append(res, bo)
+	}
+	return res
+}
+
+//option:code:43,
+type bsdpOpts struct {
+	msgtype       byte            //code 1 = uint8. 1 = LIST, 2 = SELECT, 3 = FAILED
+	version       uint16          // code 2 = uint16. Value must be 0x0101
+	srvID         net.IP          // code 3 = ip4 address, IP we respond from.
+	prio          uint16          // code = 4, uint16 , priority of the server.  Higher is higher.
+	replyPort     uint16          // code = 5, uint16, port to send reply to.  Defaults to 68.
+	defaultImage  *bsdpBootOption // code = 7, uint32, ID of the default image to boot.
+	selectedImage *bsdpBootOption // code = 8, uint32, ID of the selected image to boot.
+	imageList     bsdpBootOptions // code = 9, list of available images in the following format:
+}
+
+func (o *bsdpOpts) Parse(dhr *DhcpRequest) {
+	opts := dhr.pktOpts[43]
+	for len(opts) > 2 {
+		code := opts[0]
+		codeLen := int(opts[1])
+		if len(opts[2:]) < codeLen {
+			return
+		}
+		opts = opts[2:]
+		val := opts[:codeLen]
+		opts = opts[codeLen:]
+		switch code {
+		case 1:
+			o.msgtype = val[0]
+		case 2:
+			o.version = btouint16(val)
+		case 3:
+			o.srvID = net.IP(val)
+		case 4:
+			o.prio = btouint16(val)
+		case 5:
+			o.replyPort = btouint16(val)
+		case 7:
+			o.defaultImage = &bsdpBootOption{}
+			o.defaultImage.FromOption(val)
+		case 8:
+			o.selectedImage = &bsdpBootOption{}
+			o.selectedImage.FromOption(val)
+		case 9:
+			o.imageList = fillBsdpBootOptions(val)
+		}
+	}
+	return
+}
+
+func (o *bsdpOpts) ToOption() []byte {
+	res := []byte{}
+	if o.msgtype > 0 {
+		res = append(res, 0x01, 0x01, o.msgtype)
+	}
+	// version 1.1
+	res = append(res, 0x02, 0x02, 0x01, 0x01)
+	if len(o.srvID) > 0 {
+		res = append(res, 0x03, 0x04)
+		res = append(res, o.srvID...)
+	}
+	if o.prio > 0 {
+		res = append(res, 0x04, 0x02, byte(o.prio>>8), byte(o.prio))
+	}
+	if o.defaultImage != nil {
+		res = append(res, 0x07, 0x04)
+		res = append(res, o.defaultImage.ToID()...)
+	}
+	if o.selectedImage != nil {
+		res = append(res, 0x08, 0x04)
+		res = append(res, o.selectedImage.ToID()...)
+	}
+	if len(o.imageList) > 0 {
+		list := o.imageList.ToOptions(255 - len(res))
+		res = append(res, list...)
+	}
+	return res
+}
+
+func (dhr *DhcpRequest) buildAppleBsdpOptions(serverID net.IP) {
+	dhr.outOpts = dhcp.Options{}
+	dhr.outOpts[dhcp.OptionTFTPServerName] = []byte(dhr.nextServer.String())
+	dhr.outOpts[dhcp.OptionBootFileName] = []byte("ipxe.efi")
+	dhr.outOpts[dhcp.OptionVendorClassIdentifier] = []byte("AAPLBSDPC")
+	/*
+		if dhr.bootEnv != nil {
+			dhr.outOpts[dhcp.OptionBootFileName] = []byte(dhr.bootEnv.PathFor(dhr.bootEnv.Kernel))
+			if len(dhr.bootEnv.BootParams) > 0 {
+				dhr.outOpts[dhcp.OptionRootPath] = []byte(
+					fmt.Sprintf("http://%s:%d%s",
+						dhr.srcAddr.String(),
+						dhr.handler.bk.StaticPort,
+						dhr.bootEnv.PathFor(dhr.bootEnv.BootParams)))
+			}
+		}
+	*/
+}
+
+func (dhr *DhcpRequest) offerAppleBoot() bool {
+	if val, ok := dhr.pktOpts[dhcp.OptionVendorClassIdentifier]; ok &&
+		strings.HasPrefix(string(val), "AAPLBSDPC/i386") {
+		return true
+	}
+	return false
+}
+
+func (dhr *DhcpRequest) ServeAppleBSDP() string {
+	req, _ := dhr.reqAddr(dhr.reqType)
+	srvID := dhr.respondFrom(req)
+	if !(dhr.reqType == dhcp.Inform && dhr.offerAppleBoot()) {
+		dhr.Infof("%s: Ignoring DHCP %s from %s to the Apple BSDP service", dhr.xid(), dhr.reqType, req)
+		return "Ignored"
+	}
+	dhr.offerNetBoot = true
+	opts := &bsdpOpts{}
+	opts.Parse(dhr)
+	switch opts.msgtype {
+	case bsdpList:
+		images := bsdpBootOptions{}
+		images = append(images, &bsdpBootOption{
+			Install: false,
+			ImgType: bsdpDiags,
+			Index:   1,
+			Name:    "dr-boot",
+			Loader:  "ipxe.efi",
+		})
+		// Construct a list ACK, send it back.
+		opts.defaultImage = images[0]
+		opts.imageList = images
+		opts.srvID = srvID
+		dhr.outOpts = dhcp.Options{}
+		dhr.outOpts[dhcp.OptionVendorClassIdentifier] = []byte("AAPLBSDPC")
+		dhr.outOpts[dhcp.OptionVendorSpecificInformation] = opts.ToOption()
+		dhr.Reply(dhr.buildReply(dhcp.ACK, srvID, req))
+	case bsdpSelect:
+		if !bytes.Equal(opts.srvID, srvID) {
+			return "Ignored"
+		}
+		// Add a notation in the applicable Lease, send it back.
+		// For now, though, blatantly ignore things and always boot into ipxe
+		dhr.buildAppleBsdpOptions(srvID)
+		dhr.Reply(dhr.buildReply(dhcp.ACK, srvID, req))
+	case bsdpFail:
+		// Halt and catch fire
+		dhr.Errorf("%s: BSDP handshake from %s failed", dhr.xid(), req)
+		return "Ignored"
+	default:
+		dhr.Warnf("%s: Invalid BSDP option %d", dhr.xid(), opts.msgtype)
+		return "Invalid BSDP option"
+	}
+	return "ACK"
+}

--- a/midlayer/dhcp-tests/0003-apple-nbsp-select/0000.logs-expect
+++ b/midlayer/dhcp-tests/0003-apple-nbsp-select/0000.logs-expect
@@ -1,0 +1,2 @@
+No matching subnet, will respond to 192.168.124.10 from 10.0.0.10
+xid 0x0: Handling BSDP msg type 1 from 192.168.124.10

--- a/midlayer/dhcp-tests/0003-apple-nbsp-select/0000.request
+++ b/midlayer/dhcp-tests/0003-apple-nbsp-select/0000.request
@@ -1,0 +1,9 @@
+proto:dhcp4 iface:eno2 ifaddr:192.168.124.10:68 lport:67
+op:0x01 htype:0x01 hlen:0x06 hops:0x00 xid:0x00000000 secs:0x0000 flags:0x0000
+ci:192.168.124.10  yi:0.0.0.0 si:0.0.0.0 gi:0.0.0.0 ch:52:54:be:1e:00:00
+option:code:043 val:"1,1,1,2,2,1,1"
+option:code:053 val:"inf"
+option:code:055 val:"43,60"
+option:code:057 val:"1500"
+option:code:060 val:"AAPLBSDPC/i386/MacPro6,1"
+option:code:061 val:"1,0,62,225,205,114,239"

--- a/midlayer/dhcp-tests/0003-apple-nbsp-select/0000.response-expect
+++ b/midlayer/dhcp-tests/0003-apple-nbsp-select/0000.response-expect
@@ -1,0 +1,7 @@
+proto:dhcp4 iface:eno2 ifaddr:192.168.124.10:68 lport:67
+op:0x02 htype:0x01 hlen:0x06 hops:0x00 xid:0x00000000 secs:0x0000 flags:0x0000
+ci:0.0.0.0 yi:192.168.124.10 si:0.0.0.0 gi:0.0.0.0 ch:52:54:be:1e:00:00
+option:code:053 val:"ack"
+option:code:054 val:"10.0.0.10"
+option:code:043 val:"1,1,1,2,2,1,1,3,4,10,0,0,10,7,4,3,0,0,1,9,12,3,0,0,1,7,100,114,45,98,111,111,116"
+option:code:060 val:"AAPLBSDPC"

--- a/midlayer/dhcp-tests/0003-apple-nbsp-select/0001.logs-expect
+++ b/midlayer/dhcp-tests/0003-apple-nbsp-select/0001.logs-expect
@@ -1,0 +1,1 @@
+xid 0x0: Handling BSDP msg type 2 from 192.168.124.10

--- a/midlayer/dhcp-tests/0003-apple-nbsp-select/0001.request
+++ b/midlayer/dhcp-tests/0003-apple-nbsp-select/0001.request
@@ -1,0 +1,8 @@
+proto:dhcp4 iface:eno1 ifaddr:192.168.124.10:68 lport:67
+op:0x01 htype:0x01 hlen:0x06 hops:0x00 xid:0x00000000 secs:0x0000 flags:0x0000
+ci:192.168.124.10 yi:0.0.0.0 si:0.0.0.0 gi:0.0.0.0 ch:52:54:be:1e:00:00
+option:code:043 val:"1,1,2,2,2,1,1,3,4,192,168,124,1,8,4,3,0,0,1"
+option:code:053 val:"inf"
+option:code:055 val:"1,3,67,43,60"
+option:code:057 val:"1500"
+option:code:060 val:"AAPLBSDPC/i386/MacPro6,1"

--- a/midlayer/dhcp-tests/0003-apple-nbsp-select/0001.response-expect
+++ b/midlayer/dhcp-tests/0003-apple-nbsp-select/0001.response-expect
@@ -1,0 +1,7 @@
+proto:dhcp4 iface:eno1 ifaddr:192.168.124.10:68 lport:67
+op:0x02 htype:0x01 hlen:0x06 hops:0x00 xid:0x00000000 secs:0x0000 flags:0x0000
+ci:0.0.0.0 yi:192.168.124.10 si:0.0.0.0 gi:0.0.0.0 ch:52:54:be:1e:00:00
+file:"ipxe.efi"
+option:code:053 val:"ack"
+option:code:054 val:"192.168.124.1"
+option:code:060 val:"AAPLBSDPC"

--- a/midlayer/dhcp.go
+++ b/midlayer/dhcp.go
@@ -247,6 +247,9 @@ func (dhr *DhcpRequest) checkMachine(l *backend.Lease, s *backend.Subnet) {
 			return
 		}
 		dhr.offerNetBoot = true
+		if l.Fake() {
+			return
+		}
 		// We want the machine to PXE boot, and we know what address it is
 		// getting.  However, that address may not be one that we are
 		// currently rendering templates for.  Check to see if we need to

--- a/midlayer/dhcp.go
+++ b/midlayer/dhcp.go
@@ -373,6 +373,9 @@ func (dhr *DhcpRequest) buildReply(
 	// THis also appears to be required to make UEFI boot mode work properly on
 	// the Dell T320.
 	for _, opt := range dhr.outOpts.SelectOrderOrAll(order) {
+		if dhr.offerNetBoot {
+			dhr.Debugf("OfferBoot: opt %d: %v", opt.Code, opt.Value)
+		}
 		switch opt.Code {
 		case dhcp.OptionBootFileName:
 			fileName = opt.Value

--- a/midlayer/dhcpUtil.go
+++ b/midlayer/dhcpUtil.go
@@ -49,7 +49,7 @@ func (dhr *DhcpRequest) marshalText(p dhcp.Packet) ([]byte, error) {
 }
 
 func (dhr *DhcpRequest) MarshalText() ([]byte, error) {
-	return dhr.marshalText(dhr.pkt)
+	return dhr.marshalText(dhr.request)
 }
 
 func (dhr *DhcpRequest) PrintIncoming() string {
@@ -134,7 +134,7 @@ func (dhr *DhcpRequest) UnmarshalText(buf []byte) error {
 	}
 	res.SetCHAddr(mac)
 	if len(lines) == 3 {
-		dhr.pkt = res
+		dhr.request = res
 		return nil
 	}
 	for _, line := range lines[3:] {
@@ -167,7 +167,7 @@ func (dhr *DhcpRequest) UnmarshalText(buf []byte) error {
 			opt.AddToPacket(&res)
 		}
 	}
-	dhr.pkt = res
+	dhr.request = res
 	return nil
 }
 

--- a/midlayer/dhcp_test.go
+++ b/midlayer/dhcp_test.go
@@ -109,8 +109,12 @@ func TestDHCPCases(t *testing.T) {
 			if request.lPort == 4011 {
 				request.handler = binlHandler
 			}
-			r, _, _ := request.Process()
-			response := request.PrintOutgoing(r)
+			request.Process()
+			responses := make([]string, len(request.replies))
+			for i := range request.replies {
+				responses[i] = request.PrintOutgoing(request.replies[i])
+			}
+			response := strings.Join(responses, "\n")
 			if err := ioutil.WriteFile(actualResp, []byte(response), 0644); err != nil {
 				t.Errorf("FAIL: %s: Error saving response: %v", testPart, err)
 				break

--- a/midlayer/pxe.go
+++ b/midlayer/pxe.go
@@ -1,0 +1,319 @@
+package midlayer
+
+import (
+	"net"
+	"strings"
+
+	"github.com/digitalrebar/provision/backend"
+	"github.com/digitalrebar/provision/models"
+	dhcp "github.com/krolaw/dhcp4"
+)
+
+//option:code:175 val:“177,5,1,128,134,16,14,33,1,1,16,1,2,39,1,1,235,3,1,0,0,23,1,1,21,1,1,19,1,1”
+type ipxeOpts struct {
+	// base options
+	prio    int8 // code 1 = int8
+	keepsan bool // code 8 = uint8
+	skipsan bool // code 9 = uint8
+	// feature indicators
+	pxeext    byte // code 16 = uint8
+	biosdrive byte // code 189 = unsigned integer 8;
+	iscsi     bool // code 17 = uint8
+	aoe       bool // code 18 = uint8
+	http      bool // code 19 = uint8
+	https     bool // code 20 = uint8
+	tftp      bool // code 21 = uint8
+	ftp       bool // code 22 = uint8
+	dns       bool // code 23 = uint8
+	bzimage   bool // code 24 = uint8
+	multiboot bool // code 25 = uint8
+	slam      bool // code 26 = uint8
+	srp       bool // code 27 = uint8
+	nbi       bool // code 32 = uint8
+	pxe       bool // code 33 = uint8
+	elf       bool // code 34 = uint8
+	comboot   bool // code 35 = uint8
+	efi       bool // code 36 = uint8
+	fcoe      bool // code 37 = uint8
+	vlan      bool // code 38 = uint8
+	menu      bool // code 39 = uint8
+	sdi       bool // code 40 = uint8
+	nfs       bool // code 41 = uint8
+	nopxedhcp bool // code 176 = uint 8;
+	// strings
+	syslogs           string // code 85 = string;
+	cert              string // code 91 = string;
+	privkey           string // code 92 = string;
+	crosscert         string // code 93 = string;
+	busid             string // code 177 = string;
+	sanfilename       string // code 188 = string;
+	username          string // code 190 = string;
+	password          string // code 191 = string;
+	reverseusername   string // code 192 = string;
+	reversepassword   string // code 193 = string;
+	version           string // code 235 = string;
+	iscsiinitiatoriqn string // code 203 = string;
+}
+
+func (dhr *DhcpRequest) ipxeIsSane(arch uint) bool {
+	opts := parseIpxeOpts(dhr)
+	if !opts.http {
+		dhr.Warnf("Incoming iPXE does not support http")
+		return false
+	}
+	if arch == 0 {
+		if !opts.pxe {
+			dhr.Errorf("Incoming iPXE for arch %d does not support pxe. This should not happen", arch)
+			return false
+		}
+		if !opts.bzimage {
+			dhr.Warnf("Incoming iPXE does not support bzImage")
+			return false
+		}
+		if !opts.comboot {
+			dhr.Warnf("Incoming iPXE does not support comboot")
+			return false
+		}
+	}
+	if arch != 0 && !opts.efi {
+		dhr.Errorf("Incoming iPXE for arch %d does not support efi. This should not happen", arch)
+		return false
+	}
+	dhr.Infof("Incoming iPXE request is sane")
+	return true
+}
+
+func btob(b []byte) bool {
+	return b[0] != 0
+}
+
+func btouint16(b []byte) uint16 {
+	return uint16(b[0])<<8 + uint16(b[1])
+}
+
+func btouint32(b []byte) uint32 {
+	return uint32(b[0])<<24 + uint32(b[1])<<16 + uint32(b[2])<<8 + uint32(b[3])
+}
+
+func parseIpxeOpts(dhr *DhcpRequest) (res ipxeOpts) {
+	opts := dhr.pktOpts[175]
+	res = ipxeOpts{}
+	if opts == nil || len(opts) == 0 {
+		return res
+	}
+	for len(opts) > 2 {
+		code := opts[0]
+		codeLen := int(opts[1])
+		if len(opts[2:]) < codeLen {
+			return
+		}
+		opts = opts[2:]
+		val := opts[:codeLen]
+		dhr.Debugf("iPXE opt %d (len%d): %v", code, codeLen, val)
+		opts = opts[codeLen:]
+		switch code {
+		// base first
+		case 1:
+			res.prio = int8(val[0])
+		// byte vals
+		case 16:
+			res.pxeext = val[0]
+		case 189:
+			res.biosdrive = val[0]
+			// boolean values
+		case 176:
+			res.nopxedhcp = btob(val)
+		case 8:
+			res.keepsan = btob(val)
+		case 9:
+			res.skipsan = btob(val)
+		case 17:
+			res.iscsi = btob(val)
+		case 18:
+			res.aoe = btob(val)
+		case 19:
+			res.http = btob(val)
+		case 20:
+			res.https = btob(val)
+		case 21:
+			res.tftp = btob(val)
+		case 22:
+			res.ftp = btob(val)
+		case 23:
+			res.dns = btob(val)
+		case 24:
+			res.bzimage = btob(val)
+		case 25:
+			res.multiboot = btob(val)
+		case 26:
+			res.slam = btob(val)
+		case 27:
+			res.srp = btob(val)
+		case 32:
+			res.nbi = btob(val)
+		case 33:
+			res.pxe = btob(val)
+		case 34:
+			res.elf = btob(val)
+		case 35:
+			res.comboot = btob(val)
+		case 36:
+			res.efi = btob(val)
+		case 37:
+			res.fcoe = btob(val)
+		case 38:
+			res.vlan = btob(val)
+		case 39:
+			res.menu = btob(val)
+		case 40:
+			res.sdi = btob(val)
+		case 41:
+			res.nfs = btob(val)
+			// string values
+		case 85:
+			res.syslogs = string(val)
+		case 91:
+			res.cert = string(val)
+		case 92:
+			res.privkey = string(val)
+		case 93:
+			res.crosscert = string(val)
+		case 177:
+			res.busid = string(val)
+		case 188:
+			res.sanfilename = string(val)
+		case 190:
+			res.username = string(val)
+		case 191:
+			res.password = string(val)
+		case 192:
+			res.reverseusername = string(val)
+		case 193:
+			res.reversepassword = string(val)
+		case 203:
+			res.iscsiinitiatoriqn = string(val)
+		case 235:
+			res.version = string(val)
+		}
+	}
+	return res
+}
+
+func (dhr *DhcpRequest) offerPXE() bool {
+	if val, ok := dhr.pktOpts[dhcp.OptionVendorClassIdentifier]; ok &&
+		strings.HasPrefix(string(val), "PXEClient") {
+		return true
+	}
+	return false
+}
+
+// fillForPXE is responsible for determining whether we should handle
+// this options as a PXE request, and adding any required out options
+// based
+func (dhr *DhcpRequest) fillForPXE(l *backend.Lease, s *backend.Subnet) {
+	// The reservation already populated a BootFileName, use it.
+	if _, ok := dhr.outOpts[dhcp.OptionBootFileName]; ok {
+		return
+	}
+	// No BootFileName, fill out some sane defaults
+	fname := ""
+	var arch uint
+	if val, ok := dhr.pktOpts[dhcp.OptionClientArchitecture]; ok {
+		arch = uint(val[0])<<8 + uint(val[1])
+	}
+	inIPxe := false
+	if val, ok := dhr.pktOpts[dhcp.OptionUserClass]; ok &&
+		string(val) == "iPXE" {
+		inIPxe = true
+	}
+	if inIPxe && dhr.ipxeIsSane(arch) {
+		fname = "default.ipxe"
+	} else {
+		switch arch {
+		case 0:
+			if inIPxe {
+				fname = "ipxe.pxe"
+			} else {
+				fname = "lpxelinux.0"
+			}
+		case 7, 9:
+			fname = "ipxe.efi"
+		case 6:
+			dhr.Errorf("dr-provision does not support 32 bit EFI systems")
+		case 10:
+			dhr.Errorf("dr-provision does not support 32 bit ARM EFI systems")
+		case 11:
+			fname = "ipxe-arm64.efi"
+		default:
+			dhr.Errorf("Unknown client arch %d: cannot PXE boot it remotely", arch)
+		}
+	}
+	if fname == "" {
+		dhr.offerNetBoot = false
+		return
+	}
+	dhr.outOpts[dhcp.OptionBootFileName] = []byte(fname)
+}
+
+// buildBinlOptions builds appropriate DHCP options for use in
+// ProxyDHCP and binl handling.  These responses only include PXE
+// specific options.
+func (dhr *DhcpRequest) buildBinlOptions(
+	l *backend.Lease,
+	s *backend.Subnet,
+	r *backend.Reservation,
+	serverID net.IP) {
+	dhr.nextServer = serverID
+	dhr.coalesceOptions(l, s, r)
+	if !dhr.offerNetBoot {
+		return
+	}
+	opts := dhcp.Options{dhcp.OptionVendorClassIdentifier: []byte("PXEClient")}
+	if arch, ok := dhr.pktOpts[dhcp.OptionClientArchitecture]; ok {
+		opt := &models.DhcpOption{Code: byte(dhcp.OptionClientArchitecture)}
+		opt.FillFromPacketOpt(arch)
+		// Hack to work around buggy old UEFI firmware.
+		if opt.Value == "0" {
+			// PXE options are as follows:
+			// Discovery control: autoboot with provided name.
+			pxeOpts := []byte{0x06, 0x01, 0x08, 0xff}
+			opts[dhcp.OptionVendorSpecificInformation] = pxeOpts
+		}
+	}
+	// Send back the GUID if we got a guid
+	if dhr.pktOpts[97] != nil {
+		opts[97] = dhr.pktOpts[97]
+	}
+	opts[dhcp.OptionBootFileName] = dhr.outOpts[dhcp.OptionBootFileName]
+	opts[dhcp.OptionTFTPServerName] = dhr.outOpts[dhcp.OptionTFTPServerName]
+	dhr.outOpts = opts
+}
+
+// ServeBinl is responsible for handling ProxyDHCP Request messages
+// and binl Discover messages.  Both of those come in on port 4011.
+func (dhr *DhcpRequest) ServeBinl() string {
+	req, _ := dhr.reqAddr(dhr.reqType)
+	if !(dhr.reqType == dhcp.Discover || dhr.reqType == dhcp.Request) {
+		dhr.Infof("%s: Ignoring DHCP %s from %s to the BINL service", dhr.xid(), dhr.reqType, req)
+	}
+	// By default, all responses will be ACKs
+	respType := dhcp.ACK
+	if dhr.reqType == dhcp.Request && !req.IsGlobalUnicast() {
+		dhr.Infof("%s: NAK'ing invalid requested IP %s", dhr.xid(), req)
+		dhr.nak(dhr.respondFrom(req))
+		return "NAK"
+	}
+	lease, subnet, reservation := dhr.FakeLease(req)
+	if lease == nil {
+		return "NoInfo"
+	}
+	lease.Addr = req
+	serverID := dhr.respondFrom(req)
+	dhr.buildBinlOptions(lease, subnet, reservation, serverID)
+	if !dhr.offerNetBoot {
+		dhr.Infof("%s: BINL directed to not offer PXE response to %s", dhr.xid(), req)
+		return "NoPXE"
+	}
+	dhr.Reply(dhr.buildReply(respType, serverID, req))
+	return "ACK"
+}

--- a/models/aaplbsdp.go
+++ b/models/aaplbsdp.go
@@ -1,0 +1,103 @@
+package models
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+const (
+	BsdpOS9       = 0
+	BsdpOSX       = 1
+	BsdpOSXServer = 2
+	BsdpDiags     = 3
+)
+
+type BsdpBootOption struct {
+	Index     uint16 `plist:"Index"`
+	Install   bool   `plist:"IsInstall"`
+	OSType    byte   `plist:"Kind"`
+	OSVersion string `plist:"osVersion"`
+	Name      string `plist:"Name"`
+	Booter    string `plist:"BootFile"`
+	RootPath  string `plist:"RootPath"`
+}
+
+func (bo *BsdpBootOption) String() string {
+	res := []string{}
+	switch bo.Install {
+	case true:
+		res = append(res, "netinstall")
+	case false:
+		res = append(res, "netboot")
+	}
+	switch bo.OSType {
+	case BsdpOS9:
+		res = append(res, "os9")
+	case BsdpOSX:
+		res = append(res, "osx")
+	case BsdpOSXServer:
+		res = append(res, "osxsrv")
+	case BsdpDiags:
+		res = append(res, "diags")
+	}
+	res = append(res, bo.OSVersion)
+	res = append(res, fmt.Sprintf("%d", bo.Index))
+	res = append(res, bo.Name)
+	res = append(res, bo.Booter)
+	res = append(res, bo.RootPath)
+	return strings.Join(res, ":")
+}
+
+func (bo *BsdpBootOption) MarshalText() ([]byte, error) {
+	return []byte(bo.String()), nil
+}
+
+func (bo *BsdpBootOption) UnmarshalText(buf []byte) error {
+	parts := strings.Split(string(buf), ":")
+	if len(parts) != 7 {
+		return fmt.Errorf("Want 7 parts, got %d", len(parts))
+	}
+	for i := range parts {
+		val := parts[i]
+		switch i {
+		case 0:
+			switch val {
+			case "netboot":
+				bo.Install = false
+			case "netinstall":
+				bo.Install = true
+			default:
+				return fmt.Errorf("Invalid install type %s", val)
+			}
+		case 1:
+			switch val {
+			case "os9":
+				return fmt.Errorf("haha, try again. OS 9, really?")
+			case "osx":
+				bo.OSType = BsdpOSX
+			case "osxsrv":
+				bo.OSType = BsdpOSXServer
+			case "diags":
+				bo.OSType = BsdpDiags
+			default:
+				return fmt.Errorf("Unkown NBSP OS type %s", val)
+			}
+		case 2:
+			bo.OSVersion = val
+		case 3:
+			idx, err := strconv.ParseInt(val, 0, 64)
+			if err != nil {
+				return err
+			}
+			bo.Index = uint16(idx)
+		case 4:
+			bo.Name = val
+		case 5:
+			bo.Booter = val
+		case 6:
+			bo.RootPath = val
+		}
+	}
+	return nil
+}

--- a/models/aaplbsdp.go
+++ b/models/aaplbsdp.go
@@ -23,29 +23,41 @@ type BsdpBootOption struct {
 	RootPath  string `plist:"RootPath"`
 }
 
-func (bo *BsdpBootOption) String() string {
-	res := []string{}
-	switch bo.Install {
-	case true:
-		res = append(res, "netinstall")
-	case false:
-		res = append(res, "netboot")
-	}
+func (bo *BsdpBootOption) OSName() string {
 	switch bo.OSType {
 	case BsdpOS9:
-		res = append(res, "os9")
+		return "os9"
 	case BsdpOSX:
-		res = append(res, "osx")
+		return "osx"
 	case BsdpOSXServer:
-		res = append(res, "osxsrv")
+		return "osxsrv"
 	case BsdpDiags:
-		res = append(res, "diags")
+		return "diags"
+	default:
+		return "unknown"
 	}
-	res = append(res, bo.OSVersion)
-	res = append(res, fmt.Sprintf("%d", bo.Index))
-	res = append(res, bo.Name)
-	res = append(res, bo.Booter)
-	res = append(res, bo.RootPath)
+}
+
+func (bo *BsdpBootOption) InstallType() string {
+	switch bo.Install {
+	case true:
+		return "netinstall"
+	case false:
+		return "netboot"
+	}
+	return "Impossible"
+}
+
+func (bo *BsdpBootOption) String() string {
+	res := []string{
+		bo.InstallType(),
+		bo.OSName(),
+		bo.OSVersion,
+		fmt.Sprintf("%d", bo.Index),
+		bo.Name,
+		bo.Booter,
+		bo.RootPath,
+	}
 	return strings.Join(res, ":")
 }
 


### PR DESCRIPTION
MacPro6,1 boots into Sledgehemmer via ipxe.efi, and the High Sierra via netboot and netinstall methods.
Still need to do unit tests and the like, but it is ready to try out for our more experienced community members.