### PR TITLE
add Param for HTTP location in boot.cfg

### DIFF
--- a/embedded/assets/make-esxi-bootenv.sh
+++ b/embedded/assets/make-esxi-bootenv.sh
@@ -150,17 +150,20 @@ then
 fi
 
 # generic fixups
-[[ "$TITLE" =~ esxi-.* ]] || TITLE="esxi-$TITLE"
 TITLE=$(echo $TITLE | sed 's/^[-_~\.*\*]*\(.*\)[-_~\.*\*]/\1/')
+[[ "$TITLE" =~ ^esxi-.* ]] || TITLE="esxi-$TITLE"
 
 BUNDLE="$BLD/vmware-$TITLE.yaml"
 
+echo ""
 echo "Setting DRP Content build directory to:  $BLD"
 echo "FINAL DRP Content TITLE set to:  $TITLE"
+echo ""
 
 ###
 #  Build our content meta info files
 ###
+echo "Building meta data files for content bundle ... "
 printf "RackN, Inc." > ${BLD}/._Author.meta
 printf "https://github.com/rackn/provision-content" > ${BLD}/._CodeSource.meta
 printf "black" > ${BLD}/._Color.meta
@@ -227,12 +230,18 @@ Templates:
   - ID: esxi-pxelinux.tmpl
     Name: pxelinux-chain
     Path: '{{.Env.PathFor "tftp" ""}}/pxelinux.cfg/{{.Machine.HexAddress}}'
+  - ID: esxi-pxelinux.tmpl
+    Name: pxelinux-chain-mac
+    Path: '{{.Env.PathFor "tftp" ""}}/pxelinux.cfg/{{.Machine.MacAddr "pxelinux"}}'
   - ID: esxi-install-py3.ks.tmpl
     Name: compute.ks
     Path: '{{.Machine.Path}}/compute.ks'
   - ID: $TITLE.boot.cfg.tmpl
     Name: boot.cfg
     Path: '{{.Env.PathFor "tftp" ""}}/{{.Machine.Path}}/boot.cfg'
+  - ID: $TITLE.boot.cfg.tmpl
+    Name: boot-uefi.cfg
+    Path: '{{.Machine.Path}}/boot.cfg'
 BENV
 
 echo "Built DRP BootEnv template file '$T_YAML'"

--- a/embedded/assets/make-esxi-bootenv.sh
+++ b/embedded/assets/make-esxi-bootenv.sh
@@ -250,7 +250,7 @@ cat <<BOOT > $B_TMPL
 bootstate=0
 title=Loading ESXi installer for $TITLE
 timeout=2
-prefix=/
+prefix={{ template "esxi-get-http-mirror.tmpl" . }}
 kernel=$KERNEL
 kernelopt=ks={{.Machine.Url}}/compute.ks{{if .ParamExists "kernel-options"}} {{.Param "kernel-options"}}{{end}}{{if .ParamExists "esxi/serial-console"}} {{.Param "esxi/serial-console"}}{{end}}
 build=


### PR DESCRIPTION
- adds template piece for `boot.cfg` HTTP location
- add mac based pxelinux render
- fix naming regex logic