### PR TITLE
Dockerfile refactor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ FROM debian:stable-slim
 ENV LANG=C.UTF-8
 RUN apt-get update && \
     apt-get install --no-install-recommends -y iproute2 ipmitool libarchive-tools p7zip && \
-    rm -rf /var/lib/apt/lists/*
+    rm -rf /var/lib/apt/lists/* && \
+    mkdir -p /provision/drp-data
 
 COPY --from=builder /provision/binaries/ /usr/bin/
 
@@ -32,6 +33,6 @@ COPY --from=builder /provision/binaries/ /usr/bin/
 RUN dr-provision --version || true
 
 EXPOSE 8091 8092 69 67 4011
-VOLUME ["/drp-data"]
+VOLUME ["/provision/drp-data"]
 
-ENTRYPOINT dr-provision --base-root=/drp-data --local-content= --default-content=
+ENTRYPOINT dr-provision --base-root=/provision/drp-data --local-content= --default-content=

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,55 +1,37 @@
-FROM alpine:3.6
+FROM debian:stable-slim as builder
 
 ARG DRP_VERSION=stable
 ARG DRP_COMMIT=""
 
-# add glibc so we can run drp executables
-# credit: http://www.manorrock.com/blog/2016/08/30/docker_tip_6_create_a_base_alpine_glibc_image.html
-RUN ALPINE_GLIBC_BASE_URL="https://github.com/sgerrand/alpine-pkg-glibc/releases/download" && \
-    ALPINE_GLIBC_PACKAGE_VERSION="2.23-r3" && \
-    ALPINE_GLIBC_BASE_PACKAGE_FILENAME="glibc-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
-    ALPINE_GLIBC_BIN_PACKAGE_FILENAME="glibc-bin-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
-    ALPINE_GLIBC_I18N_PACKAGE_FILENAME="glibc-i18n-$ALPINE_GLIBC_PACKAGE_VERSION.apk" && \
-    apk add --no-cache --virtual=.build-dependencies wget ca-certificates && \
-    wget \
-        "https://alpine-pkgs.sgerrand.com/sgerrand.rsa.pub" \
-        -O "/etc/apk/keys/sgerrand.rsa.pub" && \
-    wget \
-        "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
-        "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
-        "$ALPINE_GLIBC_BASE_URL/$ALPINE_GLIBC_PACKAGE_VERSION/$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
-    apk add --no-cache \
-        "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
-        "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
-        "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME" && \
-    \
-    rm "/etc/apk/keys/sgerrand.rsa.pub" && \
-    /usr/glibc-compat/bin/localedef --force --inputfile POSIX --charmap UTF-8 C.UTF-8 || true && \
-    echo "export LANG=C.UTF-8" > /etc/profile.d/locale.sh && \
-    \
-    apk del glibc-i18n && \
-    \
-    rm "/root/.wget-hsts" && \
-    apk del .build-dependencies && \
-    rm \
-        "$ALPINE_GLIBC_BASE_PACKAGE_FILENAME" \
-        "$ALPINE_GLIBC_BIN_PACKAGE_FILENAME" \
-        "$ALPINE_GLIBC_I18N_PACKAGE_FILENAME"
-
 ENV LANG=C.UTF-8
+ENV DEBIAN_FRONTEND=noninteractive
 
 # digital rebar provision install starts here
-EXPOSE 8091 8092 69 67 4011
-ENV INSTALLDIR "/provision"
-# If you set STATICIP, use "--static-ip=<IP>"
-ENV STATICIP ""
-ENV drp "./dr-provision ${STATICIP} --base-root=${INSTALLDIR}/drp-data --local-content= --default-content="
-COPY tools/install.sh ${INSTALLDIR}/
-WORKDIR ${INSTALLDIR}
-VOLUME ["drp-data"]
+WORKDIR /provision/
+COPY tools/install.sh .
 # install provision and its deps
-RUN echo "DRP_VERSION=${DRP_VERSION}"
-RUN apk add --no-cache iproute2 bash ipmitool curl libarchive-tools p7zip && ./install.sh --isolated install --drp-version=${DRP_VERSION} --commit=${DRP_COMMIT}
+RUN echo "DRP_VERSION=${DRP_VERSION}" && \
+    apt-get update && \
+    apt-get install -y sudo curl procps iproute2 ipmitool libarchive-tools p7zip && \
+    ./install.sh --isolated install --drp-version=${DRP_VERSION} --commit=${DRP_COMMIT}
+
+# Copy binaries following symlinks. This is used for easier copying from builder image.
+RUN mkdir /provision/binaries && \
+    cp -L /provision/dr-provision /provision/drbundler /provision/drpcli /provision/binaries/
+
+# Build final container
+FROM debian:stable-slim
+ENV LANG=C.UTF-8
+RUN apt-get update && \
+    apt-get install --no-install-recommends -y iproute2 ipmitool libarchive-tools p7zip && \
+    rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /provision/binaries/ /usr/bin/
+
 # run the api server so we can install sledgehammer image
-RUN ./dr-provision --version || true
-CMD ${drp}
+RUN dr-provision --version || true
+
+EXPOSE 8091 8092 69 67 4011
+VOLUME ["/drp-data"]
+
+ENTRYPOINT dr-provision --base-root=/drp-data --local-content= --default-content=


### PR DESCRIPTION
- Use debian-slim as a base image to avoid using alpine glibc hack.

- Use builder stage to reduce number of files in final container (only 3 binaries are copied) and reduce overall image size from 434MB to 152MB in case of linux amd64 build (uncompressed image sizes are shown).

- Make use of `ENTRYPOINT` docker directive, so container can be treated as a binary. As a benefit `dr-provision` runs with PID 1 inside a container and can accept parameters passed from command-line. For example to passing `--static-ip=10.0.0.1` to `dr-provision` command can be achieved by running:
```bash
docker run -it digitalrebar/provision:latest --static-ip=10.0.0.1
```

- `drp-data` is moved from `/provision/drp-data` to `/drp-data` and it explicit. Previous setup created `/provision/drp-data` and `/drp-data` inside a container which is confusing.

- removed variable `INSTALLDIR` as it is not needed in multi stage build

- removed variable `STATICIP` as it is not needed when using ENTRYPOINT

- final container have 3 binary files (`dr-provision`, `drbundler`, `drpcli`) placed in `/usr/bin` to conform with `man hier(7)`. Directory `/provision` is not created as it would be empty.