### PR TITLE
Added Environment by mistake

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -731,7 +731,7 @@ EOF
                      if [[ ${SYSTEM_USER} != "root" ]]; then
                         cat > /etc/systemd/system/dr-provision.service.d/setcap.conf <<EOF
 [Service]
-Environment=PermissionsStartOnly=true
+PermissionsStartOnly=true
 ExecStartPre=-/usr/bin/env setcap "cap_net_raw,cap_net_bind_service=+ep" ${PROVISION}
 Environment=RS_EXIT_ON_CHANGE=true
 Environment=RS_PLUGIN_COMM_ROOT=pcr


### PR DESCRIPTION
Mistakenly added Environment= to the PermissionsStartOnly option

Signed-off-by: Michael Rice <michael@michaelrice.org>