### PR TITLE
Remove sudo: false for travis.  It isn't supported anymore.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ addons:
   apt:
     packages:
     - bsdtar
-sudo: false
 go:
 - "1.10"
 git:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: go
 addons:
   apt:

--- a/cli/fake_cli_server_test.go
+++ b/cli/fake_cli_server_test.go
@@ -53,6 +53,7 @@ func fakeServer() error {
 		"--dhcp-port", "10004",
 		"--binl-port", "10005",
 		"--metrics-port", "10006",
+		"--static-ip", "127.0.0.1",
 		"--fake-pinger",
 		"--drp-id", "Fred",
 		"--backend", "memory:///",


### PR DESCRIPTION
This is a start to address the travis changes.

https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration