### PR TITLE
Don't try to become root if we already are. Warn if sudo is not present.

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -212,6 +212,17 @@ fi
 
 [[ $DBG == true ]] && set -x
 
+
+if [[ $EUID -eq 0 ]]; then
+   _sudo=""
+fi
+
+if [[ -x "$(command -v sudo)" && $_sudo != "" ]]; then
+  echo "Script is not running as root and sudo command is not found. Please be root"
+  exit 1
+fi
+
+
 # Figure out what Linux distro we are running on.
 export OS_TYPE= OS_VER= OS_NAME= OS_FAMILY=
 


### PR DESCRIPTION
This fixes installation of `drpcli` in docker containers where:

- We already are root
- `sudo` is not present

Cheers