### PR TITLE
Allow template upload to replace the template.

### DIFF
--- a/api/bootenv.go
+++ b/api/bootenv.go
@@ -18,19 +18,20 @@ func (c *Client) InstallRawTemplateFromFile(src string) (*models.Template, error
 }
 
 func (c *Client) InstallRawTemplateFromFileWithId(src, tid string) (*models.Template, error) {
-	tmpl := &models.Template{ID: tid}
-	if fillErr := c.Req().Fill(tmpl); fillErr == nil {
-		return tmpl, nil
-	}
-	err := &models.Error{
-		Model: "templates",
-		Type:  "CLIENT_ERROR",
-		Key:   tid,
-	}
 	buf, readErr := ioutil.ReadFile(src)
 	if readErr != nil {
+		err := &models.Error{
+			Model: "templates",
+			Type:  "CLIENT_ERROR",
+			Key:   tid,
+		}
 		err.Errorf("Unable to import template %s", tid)
 		return nil, err
+	}
+	tmpl := &models.Template{ID: tid}
+	if fillErr := c.Req().Fill(tmpl); fillErr == nil {
+		tmpl.Contents = string(buf)
+		return tmpl, c.PutModel(tmpl)
 	}
 	tmpl.Contents = string(buf)
 	return tmpl, c.CreateModel(tmpl)

--- a/cli/test-data/output/TestTemplateCli/templates.upload.lease.go.as.greg/stdout.expect
+++ b/cli/test-data/output/TestTemplateCli/templates.upload.lease.go.as.greg/stdout.expect
@@ -1,6 +1,6 @@
 {
   "Available": true,
-  "Contents": "package cli\n\nimport (\n\t\"fmt\"\n\n\t\"github.com/digitalrebar/provision/models\"\n\t\"github.com/spf13/cobra\"\n)\n\nfunc init() {\n\taddRegistrar(registerTemplate)\n}\n\nfunc registerTemplate(app *cobra.Command) {\n\top := \u0026ops{\n\t\tname:       \"templates\",\n\t\tsingleName: \"template\",\n\t\texample:    func() models.Model { return \u0026models.Template{} },\n\t}\n\top.addCommand(\u0026cobra.Command{\n\t\tUse:   \"upload [file] as [id]\",\n\t\tShort: \"Upload the template file [file] as template [id]\",\n\t\tArgs: func(c *cobra.Command, args []string) error {\n\t\t\tif len(args) != 3 {\n\t\t\t\treturn fmt.Errorf(\"%v: expected 3 argument\", c.UseLine())\n\t\t\t}\n\t\t\treturn nil\n\t\t},\n\t\tRunE: func(c *cobra.Command, args []string) error {\n\t\t\ttmpl, err := session.InstallRawTemplateFromFileWithId(args[0], args[2])\n\t\t\tif err != nil {\n\t\t\t\treturn err\n\t\t\t}\n\t\t\treturn prettyPrint(tmpl)\n\t\t},\n\t})\n\top.command(app)\n}\n",
+  "Contents": "package cli\n\nimport (\n\t\"github.com/digitalrebar/provision/models\"\n\t\"github.com/spf13/cobra\"\n)\n\nfunc init() {\n\taddRegistrar(registerLease)\n}\n\nfunc registerLease(app *cobra.Command) {\n\top := \u0026ops{\n\t\tname:       \"leases\",\n\t\tsingleName: \"lease\",\n\t\texample:    func() models.Model { return \u0026models.Lease{} },\n\t\tnoCreate:   true,\n\t\tnoUpdate:   true,\n\t}\n\top.command(app)\n}\n",
   "Description": "",
   "Errors": [],
   "ID": "greg",


### PR DESCRIPTION
This is old code.  It worked that way when we loaded
bootenvs from scripts and directories.  We are soooo
beyond that.