### PR TITLE
Extend timeout on go unit tests.  On some systems, 10m is not enough.

### DIFF
--- a/backend/raw_model.go
+++ b/backend/raw_model.go
@@ -193,7 +193,7 @@ func (r *RawModel) OnLoad() error {
 }
 
 func (r *RawModel) Locks(action string) []string {
-	return []string{(*r.RawModel)["Type"].(string)}
+	return []string{(*r.RawModel)["Type"].(string), "profiles", "params"}
 }
 
 func (r *RawModel) MarshalJSON() ([]byte, error) {

--- a/cli/extended.go
+++ b/cli/extended.go
@@ -13,7 +13,7 @@ func registerExtended(app *cobra.Command) {
 	op := &ops{
 		name:       "extended",
 		singleName: "extended",
-		example:    func() models.Model { return &models.RawModel{} },
 	}
+	op.example = func() models.Model { return &models.RawModel{"Type": op.name} }
 	op.command(app)
 }

--- a/cli/fixInteractive.sh
+++ b/cli/fixInteractive.sh
@@ -17,7 +17,7 @@ while (( "$#" )); do
   shift
 done
 
-go test "${args[@]}" |& tee test.log
+go test -timeout 30m "${args[@]}" |& tee test.log
 
 readarray -t log_lines <test.log
 

--- a/models/raw_model.go
+++ b/models/raw_model.go
@@ -189,7 +189,7 @@ func (r *RawModel) AuthKey() string {
 }
 
 func (r *RawModel) SliceOf() interface{} {
-	return &[]RawModel{}
+	return &[]*RawModel{}
 }
 
 func (r *RawModel) ToModels(obj interface{}) []Model {

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -32,7 +32,7 @@ mv cli/fake_cli_server_test.go cli/fake_cli_server.go
 i=0
 for d in $(go list ./... 2>/dev/null | grep -v cmds) ; do
     echo "----------- TESTING $d -----------"
-    time go test -race -covermode=atomic -coverpkg=$packages -coverprofile="profile${i}.txt" "$d" || FAILED=true
+    time go test -timeout 30m -race -covermode=atomic -coverpkg=$packages -coverprofile="profile${i}.txt" "$d" || FAILED=true
     i=$((i+1))
 done
 go run tools/mergeProfiles.go profile*.txt >coverage.txt


### PR DESCRIPTION
Fix some issues with the RawModel exposed through more testing.