### PR TITLE
The backend is also marking a machine as not Runnable in error.

### DIFF
--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -422,22 +422,10 @@ func (j *Job) Validate() {
 	objs := j.rt.d
 	tasks := objs("tasks")
 	stages := objs("stages")
-	machines := objs("machines")
-
-	var m *Machine
-	if om := machines.Find(j.Machine.String()); om == nil {
-		j.Errorf("Machine %s does not exist", j.Machine.String())
-	} else {
-		m = AsMachine(om)
-		if j.oldState != j.State {
-			switch j.State {
-			case "failed":
-				m.Runnable = false
-				_, e2 := j.rt.Save(m)
-				j.AddError(e2)
-			case "created":
-				j.StartTime = time.Now()
-			}
+	if j.oldState != j.State {
+		switch j.State {
+		case "created":
+			j.StartTime = time.Now()
 		}
 	}
 	if !strings.Contains(j.Task, ":") {

--- a/cli/jobs_test.go
+++ b/cli/jobs_test.go
@@ -168,8 +168,6 @@ func TestJobCli(t *testing.T) {
 	// This tests that incomplet jobs come back again
 	cliTest(false, false, "jobs", "create", "-").Stdin(jobCreateNextInputString + "\n").run(t)
 	cliTest(false, false, "jobs", "update", "00000000-0000-0000-0000-000000000001", jobUpdateFailedJobInputString).run(t)
-	cliTest(false, true, "jobs", "create", "-").Stdin(jobCreateNextInputString + "\n").run(t)
-	cliTest(false, false, "machines", "update", "3e7031fe-3062-45f1-835c-92541bc9cbd3", "{ \"Runnable\": true }").run(t)
 	cliTest(false, false, "jobs", "create", "-").Stdin(jobCreateNextInputString + "\n").run(t)
 	cliTest(false, false, "jobs", "update", "00000000-0000-0000-0000-000000000002", jobUpdateFinishedJobInputString).run(t)
 	cliTest(false, false, "jobs", "create", "-").Stdin(jobCreateNextInput3String).run(t)

--- a/cli/test-data/output/TestJobCli/jobs.create.301de1c48b1b5910dc879e1f545634a8.2/stderr.expect
+++ b/cli/test-data/output/TestJobCli/jobs.create.301de1c48b1b5910dc879e1f545634a8.2/stderr.expect
@@ -1,1 +1,0 @@
-Error: Conflict: Machine 3e7031fe-3062-45f1-835c-92541bc9cbd3 is not runnable

--- a/cli/test-data/output/TestJobCli/jobs.create.301de1c48b1b5910dc879e1f545634a8.2/stdout.expect
+++ b/cli/test-data/output/TestJobCli/jobs.create.301de1c48b1b5910dc879e1f545634a8.2/stdout.expect
@@ -1,0 +1,17 @@
+RE:
+  "Archived": false,
+  "Available": true,
+  "BootEnv": "local",
+  "Current": true,
+  "CurrentIndex": 0,
+  "ExitState": "",
+  "Machine": "3e7031fe-3062-45f1-835c-92541bc9cbd3",
+  "NextIndex": 1,
+  "Previous": "00000000-0000-0000-0000-000000000001",
+  "ReadOnly": false,
+  "Stage": "stage3",
+  "State": "created",
+  "Task": "task1",
+  "Uuid": "00000000-0000-0000-0000-000000000002",
+  "Validated": true,
+  "Workflow": ""

--- a/cli/test-data/output/TestJobCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.15ef88524f82284ee914fdb15df5a1ef/stdout.expect
+++ b/cli/test-data/output/TestJobCli/machines.update.3e7031fe-3062-45f1-835c-92541bc9cbd3.15ef88524f82284ee914fdb15df5a1ef/stdout.expect
@@ -2,7 +2,7 @@
   "Address": "192.168.100.110",
   "Available": true,
   "BootEnv": "local",
-  "CurrentJob": "00000000-0000-0000-0000-000000000001",
+  "CurrentJob": "00000000-0000-0000-0000-000000000002",
   "CurrentTask": 0,
   "Description": "",
   "Errors": [],

--- a/cli/test-data/output/TestWorkflowSwitch/machines.show.Name.m1/stdout.expect
+++ b/cli/test-data/output/TestWorkflowSwitch/machines.show.Name.m1/stdout.expect
@@ -7,7 +7,7 @@ RE:
   "Name": "m1",
   "OS": "",
   "ReadOnly": false,
-  "Runnable": false,
+  "Runnable": true,
   "Stage": "stage1",
   "Tasks": \[
     "stage:stage1",


### PR DESCRIPTION
The only place that shoudl be doing that is the Runner itself,
but there was apparently backend code left over to do it as well.

The PR deletes the backend code that should not exist.