### PR TITLE
Fix user.ChangePassword invalidating future tokens

### DIFF
--- a/backend/user.go
+++ b/backend/user.go
@@ -95,9 +95,9 @@ func (u *User) ChangePassword(rt *RequestTracker, newPass string) error {
 		return err
 	}
 	u.PasswordHash = ph
-	_, err = rt.Save(u)
 	// When a user changes their password, invalidate any previous cached auth tokens.
 	u.Secret = randString(16)
+	_, err = rt.Save(u)
 	return err
 }
 

--- a/backend/user_test.go
+++ b/backend/user_test.go
@@ -55,10 +55,19 @@ func TestUserPassword(t *testing.T) {
 		} else {
 			t.Logf("Checking password failed, as expected.")
 		}
+		// store original secret and change password
+		curSecret := u.Secret
 		if err := u.ChangePassword(rt, "password"); err != nil {
 			t.Errorf("Changing password failed: %v", err)
 		} else {
 			t.Logf("Changing password passed.")
+		}
+		// store new secret and check secret was regenerated
+		newSecret := u.Secret
+		if curSecret == newSecret {
+			t.Errorf("Changing password did not regenerate Secret!")
+		} else {
+			t.Logf("Changing password regenerated Secret")
 		}
 		// reload the user, then check the password again.
 		buf := rt.find("users", "test user")
@@ -71,7 +80,13 @@ func TestUserPassword(t *testing.T) {
 		if !newU.CheckPassword("password") {
 			t.Errorf("Checking password should have succeeded.")
 		} else {
-			t.Logf("CHecking password passed, as expected.")
+			t.Logf("Checking password passed, as expected.")
+		}
+		// check secret was changed and persisted by ChangePassword above
+		if newU.Secret != newSecret {
+			t.Errorf("Changing password did not persist new Secret")
+		} else {
+			t.Logf("Changing password persisted new Secret")
 		}
 		// Make sure sanitizing the user works as expected
 		sanitizedU := newU.Sanitize().(*models.User)
@@ -82,3 +97,4 @@ func TestUserPassword(t *testing.T) {
 		}
 	})
 }
+


### PR DESCRIPTION
Versions: `tip` from installer and current code in `master` both exhibit the same behaviour.

TL;DR Writing an Ansible playbook to deploy DRP, in the following order:

1. Download and install DRP Binaries
2. Configure Service & Start
3. Create user accounts
4. Set passwords of created user accounts
5. Delete rocketskates user
6. Download and activate DRP content packs using newly created admin account

Expressed as shell commands, the relevant part is something like this:

```bash
drpcli users create '{"Name":"admin","Description":"Admin User","Roles":["superuser"],"Available":true}'
drpcli users password admin "password"
RS_KEY="admin:password" drpcli users destroy rocketskates
export RS_TOKEN=`RS_KEY="admin:password" drpcli users token admin | jq -r '.Token'`
drpcli contents create dev-library.json # Works
drpcli contents create drp-community-content.json # Fails
drpcli contents create ansible.json # Fails
...
```

It doesn't matter what order the `contents create` lines are in, it always fails on the second and subsequent lines.

I built a local copy of `dr-provision` from `master` and added debug logging to `frontend.userAuth()`, which shows that the `userSecret` and `grantorSecret` were changing between the first and second `contents create` calls [around here](https://github.com/digitalrebar/provision/blob/master/frontend/frontend.go#L323).

Checking this manually using `drpcli users list` showed the user `Secret` being updated as well.

I tracked this back to `user.ChangePassword()` which modifies the `Secret` whenever a users' password is changed, but does *not* appear to save it to the `User` store at the same time.

Currently, the `users password` call changes the `PasswordHash` and the `Secret`, but does not commit the new `Secret` into the store (changing the `Secret` happens after the `User` is saved).

A token is then generated from this `User` - either using the 'old' `Secret` which had been previously persisted, or possibly the 'new' `Secret` which is stored ephemerally in the existing `User` object but not persisted to the backing store (not sure which one happens here).

The first `content create` call (or some other consistently occurring action) then either:

 - Causes the `User` to  be reloaded from the store, invalidating any `Token`s generated using the ephemeral `Secret`, or
 - Causes the ephemeral `User` to be saved to the store, invalidating any `Token`s generated using the previously stored `Secret`.

The change in this PR appears to resolve the issue by saving the newly generated `Secret` into the `User` store so that this is consistent with the ephemeral data.

I'm not 100% that this is the correct fix or if I've missed anything as I'm not entirely familiar with the codebase - I've added some additional tests around `ChangePassword` but happy to make further changes if necessary.