### PR TITLE
Move agent out of the API.

### DIFF
--- a/agent/00_agent_test.go
+++ b/agent/00_agent_test.go
@@ -1,0 +1,272 @@
+package agent
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"os/exec"
+	"path"
+	"reflect"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/digitalrebar/logger"
+	"github.com/digitalrebar/provision/api"
+	"github.com/digitalrebar/provision/backend"
+	"github.com/digitalrebar/provision/embedded"
+	"github.com/digitalrebar/provision/midlayer"
+	"github.com/digitalrebar/provision/models"
+	"github.com/digitalrebar/provision/server"
+	"github.com/digitalrebar/yaml"
+	"github.com/jessevdk/go-flags"
+)
+
+var (
+	tmpDir              string
+	myToken             string
+	session             *api.Client
+	actuallyPowerThings = false
+)
+
+type crudTest struct {
+	name      string
+	expectRes interface{}
+	expectErr error
+	op        func() (interface{}, error)
+	clean     func()
+}
+
+func (l crudTest) run(t *testing.T) {
+	t.Helper()
+	t.Logf("Testing %s", l.name)
+	session.TraceToken(l.name)
+	if l.clean != nil {
+		defer l.clean()
+	}
+	res, err := l.op()
+	if l.expectErr == nil {
+		if err == nil {
+			if equal, delta := apiDiff(res, l.expectRes); !equal {
+				t.Errorf("ERROR: Unexpected result:\n%s\n\nDiff:%s",
+					pretty(res),
+					delta)
+			} else {
+				t.Logf("Got expected results")
+			}
+		} else {
+			t.Errorf("ERROR: Got unexpected error: %#v", err)
+		}
+	} else {
+		if err == nil {
+			t.Errorf("ERROR: Did not get expected error %v", l.expectErr)
+			t.Errorf("Got result: %v", pretty(res))
+		} else if !reflect.DeepEqual(err, l.expectErr) {
+			t.Errorf("ERROR: Expected error %#v", l.expectErr)
+			t.Errorf("Got error %#v", err)
+		} else {
+			t.Logf("Got expected error %v", err)
+		}
+	}
+	session.TraceToken("")
+}
+
+func rt(t *testing.T,
+	name string,
+	res interface{},
+	err error,
+	op func() (interface{}, error),
+	clean func()) {
+	t.Helper()
+	ct := crudTest{
+		name:      name,
+		expectRes: res,
+		expectErr: err,
+		op:        op,
+		clean:     clean,
+	}
+	ct.run(t)
+}
+
+func testFill(m models.Model) {
+	if f, ok := m.(models.Filler); ok {
+		f.Fill()
+	}
+	if v, ok := m.(models.ValidateSetter); ok {
+		v.SetValid()
+		v.SetAvailable()
+	}
+}
+
+func mustDecode(ref interface{}, obj string) interface{} {
+	if err := api.DecodeYaml([]byte(obj), ref); err != nil {
+		log.Panicf("Failed to decode: %v", err)
+	}
+	if tgt, ok := ref.(models.Model); ok {
+		testFill(tgt)
+	}
+	return ref
+}
+
+func pretty(i interface{}) string {
+	if s, k := i.(string); k {
+		return s
+	}
+	buf, err := yaml.Marshal(i)
+	if err != nil {
+		log.Panicf("Error unmarshalling: %v", err)
+	}
+	return string(buf)
+}
+
+func apiDiff(expected, got interface{}) (bool, string) {
+	a, b := pretty(expected), pretty(got)
+	f1, err := ioutil.TempFile("", "expected-api")
+	if err != nil {
+		log.Panicf("Failed to create tempfile1: %v", err)
+	}
+	defer f1.Close()
+	defer os.Remove(f1.Name())
+	f2, err := ioutil.TempFile("", "got-api")
+	if err != nil {
+		log.Panicf("Failed to create tempfile2: %v", err)
+	}
+	defer f2.Close()
+	defer os.Remove(f2.Name())
+	if _, err := io.WriteString(f1, a); err != nil {
+		log.Panicf("Failed to write tempfile1: %v", err)
+	}
+	if _, err := io.WriteString(f2, b); err != nil {
+		log.Panicf("Failed to write tempfile2: %v", err)
+	}
+	cmd := exec.Command("diff", "-u", f1.Name(), f2.Name())
+	res, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, string(res)
+	}
+	if es, ok := err.(*exec.ExitError); ok {
+		if ec, ok := es.Sys().(syscall.WaitStatus); ok {
+			if ec.ExitStatus() == 1 {
+				return false, string(res)
+			}
+		}
+	}
+	log.Panicf("diff encountered an error: %v", err)
+	return cmd.ProcessState.Success(), string(res)
+}
+
+func generateArgs(args []string) *server.ProgOpts {
+	var c_opts server.ProgOpts
+
+	parser := flags.NewParser(&c_opts, flags.Default)
+	if _, err := parser.ParseArgs(args); err != nil {
+		if flagsErr, ok := err.(*flags.Error); ok && flagsErr.Type == flags.ErrHelp {
+			os.Exit(0)
+		} else {
+			os.Exit(1)
+		}
+	}
+
+	return &c_opts
+}
+
+func fakeServer() error {
+	var err error
+
+	os.Setenv("RS_TOKEN_PATH", path.Join(tmpDir, "tokens"))
+	os.Setenv("RS_ENDPOINT", "https://127.0.0.1:10001")
+
+	testArgs := []string{
+		"--base-root", tmpDir,
+		"--tls-key", tmpDir + "/server.key",
+		"--tls-cert", tmpDir + "/server.crt",
+		"--api-port", "10001",
+		"--static-port", "10002",
+		"--tftp-port", "10003",
+		"--dhcp-port", "10004",
+		"--binl-port", "10005",
+		"--metrics-port", "10006",
+		"--static-ip", "127.0.0.1",
+		"--fake-pinger",
+		"--no-watcher",
+		"--drp-id", "Fred",
+		"--backend", "memory:///",
+		"--plugin-comm-root", "/tmp",
+		"--local-content", "directory:../test-data/etc/dr-provision?codec=yaml",
+		"--default-content", "file:../test-data/usr/share/dr-provision/default.yaml?codec=yaml",
+		"--base-token-secret", "token-secret-token-secret-token1",
+		"--system-grantor-secret", "system-grantor-secret",
+	}
+
+	err = os.MkdirAll(tmpDir+"/plugins", 0755)
+	if err != nil {
+		log.Printf("Error creating required directory %s: %v", tmpDir, err)
+		return err
+	}
+
+	out, err := exec.Command("go", "generate", "../cmds/incrementer/incrementer.go").CombinedOutput()
+	if err != nil {
+		log.Printf("Failed to generate incrementer plugin: %v, %s", err, string(out))
+		return err
+	}
+
+	out, err = exec.Command("go", "build", "-o", tmpDir+"/plugins/incrementer", "../cmds/incrementer/incrementer.go", "../cmds/incrementer/content.go").CombinedOutput()
+	if err != nil {
+		log.Printf("Failed to build incrementer plugin: %v, %s", err, string(out))
+		return err
+	}
+
+	embedded.IncludeMeFunction()
+
+	c_opts := generateArgs(testArgs)
+	go server.Server(c_opts)
+	count := 0
+	for count < 30 {
+		var apierr error
+		session, apierr = api.UserSession("https://127.0.0.1:10001", "rocketskates", "r0cketsk8ts")
+		if apierr == nil {
+			break
+		}
+		count++
+		time.Sleep(1 * time.Second)
+	}
+	if session == nil {
+		return fmt.Errorf("Server failed to start in time allowed")
+	} else {
+		log.Printf("Server started after %d seconds", count)
+		myToken = session.Token()
+		session.Close()
+		session = nil
+		midlayer.ServeStatic("127.0.0.1:10003",
+			backend.NewFS("test-data", nil),
+			logger.New(nil).Log(""),
+			backend.NewPublishers(nil))
+	}
+	return nil
+}
+
+func TestMain(m *testing.M) {
+	var err error
+	actuallyPowerThings = false
+
+	tmpDir, err = ioutil.TempDir("", "cli-")
+	if err != nil {
+		log.Printf("Creating temp dir for file root failed: %v", err)
+		os.Exit(1)
+	}
+	err = fakeServer()
+	if err != nil {
+		log.Fatalf("Failed with error: %v", err)
+	}
+
+	ret := m.Run()
+
+	err = os.RemoveAll(tmpDir)
+	if err != nil {
+		log.Printf("Removing temp dir for file root failed: %v", err)
+		os.Exit(1)
+	}
+	os.Exit(ret)
+}

--- a/agent/change_stage_test.go
+++ b/agent/change_stage_test.go
@@ -1,10 +1,11 @@
-package api
+package agent
 
 import (
 	"io/ioutil"
 	"os"
 	"testing"
 
+	"github.com/digitalrebar/provision/api"
 	"github.com/digitalrebar/provision/models"
 )
 
@@ -16,6 +17,14 @@ func TestChangeStage(t *testing.T) {
 	}
 	defer os.RemoveAll(tjd)
 	os.Setenv("JT", tjd)
+	if session == nil {
+		session, err = api.UserSession("https://127.0.0.1:10001", "rocketskates", "r0cketsk8ts")
+		if err != nil {
+			t.Errorf("Error creating session: %v", err)
+			return
+		}
+		defer func() { session = nil }()
+	}
 
 	machine1 := mustDecode(&models.Machine{}, `
 Address: 192.168.100.110

--- a/agent/chroot_linux.go
+++ b/agent/chroot_linux.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package api
+package agent
 
 import (
 	"os"
@@ -27,11 +27,11 @@ func bindMount(newRoots string, srcFS ...string) error {
 	return nil
 }
 
-func (r *TaskRunner) bindFSes() []string {
+func (r *runner) bindFSes() []string {
 	return []string{"/proc", "/sys", "/dev", "/dev/pts", r.agentDir}
 }
 
-func (r *TaskRunner) enterChroot(cmd *exec.Cmd) error {
+func (r *runner) enterChroot(cmd *exec.Cmd) error {
 	if r.chrootDir == "" {
 		return nil
 	}
@@ -42,7 +42,7 @@ func (r *TaskRunner) enterChroot(cmd *exec.Cmd) error {
 	return nil
 }
 
-func (r *TaskRunner) exitChroot() {
+func (r *runner) exitChroot() {
 	if r.chrootDir == "" {
 		return
 	}

--- a/agent/chroot_other.go
+++ b/agent/chroot_other.go
@@ -1,6 +1,6 @@
 // +build !linux
 
-package api
+package agent
 
 import (
 	"fmt"
@@ -8,11 +8,11 @@ import (
 	"runtime"
 )
 
-func (r *TaskRunner) enterChroot(cmd *exec.Cmd) error {
+func (r *runner) enterChroot(cmd *exec.Cmd) error {
 	if r.chrootDir != "" {
 		return fmt.Errorf("enterChroot not supported on %v", runtime.GOOS)
 	}
 	return nil
 }
 
-func (r *TaskRunner) exitChroot() {}
+func (r *runner) exitChroot() {}

--- a/agent/cmdHelper.go
+++ b/agent/cmdHelper.go
@@ -1,4 +1,4 @@
-package api
+package agent
 
 var cmdHelper = []byte(`
 #!/bin/bash

--- a/agent/mktd.go
+++ b/agent/mktd.go
@@ -1,6 +1,6 @@
 // +build !windows,!plan9
 
-package api
+package agent
 
 import "os"
 import "golang.org/x/sys/unix"

--- a/agent/mktd_other.go
+++ b/agent/mktd_other.go
@@ -1,6 +1,6 @@
 // +build windows plan9
 
-package api
+package agent
 
 import "os"
 

--- a/agent/taskRunner_test.go
+++ b/agent/taskRunner_test.go
@@ -1,4 +1,4 @@
-package api
+package agent
 
 import (
 	"bytes"
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitalrebar/provision/api"
 	"github.com/digitalrebar/provision/models"
 )
 
@@ -29,7 +30,7 @@ func runAgent(t *testing.T, mi *models.Machine, lastTask, lastState, lastExitSta
 	}
 
 	buf := &bytes.Buffer{}
-	agent, err := session.NewAgent(m, true, true, false, io.MultiWriter(buf, os.Stderr))
+	agent, err := New(session, m, true, true, false, io.MultiWriter(buf, os.Stderr))
 	if err != nil {
 		t.Errorf("ERROR: Agent create failed: %v", err)
 	}
@@ -68,6 +69,14 @@ func TestJobs(t *testing.T) {
 	}
 	defer os.RemoveAll(tjd)
 	os.Setenv("JT", tjd)
+	if session == nil {
+		session, err = api.UserSession("https://127.0.0.1:10001", "rocketskates", "r0cketsk8ts")
+		if err != nil {
+			t.Errorf("Error creating session: %v", err)
+			return
+		}
+		defer func() { session = nil }()
+	}
 	machine1 := mustDecode(&models.Machine{}, `
 Address: 192.168.100.110
 BootEnv: local

--- a/cli/common_test.go
+++ b/cli/common_test.go
@@ -470,6 +470,7 @@ func TestCorePieces(t *testing.T) {
 func TestMain(m *testing.M) {
 	var err error
 	actuallyPowerThings = false
+	defaultStateLoc = ""
 
 	tmpDir, err = ioutil.TempDir("", "cli-")
 	if err != nil {

--- a/cli/test-data/output/TestProcessJobsCli/machines.processjobs.b98773fd65e6e32eee9e8a357b6a3e55/stderr.expect
+++ b/cli/test-data/output/TestProcessJobsCli/machines.processjobs.b98773fd65e6e32eee9e8a357b6a3e55/stderr.expect
@@ -6,6 +6,7 @@ Flags:
       --exit-on-failure   Exit on failure of a task
   -h, --help              help for processjobs
       --oneshot           Do not wait for additional tasks to appear
+      --stateDir string   Location to save agent runtime state
 
 Global Flags:
   -c, --catalog string      The catalog file to use to get product information (default "https://repo.rackn.io")

--- a/cli/test-data/output/TestProcessJobsCli/machines.processjobs.p1.p2.p3.b98773fd65e6e32eee9e8a357b6a3e55/stderr.expect
+++ b/cli/test-data/output/TestProcessJobsCli/machines.processjobs.p1.p2.p3.b98773fd65e6e32eee9e8a357b6a3e55/stderr.expect
@@ -6,6 +6,7 @@ Flags:
       --exit-on-failure   Exit on failure of a task
   -h, --help              help for processjobs
       --oneshot           Do not wait for additional tasks to appear
+      --stateDir string   Location to save agent runtime state
 
 Global Flags:
   -c, --catalog string      The catalog file to use to get product information (default "https://repo.rackn.io")

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 5e88528d4bb15241455837c1ee59c074d66fc16c1a5de04238db88bf40f3b32d
-updated: 2019-05-29T09:36:22.940962-05:00
+hash: a3a1f6501b826cd7d08971cdb810f0926ef70b1b76528b2f2cd1c3d8808df9c9
+updated: 2019-06-07T16:04:20.499471721-05:00
 imports:
 - name: github.com/aokoli/goutils
   version: 3391d3790d23d03408670993e957e8f408993c34
@@ -57,6 +57,10 @@ imports:
   - binding
   - json
   - render
+- name: github.com/go-ole/go-ole
+  version: 97b6244175ae18ea6eef668034fd6565847501c9
+  subpackages:
+  - oleutil
 - name: github.com/gofunky/semver
   version: b182ca44e05aea9918247472dc1cf6658577f423
 - name: github.com/golang/protobuf
@@ -189,12 +193,25 @@ imports:
   version: 76f58f330d76a55c5badc74f6212e8a15e742c77
 - name: github.com/russross/blackfriday
   version: 11635eb403ff09dbc3a6b5a007ab5ab09151c229
+- name: github.com/shirou/gopsutil
+  version: 5335e3fd506df4cb63de0a8239c7461d23063be6
+  subpackages:
+  - cpu
+  - host
+  - internal/common
+  - mem
+  - net
+  - process
+- name: github.com/shirou/w32
+  version: bb4de0191aa41b5507caa14b0650cdbddcd9280b
 - name: github.com/spf13/cobra
   version: 7c4570c3ebeb8129a1f7456d0908a8b676b6f9f1
   subpackages:
   - doc
 - name: github.com/spf13/pflag
   version: 3ebe029320b2676d667ae88da602a5f854788a8a
+- name: github.com/StackExchange/wmi
+  version: cbe66965904dbe8a6cd589e2298e5d8b986bd7dd
 - name: github.com/tylerb/graceful
   version: d72b0151351a13d0421b763b88f791469c4f5dc7
 - name: github.com/ugorji/go
@@ -258,6 +275,7 @@ imports:
   version: 0ffbfd41fbef8ffcf9b62b0b0aa3a5873ed7a4fe
   subpackages:
   - unix
+  - windows
 - name: golang.org/x/tools
   version: 82515cf89538b3e8a206be74377c01dee420b76d
   subpackages:
@@ -274,4 +292,6 @@ imports:
 - name: gopkg.in/yaml.v2
   version: 7b8349ac747c6a24702b762d2c4fd9266cf4f1d6
   repo: https://github.com/go-yaml/yaml
-testImports: []
+testImports:
+- name: github.com/digitalrebar/yaml
+  version: c6f6f8e5f481599a08ad706ea6028067837b19ce

--- a/glide.yaml
+++ b/glide.yaml
@@ -60,3 +60,5 @@ import:
 - package: github.com/rackn/netwrangler
   version: v0.5.1
 - package: github.com/j-keck/arping
+- package: github.com/shirou/gopsutil/
+  version: ~v2.19

--- a/tools/test.sh
+++ b/tools/test.sh
@@ -13,7 +13,8 @@ github.com/digitalrebar/provision/embedded,\
 github.com/digitalrebar/provision/server,\
 github.com/digitalrebar/provision/plugin,\
 github.com/digitalrebar/provision/cli,\
-github.com/digitalrebar/provision/api\
+github.com/digitalrebar/provision/api,\
+github.com/digitalrebar/provision/agent\
 "
 
 if [[ `uname -s` == Darwin ]] ; then


### PR DESCRIPTION
There is no need to co-mingle the agent code with the API or the CLI
code, as it just bloats up the API package if present and is more or
less independent of the CLI.

Along the way we hide things that do not need to be exposed.