### PR TITLE
fix install.sh isolated mode for 'drpjoin' already exists

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -479,7 +479,7 @@ case $MODE in
                  TFTP_DIR="`pwd`/drp-data/tftpboot"
 
                  # Make local links for execs
-                 rm -f drpcli dr-provision drbundler
+                 rm -f drpcli dr-provision drbundler drpjoin
                  ln -s $binpath/drpcli drpcli
                  ln -s $binpath/dr-provision dr-provision
                  if [[ -e $binpath/drbundler ]] ; then


### PR DESCRIPTION
On upgrading an isolated mode DRP endpoint, the symbolic linking for `drpjoin` fails since the target exists already.  Remove the target first (as per existing behavior for `dr-provision`, `drpcli`, etc).