### PR TITLE
added RS_BASE_ROOT to systemd file

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -724,6 +724,7 @@ case $MODE in
 [Service]
 User=${SYSTEM_USER}
 Group=${SYSTEM_GROUP}
+Environment=RS_BASE_ROOT=${DRP_HOME_DIR}
 EOF
                      if [[ ${SYSTEM_USER} != "root" ]]; then
                         cat > /etc/systemd/system/dr-provision.service.d/setcap.conf <<EOF


### PR DESCRIPTION
Added missing env variable to the systemd file to allow
installs to be anywhere on the file system. Now what ever
is set for `--drp-home-dir=` will be set as RS_BASE_ROOT
with a default of `/var/lib/dr-provision`

Signed-off-by: Michael Rice <michael@michaelrice.org>