### PR TITLE
Update build to disable CGO on all platforms.

### DIFF
--- a/tools/build.sh
+++ b/tools/build.sh
@@ -49,6 +49,8 @@ set +e
 . tools/version.sh
 set -e
 
+export CGO_ENABLED=0
+
 echo "Version = $Prepart$MajorV.$MinorV.$PatchV$Extra-$GITHASH"
 
 export VERFLAGS="-s -w \


### PR DESCRIPTION
All the platforms we were cross-compiling were already building
without CGO support, this ensures that the platform we are building on
natively also has CGO support disabled.

This also gets rid of any incidental libc requirements that may have
existed.