### PR TITLE
added RS_BASE_ROOT to systemd file

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -724,10 +724,12 @@ case $MODE in
 [Service]
 User=${SYSTEM_USER}
 Group=${SYSTEM_GROUP}
+Environment=RS_BASE_ROOT=${DRP_HOME_DIR}
 EOF
                      if [[ ${SYSTEM_USER} != "root" ]]; then
                         cat > /etc/systemd/system/dr-provision.service.d/setcap.conf <<EOF
 [Service]
+Environment=PermissionsStartOnly=true
 ExecStartPre=-/usr/bin/env setcap "cap_net_raw,cap_net_bind_service=+ep" ${PROVISION}
 Environment=RS_EXIT_ON_CHANGE=true
 Environment=RS_PLUGIN_COMM_ROOT=pcr


### PR DESCRIPTION
Added missing env variable to the systemd file to allow
installs to be anywhere on the file system. Now what ever
is set for `--drp-home-dir=` will be set as RS_BASE_ROOT
with a default of `/var/lib/dr-provision`

Signed-off-by: Michael Rice <michael@michaelrice.org>