### PR TITLE
Render profiles secure

### DIFF
--- a/backend/renderData.go
+++ b/backend/renderData.go
@@ -815,7 +815,9 @@ func (r *RenderData) GenerateProfileToken(profile string, duration int) string {
 
 	t, _ := NewClaim(r.Machine.Key(), grantor, ttl).
 		AddRawClaim("profiles", "get", profile).
+		AddRawClaim("profiles", "getSecure", profile).
 		AddRawClaim("profiles", "update", profile).
+		AddRawClaim("profiles", "updateSecure", profile).
 		AddRawClaim("params", "get", "*").
 		AddMachine(r.Machine.Key()).
 		AddSecrets("", grantorSecret, r.Machine.Secret).


### PR DESCRIPTION
Token created to manage profiles needs to include get and update for secure params.

This is needed so that we can secure shared information for workflows like KRIB