### PR TITLE
Add regex filters to most applicable fields.

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -339,6 +339,9 @@ func (r *R) Params(args ...string) *R {
 //        to skip <number> of results before returning
 //    "indexName" "Eq/Lt/Lte/Gt/Gte/Ne" "value"
 //        to return results Equal, Less Than, Less Than Or Equal, Greater Than, Greater Than Or Equal, or Not Equal to value according to IndexName
+//    "indexName" "Re" "re2 compatible regular expression"
+//        to return results where values in indexName match the passed-in regular expression.
+//        The index must have the Regex flag equal to True
 //    "indexName" "Between/Except" "lowerBound" "upperBound"
 //        to return values Between(inclusive) lowerBound and Upperbound or its complement for Except.
 //    "indexName" "In/Nin" "comma,separated,list,of,values"
@@ -370,7 +373,7 @@ func (r *R) Filter(prefix string, filterArgs ...string) *R {
 			op := strings.Title(strings.ToLower(filterArgs[i+1]))
 			i += 2
 			switch op {
-			case "Eq", "Lt", "Lte", "Gt", "Gte", "Ne", "In", "Nin":
+			case "Eq", "Lt", "Lte", "Gt", "Gte", "Ne", "In", "Nin", "Re":
 				if len(filterArgs)-i < 1 {
 					r.err.Errorf("Invalid Filter: %s op %s requires 1 parameter", filter, op)
 					return r

--- a/api/info_test.go
+++ b/api/info_test.go
@@ -72,6 +72,7 @@ func TestInfo(t *testing.T) {
 				"stage-paramer",
 				"auto-boot-target",
 				"partial-objects",
+				"regex-string-filters",
 			},
 			License: models.LicenseBundle{Licenses: []models.License{}},
 			Scopes: map[string]map[string]struct{}{

--- a/backend/jobs.go
+++ b/backend/jobs.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
@@ -103,11 +104,12 @@ func (j *Job) UUID() string {
 func (j *Job) Indexes() map[string]index.Maker {
 	fix := AsJob
 	res := index.MakeBaseIndexes(j)
-	res["Uuid"] = index.Make(
-		true,
-		"UUID string",
-		func(i, j models.Model) bool { return fix(i).Uuid.String() < fix(j).Uuid.String() },
-		func(ref models.Model) (gte, gt index.Test) {
+	res["Uuid"] = index.Maker{
+		Unique: true,
+		Type:   "UUID string",
+		Less:   func(i, j models.Model) bool { return fix(i).Uuid.String() < fix(j).Uuid.String() },
+		Eq:     func(i, j models.Model) bool { return fix(i).Uuid.String() == fix(j).Uuid.String() },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refUuid := fix(ref).Uuid.String()
 			return func(s models.Model) bool {
 					return fix(s).Uuid.String() >= refUuid
@@ -116,7 +118,7 @@ func (j *Job) Indexes() map[string]index.Maker {
 					return fix(s).Uuid.String() > refUuid
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			id := uuid.Parse(s)
 			if id == nil {
 				return nil, fmt.Errorf("Invalid UUID: %s", s)
@@ -124,12 +126,14 @@ func (j *Job) Indexes() map[string]index.Maker {
 			job := fix(j.New())
 			job.Uuid = id
 			return job, nil
-		})
-	res["Previous"] = index.Make(
-		false,
-		"UUID string",
-		func(i, j models.Model) bool { return fix(i).Previous.String() < fix(j).Previous.String() },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["Previous"] = index.Maker{
+		Unique: false,
+		Type:   "UUID string",
+		Less:   func(i, j models.Model) bool { return fix(i).Previous.String() < fix(j).Previous.String() },
+		Eq:     func(i, j models.Model) bool { return fix(i).Previous.String() == fix(j).Previous.String() },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refUuid := fix(ref).Previous.String()
 			return func(s models.Model) bool {
 					return fix(s).Previous.String() >= refUuid
@@ -138,7 +142,7 @@ func (j *Job) Indexes() map[string]index.Maker {
 					return fix(s).Previous.String() > refUuid
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			id := uuid.Parse(s)
 			if id == nil {
 				return nil, fmt.Errorf("Invalid UUID: %s", s)
@@ -146,12 +150,15 @@ func (j *Job) Indexes() map[string]index.Maker {
 			job := fix(j.New())
 			job.Previous = id
 			return job, nil
-		})
-	res["Stage"] = index.Make(
-		false,
-		"string",
-		func(i, j models.Model) bool { return fix(i).Stage < fix(j).Stage },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["Stage"] = index.Maker{
+		Unique: false,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Stage < fix(j).Stage },
+		Eq:     func(i, j models.Model) bool { return fix(i).Stage == fix(j).Stage },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(j).Stage) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refStage := fix(ref).Stage
 			return func(s models.Model) bool {
 					return fix(s).Stage >= refStage
@@ -160,16 +167,19 @@ func (j *Job) Indexes() map[string]index.Maker {
 					return fix(s).Stage > refStage
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			job := fix(j.New())
 			job.Stage = s
 			return job, nil
-		})
-	res["Workflow"] = index.Make(
-		false,
-		"string",
-		func(i, j models.Model) bool { return fix(i).Workflow < fix(j).Workflow },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["Workflow"] = index.Maker{
+		Unique: false,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Workflow < fix(j).Workflow },
+		Eq:     func(i, j models.Model) bool { return fix(i).Workflow == fix(j).Workflow },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(j).Workflow) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refWorkflow := fix(ref).Workflow
 			return func(s models.Model) bool {
 					return fix(s).Workflow >= refWorkflow
@@ -178,16 +188,19 @@ func (j *Job) Indexes() map[string]index.Maker {
 					return fix(s).Workflow > refWorkflow
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			job := fix(j.New())
 			job.Workflow = s
 			return job, nil
-		})
-	res["BootEnv"] = index.Make(
-		false,
-		"string",
-		func(i, j models.Model) bool { return fix(i).BootEnv < fix(j).BootEnv },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["BootEnv"] = index.Maker{
+		Unique: false,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).BootEnv < fix(j).BootEnv },
+		Eq:     func(i, j models.Model) bool { return fix(i).BootEnv == fix(j).BootEnv },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(j).BootEnv) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refBootEnv := fix(ref).BootEnv
 			return func(s models.Model) bool {
 					return fix(s).BootEnv >= refBootEnv
@@ -196,16 +209,19 @@ func (j *Job) Indexes() map[string]index.Maker {
 					return fix(s).BootEnv > refBootEnv
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			job := fix(j.New())
 			job.BootEnv = s
 			return job, nil
-		})
-	res["Task"] = index.Make(
-		false,
-		"string",
-		func(i, j models.Model) bool { return fix(i).Task < fix(j).Task },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["Task"] = index.Maker{
+		Unique: false,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Task < fix(j).Task },
+		Eq:     func(i, j models.Model) bool { return fix(i).Task == fix(j).Task },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(j).Task) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refTask := fix(ref).Task
 			return func(s models.Model) bool {
 					return fix(s).Task >= refTask
@@ -214,16 +230,19 @@ func (j *Job) Indexes() map[string]index.Maker {
 					return fix(s).Task > refTask
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			job := fix(j.New())
 			job.Task = s
 			return job, nil
-		})
-	res["State"] = index.Make(
-		false,
-		"string",
-		func(i, j models.Model) bool { return fix(i).State < fix(j).State },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["State"] = index.Maker{
+		Unique: false,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).State < fix(j).State },
+		Eq:     func(i, j models.Model) bool { return fix(i).State == fix(j).State },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(j).State) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refState := fix(ref).State
 			return func(s models.Model) bool {
 					return fix(s).State >= refState
@@ -232,16 +251,18 @@ func (j *Job) Indexes() map[string]index.Maker {
 					return fix(s).State > refState
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			job := fix(j.New())
 			job.State = s
 			return job, nil
-		})
-	res["Machine"] = index.Make(
-		true,
-		"UUID string",
-		func(i, j models.Model) bool { return fix(i).Machine.String() < fix(j).Machine.String() },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["Machine"] = index.Maker{
+		Unique: true,
+		Type:   "UUID string",
+		Less:   func(i, j models.Model) bool { return fix(i).Machine.String() < fix(j).Machine.String() },
+		Eq:     func(i, j models.Model) bool { return fix(i).Machine.String() == fix(j).Machine.String() },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refMachine := fix(ref).Machine.String()
 			return func(s models.Model) bool {
 					return fix(s).Machine.String() >= refMachine
@@ -250,7 +271,7 @@ func (j *Job) Indexes() map[string]index.Maker {
 					return fix(s).Machine.String() > refMachine
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			id := uuid.Parse(s)
 			if id == nil {
 				return nil, fmt.Errorf("Invalid UUID: %s", s)
@@ -258,7 +279,8 @@ func (j *Job) Indexes() map[string]index.Maker {
 			job := fix(j.New())
 			job.Machine = id
 			return job, nil
-		})
+		},
+	}
 	res["Archived"] = index.MakeUnordered(
 		"boolean",
 		func(i, j models.Model) bool {

--- a/backend/machines.go
+++ b/backend/machines.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"path"
 	"reflect"
+	"regexp"
 	"strings"
 
 	"github.com/digitalrebar/provision/backend/index"
@@ -62,11 +63,12 @@ func (n *Machine) HasTask(s string) bool {
 func (n *Machine) Indexes() map[string]index.Maker {
 	fix := AsMachine
 	res := index.MakeBaseIndexes(n)
-	res["Uuid"] = index.Make(
-		true,
-		"UUID string",
-		func(i, j models.Model) bool { return fix(i).Uuid.String() < fix(j).Uuid.String() },
-		func(ref models.Model) (gte, gt index.Test) {
+	res["Uuid"] = index.Maker{
+		Unique: true,
+		Type:   "UUID string",
+		Less:   func(i, j models.Model) bool { return fix(i).Uuid.String() < fix(j).Uuid.String() },
+		Eq:     func(i, j models.Model) bool { return fix(i).Uuid.String() == fix(j).Uuid.String() },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refUuid := fix(ref).Uuid.String()
 			return func(s models.Model) bool {
 					return fix(s).Uuid.String() >= refUuid
@@ -75,7 +77,7 @@ func (n *Machine) Indexes() map[string]index.Maker {
 					return fix(s).Uuid.String() > refUuid
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			id := uuid.Parse(s)
 			if id == nil {
 				return nil, fmt.Errorf("Invalid UUID: %s", s)
@@ -83,12 +85,15 @@ func (n *Machine) Indexes() map[string]index.Maker {
 			m := fix(n.New())
 			m.Uuid = id
 			return m, nil
-		})
-	res["Name"] = index.Make(
-		true,
-		"string",
-		func(i, j models.Model) bool { return fix(i).Name < fix(j).Name },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["Name"] = index.Maker{
+		Unique: true,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Name < fix(j).Name },
+		Eq:     func(i, j models.Model) bool { return fix(i).Name == fix(j).Name },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(i).Name) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refName := fix(ref).Name
 			return func(s models.Model) bool {
 					return fix(s).Name >= refName
@@ -97,16 +102,19 @@ func (n *Machine) Indexes() map[string]index.Maker {
 					return fix(s).Name > refName
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			m := fix(n.New())
 			m.Name = s
 			return m, nil
-		})
-	res["Stage"] = index.Make(
-		false,
-		"string",
-		func(i, j models.Model) bool { return fix(i).Stage < fix(j).Stage },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["Stage"] = index.Maker{
+		Unique: false,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Stage < fix(j).Stage },
+		Eq:     func(i, j models.Model) bool { return fix(i).Stage == fix(j).Stage },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(i).Stage) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refStage := fix(ref).Stage
 			return func(s models.Model) bool {
 					return fix(s).Stage >= refStage
@@ -115,16 +123,19 @@ func (n *Machine) Indexes() map[string]index.Maker {
 					return fix(s).Stage > refStage
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			m := fix(n.New())
 			m.Stage = s
 			return m, nil
-		})
-	res["Workflow"] = index.Make(
-		false,
-		"string",
-		func(i, j models.Model) bool { return fix(i).Workflow < fix(j).Workflow },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["Workflow"] = index.Maker{
+		Unique: false,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Workflow < fix(j).Workflow },
+		Eq:     func(i, j models.Model) bool { return fix(i).Workflow == fix(j).Workflow },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(i).Workflow) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refWorkflow := fix(ref).Workflow
 			return func(s models.Model) bool {
 					return fix(s).Workflow >= refWorkflow
@@ -133,16 +144,19 @@ func (n *Machine) Indexes() map[string]index.Maker {
 					return fix(s).Workflow > refWorkflow
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			m := fix(n.New())
 			m.Workflow = s
 			return m, nil
-		})
-	res["BootEnv"] = index.Make(
-		false,
-		"string",
-		func(i, j models.Model) bool { return fix(i).BootEnv < fix(j).BootEnv },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["BootEnv"] = index.Maker{
+		Unique: false,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).BootEnv < fix(j).BootEnv },
+		Eq:     func(i, j models.Model) bool { return fix(i).BootEnv == fix(j).BootEnv },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(i).BootEnv) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refBootEnv := fix(ref).BootEnv
 			return func(s models.Model) bool {
 					return fix(s).BootEnv >= refBootEnv
@@ -151,21 +165,22 @@ func (n *Machine) Indexes() map[string]index.Maker {
 					return fix(s).BootEnv > refBootEnv
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			m := fix(n.New())
 			m.BootEnv = s
 			return m, nil
-		})
-	res["Address"] = index.Make(
-		false,
-		"IP Address",
-		func(i, j models.Model) bool {
+		},
+	}
+	res["Address"] = index.Maker{
+		Unique: false,
+		Type:   "IP Address",
+		Less: func(i, j models.Model) bool {
 			n, o := big.Int{}, big.Int{}
 			n.SetBytes(fix(i).Address.To16())
 			o.SetBytes(fix(j).Address.To16())
 			return n.Cmp(&o) == -1
 		},
-		func(ref models.Model) (gte, gt index.Test) {
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			addr := &big.Int{}
 			addr.SetBytes(fix(ref).Address.To16())
 			return func(s models.Model) bool {
@@ -179,7 +194,7 @@ func (n *Machine) Indexes() map[string]index.Maker {
 					return o.Cmp(addr) == 1
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			addr := net.ParseIP(s)
 			if addr == nil {
 				return nil, fmt.Errorf("Invalid address: %s", s)
@@ -187,7 +202,8 @@ func (n *Machine) Indexes() map[string]index.Maker {
 			m := fix(n.New())
 			m.Address = addr
 			return m, nil
-		})
+		},
+	}
 	res["Runnable"] = index.MakeUnordered(
 		"boolean",
 		func(i, j models.Model) bool {
@@ -275,15 +291,15 @@ func (n *Machine) ParameterMaker(rt *RequestTracker, parameter string) (index.Ma
 	}
 	param := AsParam(pobj)
 
-	return index.Make(
-		false,
-		"parameter",
-		func(i, j models.Model) bool {
+	return index.Maker{
+		Unique: false,
+		Type:   "parameter",
+		Less: func(i, j models.Model) bool {
 			ip, _ := rt.GetParam(fix(i), parameter, true, false)
 			jp, _ := rt.GetParam(fix(j), parameter, true, false)
 			return GeneralLessThan(ip, jp)
 		},
-		func(ref models.Model) (gte, gt index.Test) {
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			jp, _ := rt.GetParam(fix(ref), parameter, true, false)
 			return func(s models.Model) bool {
 					ip, _ := rt.GetParam(fix(s), parameter, true, false)
@@ -294,7 +310,7 @@ func (n *Machine) ParameterMaker(rt *RequestTracker, parameter string) (index.Ma
 					return GeneralGreaterThan(ip, jp)
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			obj, err := GeneralValidateParam(param, s)
 			if err != nil {
 				return nil, err
@@ -303,7 +319,8 @@ func (n *Machine) ParameterMaker(rt *RequestTracker, parameter string) (index.Ma
 			res.Params = map[string]interface{}{}
 			res.Params[parameter] = obj
 			return res, nil
-		}), nil
+		},
+	}, nil
 
 }
 

--- a/backend/subnet.go
+++ b/backend/subnet.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"regexp"
 	"sort"
 	"time"
 
@@ -176,11 +177,13 @@ func (s *Subnet) SaveClean() store.KeySaver {
 func (s *Subnet) Indexes() map[string]index.Maker {
 	fix := AsSubnet
 	res := index.MakeBaseIndexes(s)
-	res["Name"] = index.Make(
-		true,
-		"string",
-		func(i, j models.Model) bool { return fix(i).Name < fix(j).Name },
-		func(ref models.Model) (gte, gt index.Test) {
+	res["Name"] = index.Maker{
+		Unique: true,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Name < fix(j).Name },
+		Eq:     func(i, j models.Model) bool { return fix(i).Name == fix(j).Name },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(i).Name) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refName := fix(ref).Name
 			return func(s models.Model) bool {
 					return fix(s).Name >= refName
@@ -189,16 +192,19 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 					return fix(s).Name > refName
 				}
 		},
-		func(st string) (models.Model, error) {
+		Fill: func(st string) (models.Model, error) {
 			sub := fix(s.New())
 			sub.Name = st
 			return sub, nil
-		})
-	res["Strategy"] = index.Make(
-		false,
-		"string",
-		func(i, j models.Model) bool { return fix(i).Strategy < fix(j).Strategy },
-		func(ref models.Model) (gte, gt index.Test) {
+		},
+	}
+	res["Strategy"] = index.Maker{
+		Unique: false,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Strategy < fix(j).Strategy },
+		Eq:     func(i, j models.Model) bool { return fix(i).Strategy == fix(j).Strategy },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(i).Strategy) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			strategy := fix(ref).Strategy
 			return func(s models.Model) bool {
 					return fix(s).Strategy >= strategy
@@ -207,21 +213,22 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 					return fix(s).Strategy > strategy
 				}
 		},
-		func(st string) (models.Model, error) {
+		Fill: func(st string) (models.Model, error) {
 			sub := fix(s.New())
 			sub.Strategy = st
 			return sub, nil
-		})
-	res["NextServer"] = index.Make(
-		false,
-		"IP Address",
-		func(i, j models.Model) bool {
+		},
+	}
+	res["NextServer"] = index.Maker{
+		Unique: false,
+		Type:   "IP Address",
+		Less: func(i, j models.Model) bool {
 			n, o := big.Int{}, big.Int{}
 			n.SetBytes(fix(i).NextServer.To16())
 			o.SetBytes(fix(j).NextServer.To16())
 			return n.Cmp(&o) == -1
 		},
-		func(ref models.Model) (gte, gt index.Test) {
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			addr := &big.Int{}
 			addr.SetBytes(fix(ref).NextServer.To16())
 			return func(s models.Model) bool {
@@ -235,7 +242,7 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 					return o.Cmp(addr) == 1
 				}
 		},
-		func(st string) (models.Model, error) {
+		Fill: func(st string) (models.Model, error) {
 			addr := net.ParseIP(st)
 			if addr == nil {
 				return nil, fmt.Errorf("Invalid Address: %s", st)
@@ -243,11 +250,12 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 			sub := fix(s.New())
 			sub.NextServer = addr
 			return sub, nil
-		})
-	res["Subnet"] = index.Make(
-		true,
-		"CIDR Address",
-		func(i, j models.Model) bool {
+		},
+	}
+	res["Subnet"] = index.Maker{
+		Unique: true,
+		Type:   "CIDR Address",
+		Less: func(i, j models.Model) bool {
 			a, _, errA := net.ParseCIDR(fix(i).Subnet.Subnet)
 			b, _, errB := net.ParseCIDR(fix(j).Subnet.Subnet)
 			if errA != nil || errB != nil {
@@ -258,7 +266,7 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 			o.SetBytes(b.To16())
 			return n.Cmp(&o) == -1
 		},
-		func(ref models.Model) (gte, gt index.Test) {
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			cidr, _, err := net.ParseCIDR(fix(ref).Subnet.Subnet)
 			if err != nil {
 				fix(ref).rt.Panicf("Illegal subnet %s: %v", fix(ref).Subnet.Subnet, err)
@@ -284,18 +292,19 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 					return o.Cmp(addr) == 1
 				}
 		},
-		func(st string) (models.Model, error) {
+		Fill: func(st string) (models.Model, error) {
 			if _, _, err := net.ParseCIDR(st); err != nil {
 				return nil, fmt.Errorf("Invalid subnet CIDR: %s", st)
 			}
 			sub := fix(s.New())
 			sub.Subnet.Subnet = st
 			return sub, nil
-		})
-	res["Address"] = index.Make(
-		false,
-		"IP Address",
-		func(i, j models.Model) bool {
+		},
+	}
+	res["Address"] = index.Maker{
+		Unique: false,
+		Type:   "IP Address",
+		Less: func(i, j models.Model) bool {
 			a, _, errA := net.ParseCIDR(fix(i).Subnet.Subnet)
 			b, _, errB := net.ParseCIDR(fix(j).Subnet.Subnet)
 			if errA != nil || errB != nil {
@@ -306,7 +315,7 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 			o.SetBytes(b.To16())
 			return n.Cmp(&o) == -1
 		},
-		func(ref models.Model) (gte, gt index.Test) {
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			addr := fix(ref).Subnet.Subnet
 			if net.ParseIP(addr) == nil {
 				fix(ref).rt.Panicf("Illegal IP Address: %s", addr)
@@ -320,7 +329,7 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 					return u(addr)
 				}
 		},
-		func(st string) (models.Model, error) {
+		Fill: func(st string) (models.Model, error) {
 			addr := net.ParseIP(st)
 			if addr == nil {
 				return nil, fmt.Errorf("Invalid IP address: %s", st)
@@ -328,11 +337,12 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 			sub := fix(s.New())
 			sub.Subnet.Subnet = st
 			return sub, nil
-		})
-	res["ActiveAddress"] = index.Make(
-		false,
-		"IP Address",
-		func(i, j models.Model) bool {
+		},
+	}
+	res["ActiveAddress"] = index.Maker{
+		Unique: false,
+		Type:   "IP Address",
+		Less: func(i, j models.Model) bool {
 			a, _, errA := net.ParseCIDR(fix(i).Subnet.Subnet)
 			b, _, errB := net.ParseCIDR(fix(j).Subnet.Subnet)
 			if errA != nil || errB != nil {
@@ -343,7 +353,7 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 			o.SetBytes(b.To16())
 			return n.Cmp(&o) == -1
 		},
-		func(ref models.Model) (gte, gt index.Test) {
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			addr := fix(ref).Subnet.Subnet
 			if net.ParseIP(addr) == nil {
 				fix(ref).rt.Panicf("Illegal IP Address: %s", addr)
@@ -357,7 +367,7 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 					return u(addr)
 				}
 		},
-		func(st string) (models.Model, error) {
+		Fill: func(st string) (models.Model, error) {
 			addr := net.ParseIP(st)
 			if addr == nil {
 				return nil, fmt.Errorf("Invalid IP address: %s", st)
@@ -365,7 +375,8 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 			sub := fix(s.New())
 			sub.Subnet.Subnet = st
 			return sub, nil
-		})
+		},
+	}
 	res["Enabled"] = index.MakeUnordered(
 		"boolean",
 		func(i, j models.Model) bool {
@@ -383,13 +394,13 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 			}
 			return res, nil
 		})
-	res["Proxy"] = index.Make(
-		false,
-		"boolean",
-		func(i, j models.Model) bool {
+	res["Proxy"] = index.Maker{
+		Unique: false,
+		Type:   "boolean",
+		Less: func(i, j models.Model) bool {
 			return (!fix(i).Proxy) && fix(j).Proxy
 		},
-		func(ref models.Model) (gte, gt index.Test) {
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			avail := fix(ref).Proxy
 			return func(s models.Model) bool {
 					v := fix(s).Proxy
@@ -399,7 +410,7 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 					return fix(s).Proxy && !avail
 				}
 		},
-		func(st string) (models.Model, error) {
+		Fill: func(st string) (models.Model, error) {
 			res := &Subnet{Subnet: &models.Subnet{}}
 			switch st {
 			case "true":
@@ -410,7 +421,8 @@ func (s *Subnet) Indexes() map[string]index.Maker {
 				return nil, errors.New("Proxy must be true or false")
 			}
 			return res, nil
-		})
+		},
+	}
 	return res
 }
 

--- a/backend/template.go
+++ b/backend/template.go
@@ -3,6 +3,7 @@ package backend
 import (
 	"bytes"
 	"fmt"
+	"regexp"
 	"text/template"
 
 	"github.com/digitalrebar/provision/backend/index"
@@ -35,11 +36,13 @@ func (t *Template) SaveClean() store.KeySaver {
 func (t *Template) Indexes() map[string]index.Maker {
 	fix := AsTemplate
 	res := index.MakeBaseIndexes(t)
-	res["ID"] = index.Make(
-		true,
-		"string",
-		func(i, j models.Model) bool { return fix(i).ID < fix(j).ID },
-		func(ref models.Model) (gte, gt index.Test) {
+	res["ID"] = index.Maker{
+		Unique: true,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).ID < fix(j).ID },
+		Eq:     func(i, j models.Model) bool { return fix(i).ID == fix(j).ID },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(i).ID) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refID := fix(ref).ID
 			return func(s models.Model) bool {
 					return fix(s).ID >= refID
@@ -48,11 +51,12 @@ func (t *Template) Indexes() map[string]index.Maker {
 					return fix(s).ID > refID
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			tmpl := fix(t.New())
 			tmpl.ID = s
 			return tmpl, nil
-		})
+		},
+	}
 	return res
 }
 

--- a/backend/user.go
+++ b/backend/user.go
@@ -1,6 +1,7 @@
 package backend
 
 import (
+	"regexp"
 	"strings"
 	"time"
 
@@ -38,11 +39,13 @@ func (u *User) SaveClean() store.KeySaver {
 func (u *User) Indexes() map[string]index.Maker {
 	fix := AsUser
 	res := index.MakeBaseIndexes(u)
-	res["Name"] = index.Make(
-		true,
-		"string",
-		func(i, j models.Model) bool { return fix(i).Name < fix(j).Name },
-		func(ref models.Model) (gte, gt index.Test) {
+	res["Name"] = index.Maker{
+		Unique: true,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Name < fix(j).Name },
+		Eq:     func(i, j models.Model) bool { return fix(i).Name == fix(j).Name },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(i).Name) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			refName := fix(ref).Name
 			return func(s models.Model) bool {
 					return fix(s).Name >= refName
@@ -51,11 +54,12 @@ func (u *User) Indexes() map[string]index.Maker {
 					return fix(s).Name > refName
 				}
 		},
-		func(s string) (models.Model, error) {
+		Fill: func(s string) (models.Model, error) {
 			u := fix(u.New())
 			u.Name = s
 			return u, nil
-		})
+		},
+	}
 	return res
 }
 

--- a/backend/workflow.go
+++ b/backend/workflow.go
@@ -1,6 +1,9 @@
 package backend
 
 import (
+	"regexp"
+	"strings"
+
 	"github.com/digitalrebar/provision/backend/index"
 	"github.com/digitalrebar/provision/models"
 	"github.com/digitalrebar/store"
@@ -60,13 +63,13 @@ func (w *Workflow) New() store.KeySaver {
 func (w *Workflow) Indexes() map[string]index.Maker {
 	fix := AsWorkflow
 	res := index.MakeBaseIndexes(w)
-	res["Name"] = index.Make(
-		true,
-		"string",
-		func(i, j models.Model) bool {
-			return fix(i).Name < fix(j).Name
-		},
-		func(ref models.Model) (gte, gt index.Test) {
+	res["Name"] = index.Maker{
+		Unique: true,
+		Type:   "string",
+		Less:   func(i, j models.Model) bool { return fix(i).Name < fix(j).Name },
+		Eq:     func(i, j models.Model) bool { return fix(i).Name == fix(j).Name },
+		Match:  func(i models.Model, re *regexp.Regexp) bool { return re.MatchString(fix(i).Name) },
+		Tests: func(ref models.Model) (gte, gt index.Test) {
 			name := fix(ref).Name
 			return func(ss models.Model) bool {
 					return fix(ss).Name >= name
@@ -75,9 +78,40 @@ func (w *Workflow) Indexes() map[string]index.Maker {
 					return fix(ss).Name > name
 				}
 		},
-		func(ss string) (models.Model, error) {
+		Fill: func(ss string) (models.Model, error) {
 			res := fix(w.New())
 			res.Name = ss
+			return res, nil
+		},
+	}
+	res["Stages"] = index.MakeUnordered(
+		"list",
+		func(i, j models.Model) bool {
+			p1 := fix(i).Stages
+			p2 := fix(j).Stages
+			probes := map[string]bool{}
+			for _, k := range p2 {
+				probes[k] = false
+			}
+			for _, k := range p1 {
+				if v, ok := probes[k]; ok && !v {
+					probes[k] = true
+				}
+			}
+			for _, v := range probes {
+				if !v {
+					return false
+				}
+			}
+			return true
+		},
+		func(s string) (models.Model, error) {
+			res := fix(w.New())
+			keys := strings.Split(s, ",")
+			for i := range keys {
+				keys[i] = strings.TrimSpace(keys[i])
+			}
+			res.Stages = keys
 			return res, nil
 		})
 	return res

--- a/cli/commandHelper.go
+++ b/cli/commandHelper.go
@@ -48,6 +48,10 @@ To filter by indexes, you can use the following stanzas:
   This will return items Greater Than *value* according to *index*
 * *index* Gte *value*
   This will return items Greater Than Or Equal to *value* according to *index*
+* *index* Re *re2 compatible regular expression*
+  This will return items in *index* that match the passed-in regular expression
+  We use the regular expression syntax described at
+  https://github.com/google/re2/wiki/Syntax
 * *index* Between *lower* *upper*
   This will return items Greater Than Or Equal to *lower*
   and Less Than Or Equal to *upper* according to *index*

--- a/cli/machines_test.go
+++ b/cli/machines_test.go
@@ -501,6 +501,7 @@ func TestMachineProfilesAndParams(t *testing.T) {
 	cliTest(false, false, "machines", "list", "Profiles", "Nin", "foo,bar", "sort", "Name").run(t)
 	cliTest(false, false, "machines", "list", "Name", "In", "fred,bob", "sort", "Name").run(t)
 	cliTest(false, false, "machines", "list", "Name", "Nin", "fred,bob", "sort", "Name").run(t)
+	cliTest(false, false, "machines", "list", "Name", "Re", "fred|bob", "sort", "Name").run(t)
 	cliTest(false, false, "machines", "destroy", "Name:bob").run(t)
 	cliTest(false, false, "machines", "destroy", "Name:fred").run(t)
 	cliTest(false, false, "machines", "destroy", "Name:julius").run(t)

--- a/cli/test-data/output/TestAuth/info.get/stdout.expect
+++ b/cli/test-data/output/TestAuth/info.get/stdout.expect
@@ -81,7 +81,8 @@ RE:
     "content-prerequisite-version-checking",
     "stage-paramer",
     "auto-boot-target",
-    "partial-objects"
+    "partial-objects",
+    "regex-string-filters"
   \],
   "file_port": 10002,
   "id": "Fred",

--- a/cli/test-data/output/TestCorePieces/bootenvs.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/bootenvs.indexes/stdout.expect
@@ -1,40 +1,48 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "OnlyUnknown": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "OsName": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/jobs.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/jobs.indexes/stdout.expect
@@ -1,85 +1,102 @@
 {
   "Archived": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "BootEnv": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Current": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": false
   },
   "EndTime": {
+    "Regex": false,
     "Type": "dateTime",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Machine": {
+    "Regex": false,
     "Type": "UUID string",
     "Unique": true,
     "Unordered": false
   },
   "Previous": {
+    "Regex": false,
     "Type": "UUID string",
     "Unique": false,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Stage": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "StartTime": {
+    "Regex": false,
     "Type": "dateTime",
     "Unique": false,
     "Unordered": false
   },
   "State": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Task": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Uuid": {
+    "Regex": false,
     "Type": "UUID string",
     "Unique": true,
     "Unordered": false
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Workflow": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false

--- a/cli/test-data/output/TestCorePieces/leases.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/leases.indexes/stdout.expect
@@ -1,50 +1,60 @@
 {
   "Addr": {
+    "Regex": false,
     "Type": "IP Address",
     "Unique": false,
     "Unordered": false
   },
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "ExpireTime": {
+    "Regex": false,
     "Type": "Date/Time string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "State": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Strategy": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Token": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/machines.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/machines.indexes/stdout.expect
@@ -1,70 +1,84 @@
 {
   "Address": {
+    "Regex": false,
     "Type": "IP Address",
     "Unique": false,
     "Unordered": false
   },
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "BootEnv": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Params": {
+    "Regex": false,
     "Type": "list",
     "Unique": false,
     "Unordered": true
   },
   "Profiles": {
+    "Regex": false,
     "Type": "list",
     "Unique": false,
     "Unordered": true
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Runnable": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Stage": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Uuid": {
+    "Regex": false,
     "Type": "UUID string",
     "Unique": true,
     "Unordered": false
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Workflow": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false

--- a/cli/test-data/output/TestCorePieces/params.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/params.indexes/stdout.expect
@@ -1,35 +1,42 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Secure": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/plugins.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/plugins.indexes/stdout.expect
@@ -1,40 +1,48 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Params": {
+    "Regex": false,
     "Type": "list",
     "Unique": false,
     "Unordered": true
   },
   "Provider": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/profiles.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/profiles.indexes/stdout.expect
@@ -1,35 +1,42 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Params": {
+    "Regex": false,
     "Type": "list",
     "Unique": false,
     "Unordered": true
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/reservations.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/reservations.indexes/stdout.expect
@@ -1,45 +1,54 @@
 {
   "Addr": {
+    "Regex": false,
     "Type": "IP Address",
     "Unique": false,
     "Unordered": false
   },
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "NextServer": {
+    "Regex": false,
     "Type": "IP Address",
     "Unique": false,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Strategy": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Token": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/roles.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/roles.indexes/stdout.expect
@@ -1,30 +1,36 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/stages.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/stages.indexes/stdout.expect
@@ -1,50 +1,66 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "BootEnv": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Params": {
+    "Regex": false,
     "Type": "list",
     "Unique": false,
     "Unordered": true
   },
   "Profiles": {
+    "Regex": false,
     "Type": "list",
     "Unique": false,
     "Unordered": true
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Reboot": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
+  "Tasks": {
+    "Regex": false,
+    "Type": "list",
+    "Unique": false,
+    "Unordered": true
+  },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/subnets.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/subnets.indexes/stdout.expect
@@ -1,65 +1,78 @@
 {
   "ActiveAddress": {
+    "Regex": false,
     "Type": "IP Address",
     "Unique": false,
     "Unordered": false
   },
   "Address": {
+    "Regex": false,
     "Type": "IP Address",
     "Unique": false,
     "Unordered": false
   },
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Enabled": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "NextServer": {
+    "Regex": false,
     "Type": "IP Address",
     "Unique": false,
     "Unordered": false
   },
   "Proxy": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Strategy": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Subnet": {
+    "Regex": false,
     "Type": "CIDR Address",
     "Unique": true,
     "Unordered": false
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/tasks.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/tasks.indexes/stdout.expect
@@ -1,30 +1,36 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/templates.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/templates.indexes/stdout.expect
@@ -1,30 +1,36 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "ID": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/tenants.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/tenants.indexes/stdout.expect
@@ -1,30 +1,36 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/users.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/users.indexes/stdout.expect
@@ -1,30 +1,36 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestCorePieces/workflows.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/workflows.indexes/stdout.expect
@@ -1,30 +1,42 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Bundle": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Name": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
+  "Stages": {
+    "Regex": false,
+    "Type": "list",
+    "Unique": false,
+    "Unordered": true
+  },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestMachineProfilesAndParams/machines.list.Name.Re.fred|bob.sort.Name/stdout.expect
+++ b/cli/test-data/output/TestMachineProfilesAndParams/machines.list.Name.Re.fred|bob.sort.Name/stdout.expect
@@ -1,0 +1,3 @@
+RE:
+    "Name": "bob",
+    "Name": "fred",

--- a/cli/test-data/output/TestPluginProviderCli/extended.4f8f2a612fb294982641072a65234ac0/stdout.expect
+++ b/cli/test-data/output/TestPluginProviderCli/extended.4f8f2a612fb294982641072a65234ac0/stdout.expect
@@ -1,45 +1,54 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "CanMilk": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Id": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "Location": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Spotted": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Type": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestPluginProviderCli/extended.93c848b077022a7b40f85e4d82a69509/stdout.expect
+++ b/cli/test-data/output/TestPluginProviderCli/extended.93c848b077022a7b40f85e4d82a69509/stdout.expect
@@ -1,20 +1,24 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestPluginProviderCli/extended.abe26401cab1af6c8ca1774b079184dd/stdout.expect
+++ b/cli/test-data/output/TestPluginProviderCli/extended.abe26401cab1af6c8ca1774b079184dd/stdout.expect
@@ -1,30 +1,36 @@
 {
   "Available": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Id": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Key": {
+    "Regex": true,
     "Type": "string",
     "Unique": true,
     "Unordered": false
   },
   "ReadOnly": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true
   },
   "Type": {
+    "Regex": true,
     "Type": "string",
     "Unique": false,
     "Unordered": false
   },
   "Valid": {
+    "Regex": false,
     "Type": "boolean",
     "Unique": false,
     "Unordered": true

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates.scope.all.ttl.330.action.list.specific.asdgag/stdout.expect
@@ -41,7 +41,8 @@ RE:
       "content-prerequisite-version-checking",
       "stage-paramer",
       "auto-boot-target",
-      "partial-objects"
+      "partial-objects",
+      "regex-string-filters"
     \],
     "file_port": 10002,
     "id": "Fred",

--- a/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
+++ b/cli/test-data/output/TestUserCli/users.token.rocketskates/stdout.expect
@@ -41,7 +41,8 @@ RE:
       "content-prerequisite-version-checking",
       "stage-paramer",
       "auto-boot-target",
-      "partial-objects"
+      "partial-objects",
+      "regex-string-filters"
     \],
     "file_port": 10002,
     "id": "Fred",

--- a/frontend/indexes.go
+++ b/frontend/indexes.go
@@ -55,6 +55,7 @@ func indexesFor(i Indexer) map[string]index.Maker {
 	res := map[string]index.Maker{}
 	for k, v := range i.Indexes() {
 		v.Unordered = !v.Sortable()
+		v.Regex = v.Match != nil
 		res[k] = v
 	}
 	return res
@@ -162,6 +163,7 @@ func (f *Frontend) InitIndexApi() {
 			staticIndexes := idxer.Indexes()
 			if staticIndex, ok := staticIndexes[c.Param("param")]; ok {
 				staticIndex.Unordered = !staticIndex.Sortable()
+				staticIndex.Regex = staticIndex.Match != nil
 				c.JSON(http.StatusOK, staticIndex)
 			}
 			dpm, ok := bm.(dynParameter)
@@ -184,6 +186,7 @@ func (f *Frontend) InitIndexApi() {
 				return
 			}
 			dynIndex.Unordered = !dynIndex.Sortable()
+			dynIndex.Regex = dynIndex.Match != nil
 			c.JSON(http.StatusOK, dynIndex)
 		})
 }

--- a/models/index.go
+++ b/models/index.go
@@ -11,4 +11,6 @@ type Index struct {
 	Unique bool
 	// Unordered tells you whether this index cannot be sorted.
 	Unordered bool
+	// Regex indecates whether you can use the Re filter with this index
+	Regex bool
 }

--- a/models/info.go
+++ b/models/info.go
@@ -109,6 +109,7 @@ func (i *Info) Fill() {
 			"stage-paramer",
 			"auto-boot-target",
 			"partial-objects",
+			"regex-string-filters",
 		}
 	}
 	if i.Scopes == nil {


### PR DESCRIPTION
Wherever we can reasonably be certain we are filtering by something
string-ish, allow a re2 compatible regex to be used via the new Re
index operator.