### PR TITLE
Updates to inventory-via-profiles.py

### DIFF
--- a/integrations/ansible/inventory-via-profiles.py
+++ b/integrations/ansible/inventory-via-profiles.py
@@ -72,7 +72,10 @@ def main():
                 for profile in machine["Profiles"]:
                     profiles[profile].append(name)
             inventory["all"]["hosts"].append(name)
-            inventory["_meta"]["hostvars"][name] = {"ansible_ssh_user": "root", "ansible_host": machine["Address"]} 
+            inventory["_meta"]["hostvars"][name] = {"ansible_ssh_user": "root", "ansible_host": machine["Address"], "rebar_uuid": machine["Uuid"]}
+            for param in machine['Params']:
+                if param != "gohai-inventory":
+                    inventory["_meta"]["hostvars"][name][param] = machine['Params'][param]
     else:
         raise IOError(raw.text)
 
@@ -90,6 +93,10 @@ def main():
                 for param in profiles_vars[profile]:
                     value = profiles_vars[profile][param]
                     section["vars"][param] = value
+        elif 'ansible-children' in profiles_vars[profile].keys():
+            section["children"] = []
+            for child in profiles_vars[profile]['ansible-children']:
+                section["children"].extend([child])
 
         if len(list(section.keys())) > 0:
             inventory[profile] = section

--- a/integrations/ansible/inventory-via-profiles.py
+++ b/integrations/ansible/inventory-via-profiles.py
@@ -16,20 +16,9 @@
 # pip install requests
 import requests, argparse, json, urllib3, os
 
-'''
-Usage: https://github.com/digitalrebar/provision/tree/master/integration/ansible
-
-example: ansible -i inventory.py all -a "uname -a"
-'''
-
-# Children Group Support
-#   1. Create a "ansible-children" parameter
-#   2. Add that parameter to the parent profile
-#   3. Set the "ansible-children" parameter in the parent profile to the list of children's profiles
-    
 def main():
 
-    inventory = { "_meta": { "hostvars": {} } }
+    inventory = { "all": { "hosts": [] }, "_meta": { "hostvars": {} } }
 
     # change these values to match your DigitalRebar installation
     addr = os.getenv('RS_ENDPOINT', "https://127.0.0.1:8092")
@@ -60,8 +49,8 @@ def main():
     profiles_raw = requests.get(addr + "/api/v3/profiles",headers=Headers,auth=(user,password),verify=False)
     if profiles_raw.status_code == 200: 
         for profile in profiles_raw.json():
-            profiles[profile[u"Name"]] = []
-            profiles_vars[profile[u"Name"]] = profile[u"Params"] 
+            profiles[profile["Name"]] = []
+            profiles_vars[profile["Name"]] = profile["Params"] 
     else:
         raise IOError(profiles_raw.text)
 
@@ -76,13 +65,14 @@ def main():
 
     if raw.status_code == 200: 
         for machine in raw.json():
-            name = machine[u'Name']
+            name = machine['Name']
             # TODO, should we only show machines that are in local bootenv?  others could be transistioning
             # if the machine has profiles, collect them
-            if machine[u"Profiles"]:
-                for profile in machine[u"Profiles"]:
+            if machine["Profiles"]:
+                for profile in machine["Profiles"]:
                     profiles[profile].append(name)
-            inventory["_meta"]["hostvars"][name] = {"ansible_ssh_user": "root", "ansible_host": machine[u"Address"]} 
+            inventory["all"]["hosts"].append(name)
+            inventory["_meta"]["hostvars"][name] = {"ansible_ssh_user": "root", "ansible_host": machine["Address"]} 
     else:
         raise IOError(raw.text)
 
@@ -93,23 +83,19 @@ def main():
             for machine in profiles[profile]:
                 section["hosts"].extend([machine])
 
-        if profiles_vars[profile] is None:
-            pass # so nothing
-        elif u'ansible-children' in profiles_vars[profile].keys():
-            section["children"] = []
-            for child in profiles_vars[profile][u'ansible-children']:
-                section["children"].extend([child])
-        elif len(profiles_vars[profile]) > 0:
-            section["vars"] = {}
-            for param in profiles_vars[profile]:
-                value = profiles_vars[profile][param]
-                section["vars"][param] = value
+            if profiles_vars[profile] is None:
+                pass # so nothing
+            elif len(profiles_vars[profile]) > 0:
+                section["vars"] = {}
+                for param in profiles_vars[profile]:
+                    value = profiles_vars[profile][param]
+                    section["vars"][param] = value
 
-        if len(section.keys()) > 0:
+        if len(list(section.keys())) > 0:
             inventory[profile] = section
 
 
-    print json.dumps(inventory)
+    print(json.dumps(inventory))
 
 if __name__ == "__main__":
     main()  


### PR DESCRIPTION
1. Removed the section that deals with 'ansible-children', as this seems to be deprecated (no longer accessible in RackN Web UI, at least)
2. Basic updates to work with Python 3 (using 2to3)
3. Add 'all' section for all machines, as is required by ansible dynamic inventory
4. No longer display groups generated from profiles that don't apply to any machines (i.e. groups that don't have any machines in) - they are irrelevant to ansible inventory as there are no machines in them. As a beneficial side-effect, this automatically removes useless profiles (groups) like 'rackn-license'.