### PR TITLE
Docs back during migration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,19 @@
+# Copyright 2018, RackN, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Ignore when calculating language stats
+embedded/assets/swagger-ui/* linguist-vendored
+
+# Specify doc path
+doc/* linguist-documentation

--- a/doc/integrations/krib.rst
+++ b/doc/integrations/krib.rst
@@ -1,4 +1,277 @@
 Moved: KRIB (Kubernetes Rebar Integrated Bootstrapping)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-NOTICE: Moved to :ref:`component_krib`.  Please update references.
+NOTICE: Moving to :ref:`component_krib`.  Please update references.
+
+KRIB (Kubernetes Rebar Integrated Bootstrapping)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+License: KRIB is APLv2
+
+This document provides information on how to use the Digital Rebar *KRIB* content add-on.  Use of this content will enable the operator to install Kubernetes in either a Live Boot (immutable infrastructure pattern) mode, or via installed to local hard disk OS mode.
+
+KRIB uses the `kubeadm <https://kubernetes.io/docs/setup/independent/create-cluster-kubeadm/>`_ cluster deployment methodology coupled with Digital Rebar enhancements to help proctor the cluster Master election and secrets management.  With this content pack, you can install Kubernetes in a zero-touch manner.
+
+KRIB does also support production, highly available (HA) deployments, with multiple masters.  To enable this configuration, we've chosen to manage the TLS certificates and etcd installation in the Workflow instead of using the kubeadm process.
+
+This document assumes you have your Digital Rebar Provisioning endpoint fully configured, tested, and working.  We assume that you are able to properly provision Machines in your environment as a base level requirement for use of the KRIB content add-on use.
+
+KRIB Video References
+---------------------
+
+The following videos have been produced or presented by RackN related to the Digital Rebar KRIB solution.
+
+* `KRIB Zero Config Kubernetes Cluster channel <https://www.youtube.com/watch?v=SYOHI8DfRMo&list=PLXPBeIrpXjfhKqmTvxI5-0CmgUh82dztr&index=1>`_ on YouTube.
+* `KubeCon: Zero Configuration Pattern on Bare Metal <https://youtu.be/Psm9aOWzfWk>`_ on YouTube - RackN presentation at 2017 KubeCon/Cloud NativeCon in Austin TX
+
+Online Requirements
+-------------------
+
+KRIB uses community `kubeadm` for installation.  That process relies on internet connectivity to download containers and other components.
+
+Immutable -vs- Local Install Mode
+---------------------------------
+
+The two primary deployment patterns that the Digital Rebar KRIB content pack supports are:
+
+#. Live Boot (immutable infrastructure pattern - references [#]_ [#]_)
+#. Local Install (standard install-to-disk pattern)
+
+The *Live Boot* mode uses an in-memory Linux image based on the Digital Rebar Sledgehammer (CentOS based) image.  After each reboot of the Machine, the node is reloaded with the in-memory live boot image.  This enforces the concept of *immutable infrastructure* - every time a node is booted, deployed, or needs updating, simply reload the latest Live Boot image with appropriate fixes, patches, enhancements, etc.
+
+The Local Install mode mimics the traditional "install-to-my-disk" method that most people are familiar with.
+
+KRIB Basics
+-----------
+
+KRIB is a Content Pack addition to Digital Rebar Provision.  It uses the :ref:`rs_cluster_pattern` which provides atomic guarantees.  This allows for Kubernetes master(s) to be dynamically elected, forcing all other nodes to wait until the kubeadm on the elected master to generate an installation token for the rest of the nodes.  Once the Kubernetes master is bootstrapped, the Digital Rebar system facilitates the security token hand-off to rest of the cluster so they can join without any operator intervention.
+
+Elected -vs- Specified Master
+-----------------------------
+
+By default, the KRIB process will dynamically elect a Master for the Kubernetes cluster.  This masters simply win the *race-to-master* election process and the rest of the cluster will coalesce around the elected master.
+
+If you wish to specify a specific machines to be the designated masters, you can do so by setting a *Param* in the cluster *Profile* to the specific *Machine* that will be come the master.  To do so, set the ``krib/cluster-masters``  *Param* to a JSON structure with the Name, UUID and IP of the machines to become masters.  You may add this *Param* to the *Profile* in the below specifications, as follows:
+
+  ::
+
+    # JSON reference to add to the Profile Params section
+    "krib/cluster-masters": [{"Name":"<NAME>", "Uuid":"<UUID>", "Address": "<ADDRESS>"}]
+
+    # or drpcli command line option
+    drpcli profiles set my-k8s-cluster param krib/cluster-master to <JSON>
+
+The Kubernetes Master will be built on this Machine specified by the *<UUID>* value.
+
+.. note:: This *MUST* be in the cluster profile because all machines in the cluster must be able to see this parameter.
+
+Install KRIB
+------------
+
+KRIB is a Content Pack and is installed in the standard method as any other Contents.   We need the ``krib.json`` content pack to fully support KRIB and install the helper utility contents for stage changes.
+
+
+CLI Install
+===========
+
+
+Using the Command Line (`drpcli`) utility configured to your endpoint, use this process:
+
+  ::
+
+  	# Get code
+  	git clone https://github.com/digitalrebar/provision-content
+  	cd krib
+
+    # KRIB content install
+    drpcli contents bundle krib.yaml
+    drpcli contents upload krib.yaml
+
+UX Install
+==========
+
+In the UX, follow this process:
+
+#. Open your DRP Endpoint: (eg. https://127.0.0.1:8092/ )
+#. Authenticate to your Endpoint
+#. Login with your ```RackN Portal Login``` account (upper right)
+#. Go to the left panel "Content Packages" menu
+#. Select ``Kubernetes (KRIB: Kubernetes Rebar Immutable Bootstrapping)`` from the right side panel (you may need to select *Browser for more Content* or use the *Catalog* button)
+#. Select the *Transfer* button for both content packs to add the content to your local Digital Rebar endpoint
+
+
+Configuring KRIB
+----------------
+
+The basic outline for configuring KRIB follows the below steps:
+
+#. create a *Profile* to hold the *Params* for the KRIB configuration (you can also clone the ``krib-example`` profile)
+#. add a *Param* of name ``krib/cluster-profile`` to the *Profile* you created
+#. add a *Param* of name ``etcd/cluster-profile`` to the *Profile* you created
+#. apply the Profile to the Machines you are going to add to the KRIB cluster
+#. change the Workflow on the Machines to ``krib-live-cluster`` for memory booting or ``krib-install-cluster`` to install to Centos.  You may clone these reference workflows to build custom actions.
+#. installation will start as soon as the Workflow has been set.
+
+There are many configuration options available, review the ``krib/*`` and ``etcd/*`` parameters to learn more.  
+
+Configure with Terraform
+========================
+
+Please review the ``intergrations/krib`` for example Terraform plans.
+
+Configure with the CLI
+======================
+
+The configuration of the Cluster includes several reference *Workflow* that can be used for installation.  Depending on which Workflow you use, will determine if the cluster is built via install-to-local-disk or via an immutable pattern (live boot in-memory boot process).   Outside of the Workflow differences, all remaining configuration elements are the same.
+
+You must writeable create a *Profile* from YAML (or JSON if you prefer) with the Params stagemap and param required information. Modify the *Name* or other fields as appropriate - be sure you rename all subsequent fields appropriately.
+
+  ::
+
+    echo '
+    ---
+    Name: "my-k8s-cluster"
+    Description: "Kubernetes install-to-local-disk"
+    Params:
+      krib/cluster-profile: "my-k8s-cluster"
+      etcd/cluster-profile: "my-k8s-cluster"
+    Meta:
+      color: "purple"
+      icon: "ship"
+      title: "My Installed Kubernetes Cluster"
+    ' > /tmp/krib-config.yaml
+
+    drpcli profiles create - < /tmp/krib-config.yaml
+
+.. note:: The following commands should be applied to all of the Machines you wish to enroll in your KRIB cluster.  Each Machine needs to be referenced by the Digital Rebar Machine UUID.  This example shows how to collect the UUIDs, then you will need to assign them to the ``UUIDS`` variable.  We re-use this variable throughout the below documentation within the shell function named *my_machines*.  We also show the correct ``drpcli`` command that should be run for you by the helper function, for your reference.
+
+Create our helper shell function *my_machines*
+  ::
+
+    function my_machines() { for U in $UUIDS; do set -x; drpcli machines $1 $U $2; set +x; done; }
+
+List your Machines to determine which to apply the Profile to
+  ::
+
+    drpcli machines list | jq -r '.[] | "\(.Name) : \(.Uuid)"'
+
+IF YOU WANT to make ALL Machines in your endpoint use KRIB, do:
+  ::
+
+    export UUIDS=`drpcli machines list | jq -r '.[].Uuid'`
+
+Otherwise - individually add them to the *UUIDS* variable, like:
+  ::
+
+    export UUIDS="UUID_1 UUID_2 ... UUID_n"
+
+Add the Profile to your machines that will be enrolled in the cluster
+
+  ::
+
+    my_machines addprofile my-k8s-cluster
+
+    # runs example command:
+    # drpcli machines addprofile <UUID> my-k8s-cluster
+
+Change stage on the Machines to initiate the Workflow transition.  YOU MUST select the correct stage, dependent on your install type (Immutable/Live Boot mode or install-to-local-disk mode).  For Live Boot mode, select the stage ``ssh-access`` and for the install-to-local-disk mode select the stage ``centos-7-install``.
+
+  ::
+
+    # for Live Boot/Immutable Kubernetes mode
+    my_machines workflow krib-live-cluster
+
+    # for intall-to-local-disk mode:
+    my_machines workflow krib-install-cluster
+
+    # runs example command:
+    # drpcli machines workflow <UUID> krib-live-cluster
+    # or
+    # drpcli machines workflow <UUID> krib-install-cluster
+
+Configure with the UX
+=====================
+
+The below example outlines the process for the UX.
+
+RackN assumes the use of CentOS 7 BootEnv during this process.  However, it should theoretically work on most of the BootEnvs.  We have not tested it, and your mileage will absolutely vary...
+
+1. create a *Profile* for the Kubernetes Cluster (e.g. ``my-k8s-cluster``) or clone the ``krib-example`` profile.
+2. add a *Param* to that *Profile*: ``krib/cluster-profile`` = ``my-k8s-cluster``
+2. add a *Param* to that *Profile*: ``etcd/cluster-profile`` = ``my-k8s-cluster``
+3. Add the *Profile* (eg ``my-k8s-cluster``) to all the machines you want in the cluster.
+4. Change workflow on all the machines to ``krib-install-cluster`` for install-to-local-disk, or to ``krib-live-cluster`` for the Live Boot/Immutable Kubernetes mode
+
+Then wait for them to complete.  You can watch the Stage transitions via the Bulk Actions panel (which requires RackN Portal authentication to view).
+
+.. note:: The reason the *Immutable Kubernetes/Live Boot* mode does not need a reboot is because they are already running *Sledgehammer* and will start installing upon the stage change.
+
+Operating KRIB
+--------------
+
+Who is my Master?
+=================
+
+If you have not specified who the Kubernetes Master should be; and the master was chosen by election - you will need to determine which Machine is the cluster Master.
+  ::
+
+    # returns the Kubernetes cluster Machine UUID
+    drpcli profiles show my-k8s-cluster | jq -r '.Params."krib/cluster-masters"'
+
+Use ``kubectl`` - on Master
+===========================
+
+You can log in to the Master node as identified above, and execute ``kubectl`` commands as follows:
+  ::
+
+      export KUBECONFIG=/etc/kubernetes/admin.conf
+      kubectl get nodes
+
+
+Use ``kubectl`` - from anywhere
+===============================
+
+Once the Kubernetes cluster build has been completed, you may use the ``kubectl`` command to both verify and manage the cluster.  You will need to download the *conf* file with the appropriate tokens and information to connect to and authenticate your ``kubectl`` connections. Below is an example of doing this:
+  ::
+
+    # get the Admin configuration and tokens
+    drpcli profiles get my-k8s-cluster param krib/cluster-admin-conf > admin.conf
+
+    # set our KUBECONFIG variable and get nodes information
+    export KUBECONFIG=`pwd`/admin.conf
+    kubectl get nodes
+
+Ingress/Egress Traffic and Dashboard Access
+===========================================
+
+The Kubernetes dashboard is enabled within a default KRIB built cluster.  However no Ingress traffic rules are set up.  As such, you must access services from external connections by making changes to Kubernetes, or via the :ref:`rs_k8s_proxy`.
+
+These are all issues relating to managing, operating, and running a Kubernetes cluster, and not restrictions that are imposed by Digital Rebar Provision.  Please see the appropriate Kubernetes documentation on questions regarding operating, running, and administering Kubernetes (https://kubernetes.io/docs/home/).
+
+.. _rs_k8s_proxy:
+
+Kubernetes Dashboard via Proxy
+==============================
+
+Once you have obtained the ``admin.conf`` configuration file and security tokens, you may use ``kubectl`` in Proxy mode to the Master.  Simply open a separate terminal/console session to dedicate to the Proxy connection, and do:
+  ::
+
+    kubectl proxy
+
+Now, in a local web browser (on the same machine you executed the Proxy command) open the following URL:
+
+    https://127.0.0.1:8001/ui
+
+
+Multiple Clusters
+-----------------
+
+It is absolutely possible to build multiple Kubernetes KRIB clusters with this process.  The only difference is each cluster should have a unique name and profile assigned to it.  A given Machine may only participate in a single Kubernetes cluster type at any one time.  You can install and operate both Live Boot/Immutable with install-to-disk cluster types in the same DRP Endpoint.
+
+
+Footnotes
+---------
+
+.. [#] Immutable Infrastructure Reference: `Making Server Deployment 10x Faster – the ROI on Immutable Infrastructure <https://www.rackn.com/2017/10/11/making-server-deployment-10x-faster-roi-immutable-infrastructure/>`_
+
+.. [#] Immutable Infrastructure Reference: `Go CI/CD and Immutable Infrastructure for Edge Computing Management <https://www.rackn.com/2017/09/15/go-cicd-immutable-infrastructure-edge-computing-management/>`_

--- a/doc/integrations/krib.rst
+++ b/doc/integrations/krib.rst
@@ -1,7 +1,13 @@
-Moved: KRIB (Kubernetes Rebar Integrated Bootstrapping)
+Moving: KRIB (Kubernetes Rebar Integrated Bootstrapping)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 NOTICE: Moving to :ref:`component_krib`.  Please update references.
+
+DOC SOURCE: https://github.com/digitalrebar/provision-content/blob/master/krib/._Documentation.meta
+
+ADDITIONAL MATERIAL: https://provision.readthedocs.io/en/tip/doc/content-packages/krib.html
+
+.. _rs_krib:
 
 KRIB (Kubernetes Rebar Integrated Bootstrapping)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/doc/integrations/terraform.rst
+++ b/doc/integrations/terraform.rst
@@ -1,4 +1,218 @@
 Terraform Provider for Digital Rebar Provision
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-NOTICE: Moved to :ref:`component_terraform`.  Please update references.
+NOTICE: Moving to :ref:`component_terraform`.  Please update references.
+
+.. _rs_terraform:
+
+The following instructions to install the needed Digital Rebar Provision
+integrations to support Terraform.  Terraform integrations require that
+machines can reboot.  
+
+The Terraform system is not synchronized with Digital Rebar, this documentation is only
+intended to cover the provider.
+
+Note: As of DRP v3.8 (workflows enabled), changes to bootenvs will automatically
+cause reboots if the DRP runner/agent is allowed to keep running.  Otherwise, an IPMI plugin is required.
+We recommend using both Workflow and IPMI based reboots to ensure that the systems return to a consistent state.
+
+Source Code: https://github.com/rackn/terraform-provider-drp 
+
+Video Demos: 
+  * v3.8 DRP https://youtu.be/RtuZQHKmd9U
+  * v3.2 DRP https://www.youtube.com/watch?v=6MLyUVgnVo4
+
+License
+-------
+
+The Terraform Provider for Digital Rebar Provision is APLv2 licensed.  Advanced features or workflow may require capabilities that use different licenses.
+
+Prereqs
+-------
+
+Before starting this process, a Digital Rebar Provision (DRP) server is required, along with the ability to provision machines.  These machines could be VMs, Packet servers or physical servers in a data center.
+
+You must also have installed Terraform and secured the Digital Rebar Provision Terraform Provider.  You can build the provider from source or retrieve a compiled version from the Github releases area, https://github.com/rackn/terraform-provider-drp/releases.
+
+Basic Operation
+---------------
+
+The DRP Terraform Provider uses a pair of Machine Parameters to create an inventory pool.  Only machines with these parameters will be available to the provider.
+
+The `terraform/managed` parameter determines the basic inventory availability.  This flag must be set to true for Terraform to find machines.
+
+The `terraform/allocated` parameter determines when machines have been assigned to a Terraform plan.  When true, the machine is now being managed by Terraform.  When false, the machine is available for allocation.
+
+Using the RackN `terraform-ready` stage will automatically set these two parameters.
+
+The Terraform Provider can read additional fields when requesting inventory.  In this way, users can request machines with specific characteristics.
+
+.. _rs_terraform_machine:
+
+DRP Machine Configuration
+-------------------------
+
+Note: these instructions assume that you are using the RackN extension; however, it is not required for Terraform operation.
+
+Install the `Terraform` content package from RackN.  This content provides the parameters (described above) and a stage (`terraform-ready`) to configure Terraform properties on machines.
+
+Create a workflow that includes the `terraform-ready` stage to set the two parameters.  Once these values are set they do not have to be run again, but there is no harm in leaving the stage in place.
+
+Before testing Terraform, it is good practice to make sure you can manually cycle machines by changing their workflow (or change stage and reboot).  These changes should result in a machine provisioning cycle.
+
+Make sure that you know your endpoint URI, user and password.
+
+Installing The Terraform Digital Rebar Provision Provider
+---------------------------------------------------------
+
+Please install Terraform on your system: https://www.terraform.io/intro/getting-started/install.html
+
+Download (or build) the DRP Provider from https://github.com/rackn/terraform-provider-drp/releases.
+
+Initialize the plugin using `terraform init`
+
+Create a Plan using the DRP Provider Resources
+----------------------------------------------
+
+The DRP Provider exposes all the objects in Digital Rebar Project so you can script against any operation.
+
+The critical block is the provider block which identifies the provider and login information (shown here with default values):
+
+  ::
+
+   	variable "api_url" {
+   	  default = "https://127.0.0.1:8092"
+   	}
+   	variable "api_user" {
+   	  default = "rocketskates"
+   	}
+   	variable "api_password" {
+   	  default = "r0cketsk8ts"
+   	}
+   	provider "drp" {
+   	  api_user     = "${var.api_user}"
+   	  api_password = "${var.api_password}"
+   	  api_url      = "${var.api_url}"
+   	}
+
+Once you have the provider block, you can name resource blocks using the normal object key values.  For example, a machine resource looks like this:
+
+  ::
+
+  	resource "drp_machine" "one_random_node" {
+  	  count = 1
+  	  Workflow    = "centos-7"
+  	  Description = "updated description"
+  	  Name        = "greg2"
+  	  userdata    = "yaml cloudinit file"
+  	}
+
+You can set any Machine property by naming the property with correct capitalization.  You can use the Terraform syntax to create more complex models like Meta, Profiles.
+
+.. note:: If you set Profiles, Params or Meta you will override other existing information in the machine! The following helpers have been defined to avoid this:
+
+  * `add_profiles`: allows you to add profiles to the machine without override other profiles.
+
+There are many options to set including filters, parameters and profiles.  For a full example, please look at https://github.com/rackn/terraform-provider-drp/blob/master/test.tf.example
+
+Picking Machines with a Pool
+----------------------------
+
+You can add a `pool` block into the plan that will select machines based on the pool name.  This is helpful if you want to partiation your machines.  Pools use the `terraform/pool` Param on the machines and will be assumed to be `default` if omitted.
+
+For example:
+
+  ::
+
+    pool = "deep_eddy"
+
+
+Picking Machines with Filter
+----------------------------
+
+You can add a `filters` block into the plan that will select machines based on criteria.  This is helpful if you want to select specific types of machines based on Param data.  Filters use the API filters definition and are JSON formatted (types are guessed so numbers and bools are coerced).  See :ref:`rs_api_filters`.
+
+For example:
+
+  ::
+
+    filters = [{
+	    name = "Name"
+	    jsonvalue = "greg2"
+	}]
+
+You can only filter on indexed fields and defined Params.  Further, you cannot search deeply into Params, only the first level value is matched.
+
+Special Complete and Decommissioning Fields
+-------------------------------------------
+
+The provider watches until the machine reaches the `complete` or `complete-no-wait` stages; however, you can customize this behavior by setting the `completion_stage` to the plan.
+
+You can override the default the decommissioning flow (set workflow or stage back to `discover`) by adding  `decommission_workflow = "my_decom_workflow"` to the plan.
+
+You can also override the return icon (`map outline`) and color ('black') by adding `decommission_icon` and `decommission_color` to the plan.  Machine icons are handy ways to quickly show status of a provisioning cycle.
+
+Users can set icons using
+
+  ::
+
+	  Meta {
+	      icon = "leaf"
+	      color = "green"
+	  }
+
+
+Creating RAW Machines using Cloud IPMI plugins
+------------------------------------------
+
+The `drp_machine` resource relies on having a pool of machines already configured; however, you can use the `drp_raw_machine` resource to create machines in Digital Rebar Provision.  If you are using an IPMI plugin that supports creating machines, such as Packet or Virtualbox, and set the `machine-plugin` value then the plugin will create (and destroy) the associated machine in the target platform.  This can be a very powerful way to build and manage clusters.  
+
+It is possible to use raw and pooled machines together by also setting the `terraform/managed` and `terraform/allocated` parameters when creating machines.  This will allow Terraform to treat newly created machines as a pool.  It's important to include chained `depends_on` in the resource blocks when using this approach in a single plan.
+
+You may also set `terraform/pool` to something.  The default behavior assumes `default` but you can use this Param to manage multiple pools of resources.  Select pools using `pool` in the `drp_machine` resources.  
+
+Note: Unlike the `drp_machine` resource, this resource does not wait until the workflow has completed.  It will return when the machine has been create API returns.
+
+An example of the `drp_raw_machine` resource with correct parameter values is
+
+  ::
+
+    resource "drp_raw_machine" "packet-machines" {
+      Description = "Terraform Added RAW"
+      Workflow = "discover"
+      Name = "packet_machine"
+      Params {
+        "machine-plugin" = "packet-ipmi"
+        "packet/plan" ="baremetal_0"
+        "terraform/managed" = "true"
+        "terraform/allocated" = "false"
+        "terraform/pool" = "default"
+      }
+
+Running Terraform
+-----------------
+
+Just use `terraform apply` and `terraform destroy` and as normal!
+
+Note: the examples above use variables for endpoint login.  The syntax for overriding these variables to set environment variables starting with `export TF_VAR_my_var=` and the variable name or pass `-var 'api_url=https://[ip address]:8092'`.  User names and passwords should never be hard coded into plan files!
+
+Extending the Features
+----------------------
+
+Using the `terraform/owner` parameter helps administrators track who is using which machines.  You may also choose to create multiple DRP users to help track activity.
+
+It is highly recommended that you include decommissioning steps (disk scrub, bios reset, etc) and additional burn-in to validate systems during the recovery cycle.
+
+Using IPMI to reset machines is a safer bet than relying on the DRP runner to soft reboot systems.  If you want to make sure that you have a consistent recovery process, IPMI is highly recommended.
+
+To improve delivery time:
+
+1. Keep the machines running
+2. Use image based provisioning instead of netboot.
+
+.. note:: If you are relying on the DRP Running workflow to start allocation and recovery, make sure that you have your tokens set to never expire!
+
+Summary
+-------
+
+Now that these steps are completed, the Digital Rebar Provision Terraform Provider will integrate like any cloud provider.

--- a/doc/integrations/terraform.rst
+++ b/doc/integrations/terraform.rst
@@ -1,9 +1,16 @@
-Terraform Provider for Digital Rebar Provision
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+MOVING: Terraform Provider for Digital Rebar Provision
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 NOTICE: Moving to :ref:`component_terraform`.  Please update references.
 
+DOC SOURCE: https://github.com/rackn/provision-content/blob/master/terraform/._Documentation.meta
+
+ADDITIONAL MATERIAL: https://provision.readthedocs.io/en/tip/doc/content-packages/terraform.html
+
 .. _rs_terraform:
+
+Terraform Provider for Digital Rebar Provision
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following instructions to install the needed Digital Rebar Provision
 integrations to support Terraform.  Terraform integrations require that


### PR DESCRIPTION
I was too eager to move the documentation links around....

This puts the documentation back in the /docs and cross references.  We have to be careful because there are now two places to update until top level component doc generation work is completed.

Note: there is a lot of good information in the components based on the model documentation.

For .gitattributes docs, see https://github.com/github/linguist