### PR TITLE
add segment info to .ParseURL template doc

### DIFF
--- a/doc/arch/data.rst
+++ b/doc/arch/data.rst
@@ -244,7 +244,7 @@ Expansion                      Description
 .ProvisionerURL                An HTTP URL to access the base file server root
 .ApiURL                        An HTTPS URL to access the Digital Rebar Provision API
 .GenerateToken                 This generates limited use access token for the machine to either update itself if it exists or create a new machine.  The token's validity is limited in time by global preferences.  See :ref:`rs_model_prefs`.
-.ParseURL <segment> <url>      Parse the specified URL and return the segment requested.
+.ParseURL <segment> <url>      Parse the specified URL and return the segment requested. Supported segments can be one of *scheme* (eg "https"), *host* (eg "drp.example.com:8092"), or *path* (eg "/api/v3/machines").  *host* does not separate name and port.
 .ParamExists <key>             Returns true if the specified key is a valid parameter available for this rendering.
 .Param <key>                   Returns the structure for the specified key for this rendering.
 .Repos <tag>, <tag>,...        Returns Repos (as defined by the package-repositories param currently in scope) with the matching tags.

--- a/doc/arch/provision.rst
+++ b/doc/arch/provision.rst
@@ -217,7 +217,9 @@ RenderData includes the following helper methods:
 - **.GenerateInfiniteToken** works like **.GenerateToken**, but creates
   a token with a 3 year timeout.
 - **.ParseURL <segment> <url>** parses the specified URL and return the
-  segment requested.
+  segment requested.  Supported segments can be one of *scheme* (eg "https"),
+  *host* (eg "drp.example.com:8092"), or *path* (eg "/api/v3/machines").
+  (note: *host* does not separate name and port)
 - **template <string> .** includes the template specified by the string.
   String can NOT be a variable and note that template does NOT have a dot
   (.) in front.


### PR DESCRIPTION
- adds vital doc info to the `.ParseURL` golang template expansion piece so someone knows what can actually be parsed out and what to call it