### PR TITLE
This completes the endpoint support.

### DIFF
--- a/api/info_test.go
+++ b/api/info_test.go
@@ -61,6 +61,8 @@ func TestInfo(t *testing.T) {
 				"sprig",
 				"multiarch",
 				"actions-in-task-list",
+				"endpoint-refs",
+				"endpoint-proxy",
 			},
 			License: models.LicenseBundle{Licenses: []models.License{}},
 			Scopes: map[string]map[string]struct{}{

--- a/backend/bootenv.go
+++ b/backend/bootenv.go
@@ -575,7 +575,9 @@ func (b *BootEnv) New() store.KeySaver {
 }
 
 func (b *BootEnv) BeforeSave() error {
-	b.Endpoint = b.rt.dt.DrpId
+	if b.Endpoint == "" {
+		b.Endpoint = b.rt.dt.DrpId
+	}
 	b.Validate()
 	if !b.Validated {
 		return b.MakeError(422, ValidationError, b)

--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -388,7 +388,9 @@ func (j *Job) OnLoad() error {
 	defer func() { j.rt = nil }()
 	j.oldState = j.State
 	j.Fill()
-	j.Endpoint = j.rt.dt.DrpId
+	if j.Endpoint == "" {
+		j.Endpoint = j.rt.dt.DrpId
+	}
 	j.SetValid()
 	j.Validate()
 	return nil
@@ -455,7 +457,9 @@ func (j *Job) Validate() {
 }
 
 func (j *Job) BeforeSave() error {
-	j.Endpoint = j.rt.dt.DrpId
+	if j.Endpoint == "" {
+		j.Endpoint = j.rt.dt.DrpId
+	}
 	j.Validate()
 	if !j.Validated {
 		return j.MakeError(422, ValidationError, j)

--- a/backend/lease.go
+++ b/backend/lease.go
@@ -235,7 +235,9 @@ func (l *Lease) Validate() {
 }
 
 func (l *Lease) BeforeSave() error {
-	l.Endpoint = l.rt.dt.DrpId
+	if l.Endpoint == "" {
+		l.Endpoint = l.rt.dt.DrpId
+	}
 	l.Validate()
 	if !l.Useable() {
 		return l.MakeError(422, ValidationError, l)

--- a/backend/machines.go
+++ b/backend/machines.go
@@ -515,7 +515,9 @@ func (n *Machine) Validate() {
 }
 
 func (n *Machine) BeforeSave() error {
-	n.Endpoint = n.rt.dt.DrpId
+	if n.Endpoint == "" {
+		n.Endpoint = n.rt.dt.DrpId
+	}
 	// Always make sure we have a secret
 	if n.Secret == "" {
 		n.Secret = randString(16)

--- a/backend/param.go
+++ b/backend/param.go
@@ -87,7 +87,9 @@ func (p *Param) Validate() {
 }
 
 func (p *Param) BeforeSave() error {
-	p.Endpoint = p.rt.dt.DrpId
+	if p.Endpoint == "" {
+		p.Endpoint = p.rt.dt.DrpId
+	}
 	p.Validate()
 	if !p.Useable() {
 		return p.MakeError(422, ValidationError, p)

--- a/backend/plugins.go
+++ b/backend/plugins.go
@@ -140,7 +140,9 @@ func (n *Plugin) Validate() {
 }
 
 func (n *Plugin) BeforeSave() error {
-	n.Endpoint = n.rt.dt.DrpId
+	if n.Endpoint == "" {
+		n.Endpoint = n.rt.dt.DrpId
+	}
 	n.Validate()
 	if !n.Useable() {
 		return n.MakeError(422, ValidationError, n)

--- a/backend/profiles.go
+++ b/backend/profiles.go
@@ -150,7 +150,9 @@ func (p *Profile) Validate() {
 }
 
 func (p *Profile) BeforeSave() error {
-	p.Endpoint = p.rt.dt.DrpId
+	if p.Endpoint == "" {
+		p.Endpoint = p.rt.dt.DrpId
+	}
 	p.Validate()
 	if !p.Useable() {
 		return p.MakeError(422, ValidationError, p)

--- a/backend/raw_model.go
+++ b/backend/raw_model.go
@@ -179,7 +179,10 @@ func (r *RawModel) Validate() {
 }
 
 func (r *RawModel) BeforeSave() error {
-	(*r.RawModel)["Endpoint"] = r.rt.dt.DrpId
+	ep, _ := (*r.RawModel).GetStringField("Endpoint")
+	if ep == "" {
+		(*r.RawModel)["Endpoint"] = r.rt.dt.DrpId
+	}
 	r.Validate()
 	if !r.Useable() {
 		return r.MakeError(422, ValidationError, r)

--- a/backend/reservation.go
+++ b/backend/reservation.go
@@ -251,7 +251,9 @@ func (r *Reservation) Validate() {
 // BeforeSave validates the object and returns an error
 // if the operation should be aborted.
 func (r *Reservation) BeforeSave() error {
-	r.Endpoint = r.rt.dt.DrpId
+	if r.Endpoint == "" {
+		r.Endpoint = r.rt.dt.DrpId
+	}
 	r.Validate()
 	if !r.Useable() {
 		return r.MakeError(422, ValidationError, r)

--- a/backend/roles.go
+++ b/backend/roles.go
@@ -113,7 +113,9 @@ func (r *Role) Validate() {
 // BeforeSave returns an error if the Role is not Valid.
 // This aborts the save to a data store.
 func (r *Role) BeforeSave() error {
-	r.Endpoint = r.rt.dt.DrpId
+	if r.Endpoint == "" {
+		r.Endpoint = r.rt.dt.DrpId
+	}
 	r.Validate()
 	if !r.Validated {
 		return r.MakeError(422, ValidationError, r)

--- a/backend/stage.go
+++ b/backend/stage.go
@@ -255,7 +255,9 @@ func (s *Stage) New() store.KeySaver {
 // BeforeSave returns an error if the Stage
 // is not valid to abort the Save.
 func (s *Stage) BeforeSave() error {
-	s.Endpoint = s.rt.dt.DrpId
+	if s.Endpoint == "" {
+		s.Endpoint = s.rt.dt.DrpId
+	}
 	s.Fill()
 	s.Validate()
 	if !s.Validated {

--- a/backend/subnet.go
+++ b/backend/subnet.go
@@ -639,7 +639,9 @@ func (s *Subnet) OnChange(old store.KeySaver) error {
 // BeforeSave returns an error if the subnet is not valid.  This
 // is used by the store system to avoid saving bad Subnets.
 func (s *Subnet) BeforeSave() error {
-	s.Endpoint = s.rt.dt.DrpId
+	if s.Endpoint == "" {
+		s.Endpoint = s.rt.dt.DrpId
+	}
 	s.Validate()
 	if !s.Useable() {
 		return s.MakeError(422, ValidationError, s)

--- a/backend/task.go
+++ b/backend/task.go
@@ -137,7 +137,9 @@ func (t *Task) OnLoad() error {
 // BeforeSave makes sure the Task is valid and returns an error if not.
 // This is used to abort saving invalid objects.
 func (t *Task) BeforeSave() error {
-	t.Endpoint = t.rt.dt.DrpId
+	if t.Endpoint == "" {
+		t.Endpoint = t.rt.dt.DrpId
+	}
 	t.Validate()
 	if !t.HasFeature("sane-exit-codes") {
 		t.AddFeature("original-exit-codes")

--- a/backend/template.go
+++ b/backend/template.go
@@ -138,7 +138,9 @@ func (t *Template) Validate() {
 // BeforeSave makes sure that the template is valid and returns
 // an error otherwise.
 func (t *Template) BeforeSave() error {
-	t.Endpoint = t.rt.dt.DrpId
+	if t.Endpoint == "" {
+		t.Endpoint = t.rt.dt.DrpId
+	}
 	t.Validate()
 	if !t.Useable() {
 		return t.MakeError(422, ValidationError, t)

--- a/backend/tenants.go
+++ b/backend/tenants.go
@@ -113,7 +113,9 @@ func (t *Tenant) Validate() {
 // also responsible for validating User membership is valid.
 // todo: Actually validate that all the items the Tenant references still exist.
 func (t *Tenant) BeforeSave() error {
-	t.Endpoint = t.rt.dt.DrpId
+	if t.Endpoint == "" {
+		t.Endpoint = t.rt.dt.DrpId
+	}
 	t.Validate()
 	if !t.Validated {
 		return t.MakeError(422, ValidationError, t)

--- a/backend/user.go
+++ b/backend/user.go
@@ -157,7 +157,9 @@ func (u *User) GenClaim(grantor string, ttl time.Duration, wantedRoles ...string
 // BeforeSave validates and sets required fields
 // on the User object before savining.
 func (u *User) BeforeSave() error {
-	u.Endpoint = u.rt.dt.DrpId
+	if u.Endpoint == "" {
+		u.Endpoint = u.rt.dt.DrpId
+	}
 	if u.Secret == "" {
 		u.Secret = randString(16)
 	}

--- a/backend/workflow.go
+++ b/backend/workflow.go
@@ -107,7 +107,9 @@ func (w *Workflow) Validate() {
 // when an object needs to initialized and
 // validated.
 func (w *Workflow) BeforeSave() error {
-	w.Endpoint = w.rt.dt.DrpId
+	if w.Endpoint == "" {
+		w.Endpoint = w.rt.dt.DrpId
+	}
 	w.Fill()
 	w.Validate()
 	if !w.Validated {

--- a/cli/test-data/output/TestAuth/info.get/stdout.expect
+++ b/cli/test-data/output/TestAuth/info.get/stdout.expect
@@ -70,7 +70,9 @@ RE:
     "secure-param-upgrade",
     "sprig",
     "multiarch",
-    "actions-in-task-list"
+    "actions-in-task-list",
+    "endpoint-refs",
+    "endpoint-proxy"
   \],
   "file_port": 10002,
   "id": "Fred",
@@ -287,5 +289,5 @@ RE:
   \],
   "tftp_enabled": true,
   "tftp_port": 10003,
-  "version": "v3.0.2-pre-alpha-NotSet"
+  "version": "v3.8.2-pre-alpha-NotSet"
 }

--- a/cli/test-data/output/TestAuth/plugin_providers.list.611601b3efac342fd10027372140fe8c/stdout.expect
+++ b/cli/test-data/output/TestAuth/plugin_providers.list.611601b3efac342fd10027372140fe8c/stdout.expect
@@ -51,6 +51,6 @@
         }
       }
     },
-    "Version": "v3.0.2-pre-alpha-NotSet"
+    "Version": "v3.8.2-pre-alpha-NotSet"
   }
 ]

--- a/cli/test-data/output/TestAuth/plugin_providers.list.e8e0775e692adbcb8acdf3799178655c/stdout.expect
+++ b/cli/test-data/output/TestAuth/plugin_providers.list.e8e0775e692adbcb8acdf3799178655c/stdout.expect
@@ -51,6 +51,6 @@
         }
       }
     },
-    "Version": "v3.0.2-pre-alpha-NotSet"
+    "Version": "v3.8.2-pre-alpha-NotSet"
   }
 ]

--- a/cli/test-data/output/TestCorePieces/b3a8098dcd1bdc402b5f826708863989/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/b3a8098dcd1bdc402b5f826708863989/stdout.expect
@@ -1,1 +1,1 @@
-Version: v3.0.2-pre-alpha-NotSet
+Version: v3.8.2-pre-alpha-NotSet

--- a/cli/test-data/output/TestPluginProviderCli/plugin_providers.list.3/stdout.expect
+++ b/cli/test-data/output/TestPluginProviderCli/plugin_providers.list.3/stdout.expect
@@ -51,6 +51,6 @@
         }
       }
     },
-    "Version": "v3.0.2-pre-alpha-NotSet"
+    "Version": "v3.8.2-pre-alpha-NotSet"
   }
 ]

--- a/cli/test-data/output/TestPluginProviderCli/plugin_providers.list/stdout.expect
+++ b/cli/test-data/output/TestPluginProviderCli/plugin_providers.list/stdout.expect
@@ -51,6 +51,6 @@
         }
       }
     },
-    "Version": "v3.0.2-pre-alpha-NotSet"
+    "Version": "v3.8.2-pre-alpha-NotSet"
   }
 ]

--- a/cli/test-data/output/TestPluginProviderCli/plugin_providers.show.incrementer/stdout.expect
+++ b/cli/test-data/output/TestPluginProviderCli/plugin_providers.show.incrementer/stdout.expect
@@ -50,5 +50,5 @@
       }
     }
   },
-  "Version": "v3.0.2-pre-alpha-NotSet"
+  "Version": "v3.8.2-pre-alpha-NotSet"
 }

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
@@ -31,7 +31,9 @@ RE:
       "secure-param-upgrade",
       "sprig",
       "multiarch",
-      "actions-in-task-list"
+      "actions-in-task-list",
+      "endpoint-refs",
+      "endpoint-proxy"
     \],
     "file_port": 10002,
     "id": "Fred",
@@ -239,6 +241,6 @@ RE:
     \],
     "tftp_enabled": true,
     "tftp_port": 10003,
-    "version": "v3.0.2-pre-alpha-NotSet"
+    "version": "v3.8.2-pre-alpha-NotSet"
   \},
 \}

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
@@ -31,7 +31,9 @@ RE:
       "secure-param-upgrade",
       "sprig",
       "multiarch",
-      "actions-in-task-list"
+      "actions-in-task-list",
+      "endpoint-refs",
+      "endpoint-proxy"
     \],
     "file_port": 10002,
     "id": "Fred",
@@ -239,6 +241,6 @@ RE:
     \],
     "tftp_enabled": true,
     "tftp_port": 10003,
-    "version": "v3.0.2-pre-alpha-NotSet"
+    "version": "v3.8.2-pre-alpha-NotSet"
   \},
 \}

--- a/frontend/actions.go
+++ b/frontend/actions.go
@@ -59,6 +59,9 @@ func (f *Frontend) makeActionEndpoints(cmdSet string, obj models.Model, idKey st
 			if ref == nil {
 				return
 			}
+			if fok, mok := f.processRequestWithForwarding(c, ref, nil); fok || mok {
+				return
+			}
 			p := plugin(c)
 			for _, laa := range f.pc.Actions.List(cmdSet) {
 				for _, aa := range laa {
@@ -89,6 +92,9 @@ func (f *Frontend) makeActionEndpoints(cmdSet string, obj models.Model, idKey st
 			}
 			ref := f.Find(c, rt, obj.Prefix(), id)
 			if ref == nil {
+				return
+			}
+			if fok, mok := f.processRequestWithForwarding(c, ref, nil); fok || mok {
 				return
 			}
 			err := &models.Error{
@@ -129,6 +135,9 @@ func (f *Frontend) makeActionEndpoints(cmdSet string, obj models.Model, idKey st
 			}
 			ref := f.Find(c, rt, obj.Prefix(), id)
 			if ref == nil {
+				return
+			}
+			if fok, mok := f.processRequestWithForwarding(c, ref, val); fok || mok {
 				return
 			}
 			res := &models.Action{

--- a/frontend/endpoint.go
+++ b/frontend/endpoint.go
@@ -1,0 +1,134 @@
+package frontend
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+
+	"github.com/digitalrebar/provision/backend"
+	"github.com/digitalrebar/provision/models"
+	"github.com/galthaus/gzip"
+	"github.com/gin-gonic/gin"
+)
+
+func (fe *Frontend) getEndpoint(c *gin.Context, id string) *backend.RawModel {
+	ots := fe.dt.GetObjectTypes()
+	found := false
+	for _, ot := range ots {
+		if ot == "endpoints" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil
+	}
+	rt := fe.rt(c, "endpoints")
+	var res *backend.RawModel
+	rt.Do(func(d backend.Stores) {
+		if u := rt.Find("endpoints", id); u != nil {
+			res = u.(*backend.RawModel)
+		}
+	})
+	return res
+}
+
+func (fe *Frontend) getEndpointUrl(c *gin.Context, id string) (string, bool) {
+	if res := fe.getEndpoint(c, id); res != nil {
+		return res.GetStringField("URL")
+	}
+	return "", false
+}
+
+func (fe *Frontend) forwardRequest(c *gin.Context, id, rest string, newBody interface{}) bool {
+	if ep, ok := fe.getEndpointUrl(c, id); ok {
+		// parse the url
+		turl, _ := url.Parse(ep)
+
+		// create the reverse proxy
+		proxy := httputil.NewSingleHostReverseProxy(turl)
+		proxy.Transport = &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, // client uses self-signed cert
+		}
+
+		// Update the headers to allow for SSL redirection
+		req := c.Request
+		req.URL.Host = turl.Host
+		req.URL.Scheme = turl.Scheme
+		if rest != "" {
+			req.URL.Path = rest
+		}
+		req.Header.Set("X-Forwarded-Host", req.Header.Get("Host"))
+		req.Host = turl.Host
+
+		if newBody != nil {
+			jstr, jerr := json.Marshal(newBody)
+			if jerr != nil {
+				err := &models.Error{
+					Model:    "endpoints", // XXX: This is not right.
+					Key:      id,
+					Code:     http.StatusBadRequest,
+					Type:     c.Request.Method,
+					Messages: []string{jerr.Error()},
+				}
+				c.AbortWithStatusJSON(err.Code, err)
+				return true
+			}
+			if req.Body != nil {
+				req.Body.Close()
+			}
+			req.Body = ioutil.NopCloser(bytes.NewReader([]byte(jstr)))
+			req.ContentLength = int64(len([]byte(jstr)))
+		}
+
+		// Remove Writer Headers - let the caller put them in.
+		c.Writer.Header().Del("Access-Control-Allow-Credentials")
+		c.Writer.Header().Del("Access-Control-Expose-Headers")
+		c.Writer.Header().Del("Access-Control-Allow-Origin")
+
+		if gzw, ok := c.Writer.(*gzip.GzipWriter); ok {
+			gzw.SetSkipCompression(c)
+		}
+
+		// Note that ServeHttp is non blocking and uses a go routine under the hood
+		proxy.ServeHTTP(c.Writer, req)
+		return true
+	}
+	return false
+}
+
+//
+// This returns two bools.  If either is true, the call should just return.
+// First bool is forwarded or not.
+// Second bool is true if the object is not yours and an error was returned.
+//
+func (fe *Frontend) processRequestWithForwarding(c *gin.Context, obj interface{}, newBody interface{}) (bool, bool) {
+	// Should we proxy this - manager plugin sends with true.
+	if v, ok := c.GetQuery("noproxy"); ok && v == "true" {
+		return false, false
+	}
+	mobj, _ := obj.(models.Model)
+	if owned, ook := mobj.(models.Owner); ook {
+		owner := owned.GetEndpoint()
+		if owner == "" || owner == fe.DrpId {
+			return false, false // This is mine, don't forward.
+		}
+		if fok := fe.forwardRequest(c, owned.GetEndpoint(), "", newBody); fok {
+			return true, true // forwarded and not mine
+		}
+		err := &models.Error{
+			Model:    mobj.Prefix(),
+			Key:      mobj.Key(),
+			Code:     http.StatusNotFound,
+			Type:     c.Request.Method,
+			Messages: []string{"Not Found"},
+		}
+		c.AbortWithStatusJSON(err.Code, err)
+		return false, true // This is not forward, but is also not mine.
+	}
+	return false, false // Not forwarded and mine (likely)
+}

--- a/frontend/info.go
+++ b/frontend/info.go
@@ -18,10 +18,10 @@ type InfoResponse struct {
 	Body *models.Info
 }
 
-func (f *Frontend) GetInfo(c *gin.Context, drpid string) (*models.Info, *models.Error) {
+func (f *Frontend) GetInfo(c *gin.Context) (*models.Info, *models.Error) {
 	i := &models.Info{
 		Version:            provision.RSVersion,
-		Id:                 drpid,
+		Id:                 f.DrpId,
 		ApiPort:            f.ApiPort,
 		FilePort:           f.ProvPort,
 		TftpPort:           f.TftpPort,
@@ -62,7 +62,7 @@ func (f *Frontend) GetInfo(c *gin.Context, drpid string) (*models.Info, *models.
 	return i, res
 }
 
-func (f *Frontend) InitInfoApi(drpid string) {
+func (f *Frontend) InitInfoApi() {
 	// swagger:route GET /info Info getInfo
 	//
 	// Return current system info.
@@ -80,7 +80,7 @@ func (f *Frontend) InitInfoApi(drpid string) {
 			if !f.assureSimpleAuth(c, "info", "get", "") {
 				return
 			}
-			info, err := f.GetInfo(c, drpid)
+			info, err := f.GetInfo(c)
 			if err != nil {
 				c.JSON(err.Code, err)
 				return

--- a/frontend/users.go
+++ b/frontend/users.go
@@ -137,7 +137,7 @@ type UserActionBodyParameter struct {
 	Body map[string]interface{}
 }
 
-func (f *Frontend) InitUserApi(drpid string) {
+func (f *Frontend) InitUserApi() {
 	// swagger:route GET /users Users listUsers
 	//
 	// Lists Users filtered by some parameters.
@@ -346,7 +346,7 @@ func (f *Frontend) InitUserApi(drpid string) {
 			} else {
 				// Error is only if stats are not filled in.  User
 				// Token should work regardless of that.
-				info, _ := f.GetInfo(c, drpid)
+				info, _ := f.GetInfo(c)
 				if info != nil {
 					if a, _, e := net.SplitHostPort(c.Request.RemoteAddr); e == nil {
 						info.Address = backend.LocalFor(f.l(c), net.ParseIP(a))

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
 hash: 4be4cf0b50b99d5118776bab2457d8f82e4997456ddfefd0880518368d040c15
-updated: 2019-01-09T14:14:54.011795-06:00
+updated: 2019-01-19T13:11:09.851903-06:00
 imports:
 - name: github.com/aokoli/goutils
   version: 3391d3790d23d03408670993e957e8f408993c34
@@ -37,6 +37,8 @@ imports:
   version: 28a8a89db0e1201d1b61b8ee90597fd7d035c0d5
 - name: github.com/fsnotify/fsnotify
   version: c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9
+- name: github.com/galthaus/gzip
+  version: cfbca743ba8cc91ec4167e8a6c44626c5fad7288
 - name: github.com/ghodss/yaml
   version: e9ed3c6dfb39bb1a32197cb10d527906fe4da4b6
 - name: github.com/gin-contrib/cors

--- a/models/info.go
+++ b/models/info.go
@@ -84,6 +84,8 @@ func (i *Info) Fill() {
 			"sprig",
 			"multiarch",
 			"actions-in-task-list",
+			"endpoint-refs",
+			"endpoint-proxy",
 		}
 	}
 }

--- a/models/raw_model.go
+++ b/models/raw_model.go
@@ -20,7 +20,18 @@ func (r *RawModel) IsReadOnly() bool {
 
 // Owner Interface
 func (r *RawModel) GetEndpoint() string {
-	return (*r)["Endpoint"].(string)
+	sobj, _ := r.GetStringField("Endpoint")
+	return sobj
+}
+
+// Helpers to get fields
+func (r *RawModel) GetStringField(field string) (string, bool) {
+	if val, ok := (*r)[field]; ok {
+		if sval, ok := val.(string); ok {
+			return sval, true
+		}
+	}
+	return "", false
 }
 
 // Validator Interface

--- a/version.go
+++ b/version.go
@@ -10,7 +10,7 @@ var RSPrePart = "v"
 var RSMajorVersion = "3"
 
 // RSMinorVersion is the second number of SemVer
-var RSMinorVersion = "0"
+var RSMinorVersion = "8"
 
 // RSPatchVersion is the third number of SemVer
 var RSPatchVersion = "2"


### PR DESCRIPTION
With this change, DRP tags all objects as to their
owner.  The endpoint field in the objects is stored
and propagated through events.