### PR TITLE
add 'info check' drpcli command

### DIFF
--- a/cli/info.go
+++ b/cli/info.go
@@ -30,6 +30,18 @@ func addInfoCommands() (res *cobra.Command) {
 		Use:   name,
 		Short: fmt.Sprintf("Access CLI commands relating to %v", name),
 	}
+
+	res.AddCommand(&cobra.Command{
+		Use:   "check",
+		Short: fmt.Sprintf("Fast API check that returns DRP Version"),
+		Long:  `A helper function to return API response with version of DRP`,
+		Args:  cobra.NoArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			fmt.Printf("{ \"active\": true }\n")
+			return nil
+		},
+	})
+
 	res.AddCommand(&cobra.Command{
 		Use:   "get",
 		Short: fmt.Sprintf("Get info about DRP"),

--- a/cli/info_test.go
+++ b/cli/info_test.go
@@ -5,6 +5,7 @@ import "testing"
 func TestInfoCli(t *testing.T) {
 	// Since this data is dynamic, we will test errors here.
 	cliTest(true, false, "info").run(t)
+	cliTest(true, true, "info", "check").run(t)
 	cliTest(true, true, "info", "get", "john2").run(t)
 	cliTest(false, false, "info", "status").run(t)
 }

--- a/cli/info_test.go
+++ b/cli/info_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestInfoCli(t *testing.T) {
 	// Since this data is dynamic, we will test errors here.
 	cliTest(true, false, "info").run(t)
-	cliTest(true, true, "info", "check").run(t)
+	cliTest(false, false, "info", "check").run(t)
 	cliTest(true, true, "info", "get", "john2").run(t)
 	cliTest(false, false, "info", "status").run(t)
 }

--- a/cli/test-data/output/TestInfoCli/info.check/stdout.expect
+++ b/cli/test-data/output/TestInfoCli/info.check/stdout.expect
@@ -1,0 +1,1 @@
+{ "active": true }

--- a/cli/test-data/output/TestInfoCli/info/stdout.expect
+++ b/cli/test-data/output/TestInfoCli/info/stdout.expect
@@ -4,6 +4,7 @@ Usage:
   drpcli info [command]
 
 Available Commands:
+  check       Fast API check that returns DRP Version
   get         Get info about DRP
   status      Get aliveness status of the various DRP ports
 


### PR DESCRIPTION
adds a new `info` command to drpcli, intended to be a very fast check that the API service is up and running, and auth has passed successfully - simply returns JSON `active: true`.

- `drpcli info check`
