### PR TITLE
Make drpcli running in agent mode honor runner-tmpdir

### DIFF
--- a/api/agent.go
+++ b/api/agent.go
@@ -102,15 +102,15 @@ func (c *Client) NewAgent(m *models.Machine,
 			if err = os.Setenv("TMP", td); err != nil {
 				return nil, err
 			}
-			runnerDir, err := ioutil.TempDir("", "runner-")
-			if err != nil {
-				return nil, err
-			}
-			if err := os.Setenv("RS_RUNNER_DIR", runnerDir); err != nil {
-				return nil, err
-			}
-			res.runnerDir = runnerDir
 		}
+		runnerDir, err := ioutil.TempDir("", "runner-")
+		if err != nil {
+			return nil, err
+		}
+		if err := os.Setenv("RS_RUNNER_DIR", runnerDir); err != nil {
+			return nil, err
+		}
+		res.runnerDir = runnerDir
 	}
 	if !rdExists {
 		if err := os.MkdirAll(res.runnerDir, 0755); err != nil {

--- a/api/jobs.go
+++ b/api/jobs.go
@@ -165,7 +165,7 @@ func (r *TaskRunner) Perform(action *models.JobAction, taskDir string) error {
 	cmdArray = append(cmdArray, "./"+path.Base(taskFile))
 	cmd := exec.Command(cmdArray[0], cmdArray[1:]...)
 	cmd.Dir = taskDir
-	cmd.Env = append(os.Environ(), "RS_TASK_DIR="+taskDir, "RS_RUNNER_DIR="+r.agentDir)
+	cmd.Env = append(os.Environ(), "RS_TASK_DIR="+taskDir)
 	for _, e := range []string{"RS_UUID", "RS_ENDPOINT", "RS_TOKEN"} {
 		if os.Getenv(e) == "" {
 			switch e {

--- a/api/mktd.go
+++ b/api/mktd.go
@@ -1,0 +1,12 @@
+// +build !windows,!plan9
+
+package api
+
+import "os"
+import "golang.org/x/sys/unix"
+
+func mktd(p string) error {
+	umask := unix.Umask(0)
+	defer unix.Umask(umask)
+	return os.MkdirAll(p, 0777|os.ModeSticky)
+}

--- a/api/mktd_other.go
+++ b/api/mktd_other.go
@@ -1,0 +1,9 @@
+// +build windows plan9
+
+package api
+
+import "os"
+
+func mktd(p string) error {
+	return os.MkdirAll(p, 01777)
+}


### PR DESCRIPTION
If runner-tmpdir is defined on a machine, the runner will create and
use it in preference to the system default temporary directory.