### PR TITLE
Give PluginProviders an AutoStart capability to allow them

### DIFF
--- a/backend/plugin_controller.go
+++ b/backend/plugin_controller.go
@@ -421,8 +421,8 @@ func (pc *PluginController) UploadPluginProvider(c *gin.Context, fileRoot, name 
 	os.Remove(ppName)
 	os.Rename(ppTmpName, ppName)
 	pc.AvailableProviders[pp.Name] = pp
-	pc.allPlugins(pp.Name, "stop")
-	pc.allPlugins(pp.Name, "start")
+	pc.allPlugins(pp.Name, "stop", false)
+	pc.allPlugins(pp.Name, "start", pp.AutoStart)
 	return &models.PluginProviderUploadInfo{Path: pp.Name, Size: copied}, nil
 }
 

--- a/cli/test-data/output/TestAuth/plugin_providers.list.611601b3efac342fd10027372140fe8c/stdout.expect
+++ b/cli/test-data/output/TestAuth/plugin_providers.list.611601b3efac342fd10027372140fe8c/stdout.expect
@@ -1,5 +1,6 @@
 [
   {
+    "AutoStart": false,
     "AvailableActions": [
       {
         "Command": "increment",

--- a/cli/test-data/output/TestAuth/plugin_providers.list.e8e0775e692adbcb8acdf3799178655c/stdout.expect
+++ b/cli/test-data/output/TestAuth/plugin_providers.list.e8e0775e692adbcb8acdf3799178655c/stdout.expect
@@ -1,5 +1,6 @@
 [
   {
+    "AutoStart": false,
     "AvailableActions": [
       {
         "Command": "increment",

--- a/cli/test-data/output/TestPluginProviderCli/plugin_providers.list.3/stdout.expect
+++ b/cli/test-data/output/TestPluginProviderCli/plugin_providers.list.3/stdout.expect
@@ -1,5 +1,6 @@
 [
   {
+    "AutoStart": false,
     "AvailableActions": [
       {
         "Command": "increment",

--- a/cli/test-data/output/TestPluginProviderCli/plugin_providers.list/stdout.expect
+++ b/cli/test-data/output/TestPluginProviderCli/plugin_providers.list/stdout.expect
@@ -1,5 +1,6 @@
 [
   {
+    "AutoStart": false,
     "AvailableActions": [
       {
         "Command": "increment",

--- a/cli/test-data/output/TestPluginProviderCli/plugin_providers.show.incrementer/stdout.expect
+++ b/cli/test-data/output/TestPluginProviderCli/plugin_providers.show.incrementer/stdout.expect
@@ -1,4 +1,5 @@
 {
+  "AutoStart": false,
   "AvailableActions": [
     {
       "Command": "increment",

--- a/models/plugin_provider.go
+++ b/models/plugin_provider.go
@@ -18,6 +18,7 @@ type PluginProvider struct {
 	// This is used to indicate what version the plugin is built for
 	PluginVersion int
 
+	AutoStart        bool
 	HasPublish       bool
 	AvailableActions []AvailableAction
 


### PR DESCRIPTION
be autoconfigured but still editable.  This will allow
manager to update existing plugins.