### PR TITLE
Publish linux drbundler and drpcli so other trees don't have to build…

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,8 @@ deploy:
   - dr-provision.sha256
   - embedded/assets/swagger.json
   - dr-provision-hash.*
+  - bin/linux/amd64/drbundler
+  - bin/linux/amd64/drpcli
   skip_cleanup: true
   on:
     repo: digitalrebar/provision

--- a/glide.lock
+++ b/glide.lock
@@ -176,7 +176,7 @@ imports:
   - nfs
   - xfs
 - name: github.com/rackn/gohai
-  version: 5053e7f1fa367302732ffcd47b99fb07254499d9
+  version: 92918a70111796e9e3eb4e53b0ce96c660fc7e09
   subpackages:
   - plugins/dmi
   - plugins/net


### PR DESCRIPTION
… them.

Update GOHAI to include baseboard info.