### PR TITLE
Add NOJQSource to the catalog for use in install.sh without jq.

### DIFF
--- a/models/catalogItem.go
+++ b/models/catalogItem.go
@@ -37,6 +37,7 @@ type CatalogItem struct {
 	ContentType   string
 	Source        string
 	Shasum256     map[string]string
+	NOJQSource    string
 
 	Tip    bool
 	HotFix bool


### PR DESCRIPTION
Update jq to not use bsdtar and not require jq.
This requires tar and the "zip" file to be tgz.