### PR TITLE
Add a "human" readable formatter for objects.  table and text

### DIFF
--- a/api/utils.go
+++ b/api/utils.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/VictorLowther/jsonpatch2"
 	"github.com/digitalrebar/provision/v4/models"
-	yaml "github.com/ghodss/yaml"
+	"github.com/ghodss/yaml"
 )
 
 type Decoder interface {
@@ -30,7 +30,7 @@ func DecodeYaml(buf []byte, ref interface{}) error {
 	return models.DecodeYaml(buf, ref)
 }
 
-// Pretty marshals object acciording to the the fmt, in whatever
+// Pretty marshals object according to the the fmt, in whatever
 // passed for "pretty" according to fmt.
 func Pretty(f string, obj interface{}) ([]byte, error) {
 	switch f {

--- a/cli/test-data/output/TestCorePieces/gohai.0c113ca6d57519b559ba5a426be3c6b6/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/gohai.0c113ca6d57519b559ba5a426be3c6b6/stdout.expect
@@ -12,11 +12,14 @@ Global Flags:
   -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
   -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:10001")
   -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-  -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+  -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+  -H, --no-header               Should header be shown in "text" or "table" mode
   -x, --noToken                 Do not use token auth or token cache
   -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+  -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
   -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
   -T, --token string            token of the Digital Rebar Provision access
   -t, --trace string            The log level API requests should be logged at on the server side
   -Z, --traceToken string       A token that individual traced requests should report in the server logs
+  -j, --truncate-length int     Truncate columns at this length (default 40)
   -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")

--- a/doc/cli/drpcli.rst
+++ b/doc/cli/drpcli.rst
@@ -18,19 +18,24 @@ Options
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -h, --help                    help for drpcli
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO
 ~~~~~~~~
 
+-  `drpcli agent <drpcli_agent.html>`__ - Manage drpcli running as an
+   agent
 -  `drpcli autocomplete <drpcli_autocomplete.html>`__ - Generate CLI
    Command Bash AutoCompletion File (may require ‘bash-completion’ pkg
    be installed)

--- a/doc/cli/drpcli_agent.rst
+++ b/doc/cli/drpcli_agent.rst
@@ -1,24 +1,24 @@
-drpcli certs csr
-----------------
+drpcli agent
+------------
 
-Create a CSR and private key
+Manage drpcli running as an agent
 
 Synopsis
 ~~~~~~~~
 
-You must pass the root CA name, the common name, and may add additional
-hosts
+Use this command to install, remove, stop, start, restart drpcli running
+as a task runner
 
 ::
 
-   drpcli certs csr [root] [cn] [hosts...] [flags]
+   drpcli agent [operation] [flags]
 
 Options
 ~~~~~~~
 
 ::
 
-     -h, --help   help for csr
+     -h, --help   help for agent
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -45,5 +45,5 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
--  `drpcli certs <drpcli_certs.html>`__ - Access CLI commands relating
-   to certs
+-  `drpcli <drpcli.html>`__ - A CLI application for interacting with the
+   DigitalRebar Provision API

--- a/doc/cli/drpcli_autocomplete.rst
+++ b/doc/cli/drpcli_autocomplete.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs.rst
+++ b/doc/cli/drpcli_bootenvs.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_action.rst
+++ b/doc/cli/drpcli_bootenvs_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_actions.rst
+++ b/doc/cli/drpcli_bootenvs_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_create.rst
+++ b/doc/cli/drpcli_bootenvs_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_destroy.rst
+++ b/doc/cli/drpcli_bootenvs_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_exists.rst
+++ b/doc/cli/drpcli_bootenvs_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_fromAppleNBI.rst
+++ b/doc/cli/drpcli_bootenvs_fromAppleNBI.rst
@@ -41,13 +41,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_indexes.rst
+++ b/doc/cli/drpcli_bootenvs_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_install.rst
+++ b/doc/cli/drpcli_bootenvs_install.rst
@@ -42,13 +42,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_list.rst
+++ b/doc/cli/drpcli_bootenvs_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_meta.rst
+++ b/doc/cli/drpcli_bootenvs_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_meta_add.rst
+++ b/doc/cli/drpcli_bootenvs_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_meta_get.rst
+++ b/doc/cli/drpcli_bootenvs_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_meta_remove.rst
+++ b/doc/cli/drpcli_bootenvs_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_meta_set.rst
+++ b/doc/cli/drpcli_bootenvs_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_runaction.rst
+++ b/doc/cli/drpcli_bootenvs_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_show.rst
+++ b/doc/cli/drpcli_bootenvs_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_update.rst
+++ b/doc/cli/drpcli_bootenvs_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_uploadiso.rst
+++ b/doc/cli/drpcli_bootenvs_uploadiso.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_bootenvs_wait.rst
+++ b/doc/cli/drpcli_bootenvs_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_catalog.rst
+++ b/doc/cli/drpcli_catalog.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_catalog_item.rst
+++ b/doc/cli/drpcli_catalog_item.rst
@@ -28,13 +28,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_catalog_item_download.rst
+++ b/doc/cli/drpcli_catalog_item_download.rst
@@ -33,14 +33,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
          --os string               OS of the item to work with when downloading a plugin provider (default "darwin")
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
          --version string          Version of the item to work with (default "stable")
 

--- a/doc/cli/drpcli_catalog_item_install.rst
+++ b/doc/cli/drpcli_catalog_item_install.rst
@@ -30,14 +30,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
          --os string               OS of the item to work with when downloading a plugin provider (default "darwin")
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
          --version string          Version of the item to work with (default "stable")
 

--- a/doc/cli/drpcli_catalog_item_show.rst
+++ b/doc/cli/drpcli_catalog_item_show.rst
@@ -30,14 +30,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
          --os string               OS of the item to work with when downloading a plugin provider (default "darwin")
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
          --version string          Version of the item to work with (default "stable")
 

--- a/doc/cli/drpcli_catalog_items.rst
+++ b/doc/cli/drpcli_catalog_items.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_catalog_show.rst
+++ b/doc/cli/drpcli_catalog_show.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_catalog_updateLocal.rst
+++ b/doc/cli/drpcli_catalog_updateLocal.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_certs.rst
+++ b/doc/cli/drpcli_certs.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents.rst
+++ b/doc/cli/drpcli_contents.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_bundle.rst
+++ b/doc/cli/drpcli_contents_bundle.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_bundlize.rst
+++ b/doc/cli/drpcli_contents_bundlize.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_convert.rst
+++ b/doc/cli/drpcli_contents_convert.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_create.rst
+++ b/doc/cli/drpcli_contents_create.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_destroy.rst
+++ b/doc/cli/drpcli_contents_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_document.rst
+++ b/doc/cli/drpcli_contents_document.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_exists.rst
+++ b/doc/cli/drpcli_contents_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_list.rst
+++ b/doc/cli/drpcli_contents_list.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_show.rst
+++ b/doc/cli/drpcli_contents_show.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_unbundle.rst
+++ b/doc/cli/drpcli_contents_unbundle.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_update.rst
+++ b/doc/cli/drpcli_contents_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contents_upload.rst
+++ b/doc/cli/drpcli_contents_upload.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts.rst
+++ b/doc/cli/drpcli_contexts.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_create.rst
+++ b/doc/cli/drpcli_contexts_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_destroy.rst
+++ b/doc/cli/drpcli_contexts_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_exists.rst
+++ b/doc/cli/drpcli_contexts_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_indexes.rst
+++ b/doc/cli/drpcli_contexts_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_list.rst
+++ b/doc/cli/drpcli_contexts_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_meta.rst
+++ b/doc/cli/drpcli_contexts_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_meta_add.rst
+++ b/doc/cli/drpcli_contexts_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_meta_get.rst
+++ b/doc/cli/drpcli_contexts_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_meta_remove.rst
+++ b/doc/cli/drpcli_contexts_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_meta_set.rst
+++ b/doc/cli/drpcli_contexts_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_show.rst
+++ b/doc/cli/drpcli_contexts_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_update.rst
+++ b/doc/cli/drpcli_contexts_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_contexts_wait.rst
+++ b/doc/cli/drpcli_contexts_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_debug.rst
+++ b/doc/cli/drpcli_debug.rst
@@ -57,13 +57,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_events.rst
+++ b/doc/cli/drpcli_events.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_events_post.rst
+++ b/doc/cli/drpcli_events_post.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_events_watch.rst
+++ b/doc/cli/drpcli_events_watch.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended.rst
+++ b/doc/cli/drpcli_extended.rst
@@ -26,13 +26,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_action.rst
+++ b/doc/cli/drpcli_extended_action.rst
@@ -30,14 +30,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_actions.rst
+++ b/doc/cli/drpcli_extended_actions.rst
@@ -30,14 +30,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_add.rst
+++ b/doc/cli/drpcli_extended_add.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_create.rst
+++ b/doc/cli/drpcli_extended_create.rst
@@ -34,14 +34,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_destroy.rst
+++ b/doc/cli/drpcli_extended_destroy.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_exists.rst
+++ b/doc/cli/drpcli_extended_exists.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_get.rst
+++ b/doc/cli/drpcli_extended_get.rst
@@ -32,14 +32,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_indexes.rst
+++ b/doc/cli/drpcli_extended_indexes.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_list.rst
+++ b/doc/cli/drpcli_extended_list.rst
@@ -74,14 +74,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_meta.rst
+++ b/doc/cli/drpcli_extended_meta.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_meta_add.rst
+++ b/doc/cli/drpcli_extended_meta_add.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_meta_get.rst
+++ b/doc/cli/drpcli_extended_meta_get.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_meta_remove.rst
+++ b/doc/cli/drpcli_extended_meta_remove.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_meta_set.rst
+++ b/doc/cli/drpcli_extended_meta_set.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_params.rst
+++ b/doc/cli/drpcli_extended_params.rst
@@ -33,14 +33,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_remove.rst
+++ b/doc/cli/drpcli_extended_remove.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_runaction.rst
+++ b/doc/cli/drpcli_extended_runaction.rst
@@ -30,14 +30,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_set.rst
+++ b/doc/cli/drpcli_extended_set.rst
@@ -29,14 +29,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_show.rst
+++ b/doc/cli/drpcli_extended_show.rst
@@ -33,14 +33,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_update.rst
+++ b/doc/cli/drpcli_extended_update.rst
@@ -30,14 +30,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_extended_wait.rst
+++ b/doc/cli/drpcli_extended_wait.rst
@@ -34,14 +34,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -l, --ldata string            object type for extended data commands
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_files.rst
+++ b/doc/cli/drpcli_files.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_files_destroy.rst
+++ b/doc/cli/drpcli_files_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_files_download.rst
+++ b/doc/cli/drpcli_files_download.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_files_exists.rst
+++ b/doc/cli/drpcli_files_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_files_list.rst
+++ b/doc/cli/drpcli_files_list.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_files_upload.rst
+++ b/doc/cli/drpcli_files_upload.rst
@@ -6,7 +6,20 @@ Upload the files [src] as [dest]
 Synopsis
 ~~~~~~~~
 
-Upload the files [src] as [dest]
+The DRP files API allows exploding a compressed file, using bsdtar,
+after it has been uploaded. This can be very helpful when multiple files
+or a full directory tree are being uploaded.
+
+This is a two stage process enabled by the –explode flag. The first
+stage simply uploads the compressed file to the target path and
+location. The second stage explodes the file in that path.
+
+For example: *drpcli files upload my.zip as mypath/my.zip –explode*
+
+The above command will upload the *my.zip* file to the files *mypath*
+location. It will also expand all the files in *my.zip* into */mypath*
+after upload. All paths in *my.zip* will be preserved and created
+relative to */mypath*.
 
 ::
 
@@ -17,7 +30,7 @@ Options
 
 ::
 
-         --explode   Should the upload file be untarred
+         --explode   After upload, file will be untarred/unzipped in file's local path
      -h, --help      help for upload
 
 Options inherited from parent commands
@@ -30,13 +43,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_gohai.rst
+++ b/doc/cli/drpcli_gohai.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_info.rst
+++ b/doc/cli/drpcli_info.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_info_check.rst
+++ b/doc/cli/drpcli_info_check.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_info_get.rst
+++ b/doc/cli/drpcli_info_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_info_status.rst
+++ b/doc/cli/drpcli_info_status.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_interfaces.rst
+++ b/doc/cli/drpcli_interfaces.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_interfaces_exists.rst
+++ b/doc/cli/drpcli_interfaces_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_interfaces_indexes.rst
+++ b/doc/cli/drpcli_interfaces_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_interfaces_list.rst
+++ b/doc/cli/drpcli_interfaces_list.rst
@@ -71,13 +71,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_interfaces_show.rst
+++ b/doc/cli/drpcli_interfaces_show.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_interfaces_wait.rst
+++ b/doc/cli/drpcli_interfaces_wait.rst
@@ -35,13 +35,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_isos.rst
+++ b/doc/cli/drpcli_isos.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_isos_destroy.rst
+++ b/doc/cli/drpcli_isos_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_isos_download.rst
+++ b/doc/cli/drpcli_isos_download.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_isos_exists.rst
+++ b/doc/cli/drpcli_isos_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_isos_list.rst
+++ b/doc/cli/drpcli_isos_list.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_isos_upload.rst
+++ b/doc/cli/drpcli_isos_upload.rst
@@ -6,7 +6,20 @@ Upload the isos [src] as [dest]
 Synopsis
 ~~~~~~~~
 
-Upload the isos [src] as [dest]
+The DRP files API allows exploding a compressed file, using bsdtar,
+after it has been uploaded. This can be very helpful when multiple files
+or a full directory tree are being uploaded.
+
+This is a two stage process enabled by the –explode flag. The first
+stage simply uploads the compressed file to the target path and
+location. The second stage explodes the file in that path.
+
+For example: *drpcli files upload my.zip as mypath/my.zip –explode*
+
+The above command will upload the *my.zip* file to the files *mypath*
+location. It will also expand all the files in *my.zip* into */mypath*
+after upload. All paths in *my.zip* will be preserved and created
+relative to */mypath*.
 
 ::
 
@@ -17,7 +30,7 @@ Options
 
 ::
 
-         --explode   Should the upload file be untarred
+         --explode   After upload, file will be untarred/unzipped in file's local path
      -h, --help      help for upload
 
 Options inherited from parent commands
@@ -30,13 +43,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs.rst
+++ b/doc/cli/drpcli_jobs.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_actions.rst
+++ b/doc/cli/drpcli_jobs_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_create.rst
+++ b/doc/cli/drpcli_jobs_create.rst
@@ -33,13 +33,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_destroy.rst
+++ b/doc/cli/drpcli_jobs_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_exists.rst
+++ b/doc/cli/drpcli_jobs_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_indexes.rst
+++ b/doc/cli/drpcli_jobs_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_list.rst
+++ b/doc/cli/drpcli_jobs_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_log.rst
+++ b/doc/cli/drpcli_jobs_log.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_meta.rst
+++ b/doc/cli/drpcli_jobs_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_meta_add.rst
+++ b/doc/cli/drpcli_jobs_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_meta_get.rst
+++ b/doc/cli/drpcli_jobs_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_meta_remove.rst
+++ b/doc/cli/drpcli_jobs_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_meta_set.rst
+++ b/doc/cli/drpcli_jobs_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_plugin_action.rst
+++ b/doc/cli/drpcli_jobs_plugin_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_plugin_actions.rst
+++ b/doc/cli/drpcli_jobs_plugin_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_runplugin_action.rst
+++ b/doc/cli/drpcli_jobs_runplugin_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_show.rst
+++ b/doc/cli/drpcli_jobs_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_update.rst
+++ b/doc/cli/drpcli_jobs_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_jobs_wait.rst
+++ b/doc/cli/drpcli_jobs_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases.rst
+++ b/doc/cli/drpcli_leases.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_action.rst
+++ b/doc/cli/drpcli_leases_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_actions.rst
+++ b/doc/cli/drpcli_leases_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_destroy.rst
+++ b/doc/cli/drpcli_leases_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_exists.rst
+++ b/doc/cli/drpcli_leases_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_indexes.rst
+++ b/doc/cli/drpcli_leases_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_list.rst
+++ b/doc/cli/drpcli_leases_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_meta.rst
+++ b/doc/cli/drpcli_leases_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_meta_add.rst
+++ b/doc/cli/drpcli_leases_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_meta_get.rst
+++ b/doc/cli/drpcli_leases_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_meta_remove.rst
+++ b/doc/cli/drpcli_leases_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_meta_set.rst
+++ b/doc/cli/drpcli_leases_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_runaction.rst
+++ b/doc/cli/drpcli_leases_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_show.rst
+++ b/doc/cli/drpcli_leases_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_leases_wait.rst
+++ b/doc/cli/drpcli_leases_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_logs.rst
+++ b/doc/cli/drpcli_logs.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_logs_get.rst
+++ b/doc/cli/drpcli_logs_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_logs_watch.rst
+++ b/doc/cli/drpcli_logs_watch.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines.rst
+++ b/doc/cli/drpcli_machines.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_action.rst
+++ b/doc/cli/drpcli_machines_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_actions.rst
+++ b/doc/cli/drpcli_machines_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_add.rst
+++ b/doc/cli/drpcli_machines_add.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_addprofile.rst
+++ b/doc/cli/drpcli_machines_addprofile.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_addtask.rst
+++ b/doc/cli/drpcli_machines_addtask.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_bootenv.rst
+++ b/doc/cli/drpcli_machines_bootenv.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_create.rst
+++ b/doc/cli/drpcli_machines_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_currentlog.rst
+++ b/doc/cli/drpcli_machines_currentlog.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_deletejobs.rst
+++ b/doc/cli/drpcli_machines_deletejobs.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_destroy.rst
+++ b/doc/cli/drpcli_machines_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_exists.rst
+++ b/doc/cli/drpcli_machines_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_get.rst
+++ b/doc/cli/drpcli_machines_get.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_indexes.rst
+++ b/doc/cli/drpcli_machines_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_inserttask.rst
+++ b/doc/cli/drpcli_machines_inserttask.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_inspect.rst
+++ b/doc/cli/drpcli_machines_inspect.rst
@@ -26,13 +26,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_inspect_jobs.rst
+++ b/doc/cli/drpcli_machines_inspect_jobs.rst
@@ -31,14 +31,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -A, --full                    Should the command return full information or summary
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_inspect_tasks.rst
+++ b/doc/cli/drpcli_machines_inspect_tasks.rst
@@ -32,14 +32,17 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
      -A, --full                    Should the command return full information or summary
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_jobs.rst
+++ b/doc/cli/drpcli_machines_jobs.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_jobs_create.rst
+++ b/doc/cli/drpcli_machines_jobs_create.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_jobs_current.rst
+++ b/doc/cli/drpcli_machines_jobs_current.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_jobs_state.rst
+++ b/doc/cli/drpcli_machines_jobs_state.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_list.rst
+++ b/doc/cli/drpcli_machines_list.rst
@@ -74,13 +74,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_meta.rst
+++ b/doc/cli/drpcli_machines_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_meta_add.rst
+++ b/doc/cli/drpcli_machines_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_meta_get.rst
+++ b/doc/cli/drpcli_machines_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_meta_remove.rst
+++ b/doc/cli/drpcli_machines_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_meta_set.rst
+++ b/doc/cli/drpcli_machines_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_params.rst
+++ b/doc/cli/drpcli_machines_params.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_processjobs.rst
+++ b/doc/cli/drpcli_machines_processjobs.rst
@@ -37,13 +37,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_remove.rst
+++ b/doc/cli/drpcli_machines_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_removeprofile.rst
+++ b/doc/cli/drpcli_machines_removeprofile.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_removetask.rst
+++ b/doc/cli/drpcli_machines_removetask.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_runaction.rst
+++ b/doc/cli/drpcli_machines_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_set.rst
+++ b/doc/cli/drpcli_machines_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_show.rst
+++ b/doc/cli/drpcli_machines_show.rst
@@ -33,13 +33,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_stage.rst
+++ b/doc/cli/drpcli_machines_stage.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_tasks.rst
+++ b/doc/cli/drpcli_machines_tasks.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_tasks_add.rst
+++ b/doc/cli/drpcli_machines_tasks_add.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_tasks_del.rst
+++ b/doc/cli/drpcli_machines_tasks_del.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_update.rst
+++ b/doc/cli/drpcli_machines_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_wait.rst
+++ b/doc/cli/drpcli_machines_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_machines_workflow.rst
+++ b/doc/cli/drpcli_machines_workflow.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_objects.rst
+++ b/doc/cli/drpcli_objects.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_objects_list.rst
+++ b/doc/cli/drpcli_objects_list.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params.rst
+++ b/doc/cli/drpcli_params.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_create.rst
+++ b/doc/cli/drpcli_params_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_destroy.rst
+++ b/doc/cli/drpcli_params_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_exists.rst
+++ b/doc/cli/drpcli_params_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_indexes.rst
+++ b/doc/cli/drpcli_params_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_list.rst
+++ b/doc/cli/drpcli_params_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_meta.rst
+++ b/doc/cli/drpcli_params_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_meta_add.rst
+++ b/doc/cli/drpcli_params_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_meta_get.rst
+++ b/doc/cli/drpcli_params_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_meta_remove.rst
+++ b/doc/cli/drpcli_params_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_meta_set.rst
+++ b/doc/cli/drpcli_params_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_show.rst
+++ b/doc/cli/drpcli_params_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_update.rst
+++ b/doc/cli/drpcli_params_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_params_wait.rst
+++ b/doc/cli/drpcli_params_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers.rst
+++ b/doc/cli/drpcli_plugin_providers.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_destroy.rst
+++ b/doc/cli/drpcli_plugin_providers_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_exists.rst
+++ b/doc/cli/drpcli_plugin_providers_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_indexes.rst
+++ b/doc/cli/drpcli_plugin_providers_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_list.rst
+++ b/doc/cli/drpcli_plugin_providers_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_meta.rst
+++ b/doc/cli/drpcli_plugin_providers_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_meta_add.rst
+++ b/doc/cli/drpcli_plugin_providers_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_meta_get.rst
+++ b/doc/cli/drpcli_plugin_providers_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_meta_remove.rst
+++ b/doc/cli/drpcli_plugin_providers_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_meta_set.rst
+++ b/doc/cli/drpcli_plugin_providers_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_show.rst
+++ b/doc/cli/drpcli_plugin_providers_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_upload.rst
+++ b/doc/cli/drpcli_plugin_providers_upload.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugin_providers_wait.rst
+++ b/doc/cli/drpcli_plugin_providers_wait.rst
@@ -35,13 +35,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins.rst
+++ b/doc/cli/drpcli_plugins.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_action.rst
+++ b/doc/cli/drpcli_plugins_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_actions.rst
+++ b/doc/cli/drpcli_plugins_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_add.rst
+++ b/doc/cli/drpcli_plugins_add.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_create.rst
+++ b/doc/cli/drpcli_plugins_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_destroy.rst
+++ b/doc/cli/drpcli_plugins_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_exists.rst
+++ b/doc/cli/drpcli_plugins_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_get.rst
+++ b/doc/cli/drpcli_plugins_get.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_indexes.rst
+++ b/doc/cli/drpcli_plugins_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_list.rst
+++ b/doc/cli/drpcli_plugins_list.rst
@@ -74,13 +74,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_meta.rst
+++ b/doc/cli/drpcli_plugins_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_meta_add.rst
+++ b/doc/cli/drpcli_plugins_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_meta_get.rst
+++ b/doc/cli/drpcli_plugins_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_meta_remove.rst
+++ b/doc/cli/drpcli_plugins_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_meta_set.rst
+++ b/doc/cli/drpcli_plugins_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_params.rst
+++ b/doc/cli/drpcli_plugins_params.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_remove.rst
+++ b/doc/cli/drpcli_plugins_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_runaction.rst
+++ b/doc/cli/drpcli_plugins_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_set.rst
+++ b/doc/cli/drpcli_plugins_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_show.rst
+++ b/doc/cli/drpcli_plugins_show.rst
@@ -33,13 +33,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_update.rst
+++ b/doc/cli/drpcli_plugins_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_plugins_wait.rst
+++ b/doc/cli/drpcli_plugins_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_prefs.rst
+++ b/doc/cli/drpcli_prefs.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_prefs_list.rst
+++ b/doc/cli/drpcli_prefs_list.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_prefs_set.rst
+++ b/doc/cli/drpcli_prefs_set.rst
@@ -6,7 +6,10 @@ Set preferences
 Synopsis
 ~~~~~~~~
 
-Set preferences
+WARNING! Changing baseTokenSecret or systemGrantorSecret will invalidate
+existing sessions and tokens. This will require users to reauthenticate
+and may cause active WSS sessions to hang. Do not change these values
+unless you are able to reset all client sessions.
 
 ::
 
@@ -29,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles.rst
+++ b/doc/cli/drpcli_profiles.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_action.rst
+++ b/doc/cli/drpcli_profiles_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_actions.rst
+++ b/doc/cli/drpcli_profiles_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_add.rst
+++ b/doc/cli/drpcli_profiles_add.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_addprofile.rst
+++ b/doc/cli/drpcli_profiles_addprofile.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_create.rst
+++ b/doc/cli/drpcli_profiles_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_destroy.rst
+++ b/doc/cli/drpcli_profiles_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_exists.rst
+++ b/doc/cli/drpcli_profiles_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_get.rst
+++ b/doc/cli/drpcli_profiles_get.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_indexes.rst
+++ b/doc/cli/drpcli_profiles_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_list.rst
+++ b/doc/cli/drpcli_profiles_list.rst
@@ -74,13 +74,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_meta.rst
+++ b/doc/cli/drpcli_profiles_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_meta_add.rst
+++ b/doc/cli/drpcli_profiles_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_meta_get.rst
+++ b/doc/cli/drpcli_profiles_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_meta_remove.rst
+++ b/doc/cli/drpcli_profiles_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_meta_set.rst
+++ b/doc/cli/drpcli_profiles_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_params.rst
+++ b/doc/cli/drpcli_profiles_params.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_remove.rst
+++ b/doc/cli/drpcli_profiles_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_removeprofile.rst
+++ b/doc/cli/drpcli_profiles_removeprofile.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_runaction.rst
+++ b/doc/cli/drpcli_profiles_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_set.rst
+++ b/doc/cli/drpcli_profiles_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_show.rst
+++ b/doc/cli/drpcli_profiles_show.rst
@@ -33,13 +33,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_update.rst
+++ b/doc/cli/drpcli_profiles_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_profiles_wait.rst
+++ b/doc/cli/drpcli_profiles_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_proxy.rst
+++ b/doc/cli/drpcli_proxy.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations.rst
+++ b/doc/cli/drpcli_reservations.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_action.rst
+++ b/doc/cli/drpcli_reservations_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_actions.rst
+++ b/doc/cli/drpcli_reservations_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_create.rst
+++ b/doc/cli/drpcli_reservations_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_destroy.rst
+++ b/doc/cli/drpcli_reservations_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_exists.rst
+++ b/doc/cli/drpcli_reservations_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_indexes.rst
+++ b/doc/cli/drpcli_reservations_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_list.rst
+++ b/doc/cli/drpcli_reservations_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_meta.rst
+++ b/doc/cli/drpcli_reservations_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_meta_add.rst
+++ b/doc/cli/drpcli_reservations_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_meta_get.rst
+++ b/doc/cli/drpcli_reservations_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_meta_remove.rst
+++ b/doc/cli/drpcli_reservations_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_meta_set.rst
+++ b/doc/cli/drpcli_reservations_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_runaction.rst
+++ b/doc/cli/drpcli_reservations_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_show.rst
+++ b/doc/cli/drpcli_reservations_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_update.rst
+++ b/doc/cli/drpcli_reservations_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_reservations_wait.rst
+++ b/doc/cli/drpcli_reservations_wait.rst
@@ -35,13 +35,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles.rst
+++ b/doc/cli/drpcli_roles.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_create.rst
+++ b/doc/cli/drpcli_roles_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_destroy.rst
+++ b/doc/cli/drpcli_roles_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_exists.rst
+++ b/doc/cli/drpcli_roles_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_indexes.rst
+++ b/doc/cli/drpcli_roles_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_list.rst
+++ b/doc/cli/drpcli_roles_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_meta.rst
+++ b/doc/cli/drpcli_roles_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_meta_add.rst
+++ b/doc/cli/drpcli_roles_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_meta_get.rst
+++ b/doc/cli/drpcli_roles_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_meta_remove.rst
+++ b/doc/cli/drpcli_roles_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_meta_set.rst
+++ b/doc/cli/drpcli_roles_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_show.rst
+++ b/doc/cli/drpcli_roles_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_update.rst
+++ b/doc/cli/drpcli_roles_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_roles_wait.rst
+++ b/doc/cli/drpcli_roles_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages.rst
+++ b/doc/cli/drpcli_stages.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_action.rst
+++ b/doc/cli/drpcli_stages_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_actions.rst
+++ b/doc/cli/drpcli_stages_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_add.rst
+++ b/doc/cli/drpcli_stages_add.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_addprofile.rst
+++ b/doc/cli/drpcli_stages_addprofile.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_addtask.rst
+++ b/doc/cli/drpcli_stages_addtask.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_bootenv.rst
+++ b/doc/cli/drpcli_stages_bootenv.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_create.rst
+++ b/doc/cli/drpcli_stages_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_destroy.rst
+++ b/doc/cli/drpcli_stages_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_exists.rst
+++ b/doc/cli/drpcli_stages_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_get.rst
+++ b/doc/cli/drpcli_stages_get.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_indexes.rst
+++ b/doc/cli/drpcli_stages_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_list.rst
+++ b/doc/cli/drpcli_stages_list.rst
@@ -74,13 +74,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_meta.rst
+++ b/doc/cli/drpcli_stages_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_meta_add.rst
+++ b/doc/cli/drpcli_stages_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_meta_get.rst
+++ b/doc/cli/drpcli_stages_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_meta_remove.rst
+++ b/doc/cli/drpcli_stages_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_meta_set.rst
+++ b/doc/cli/drpcli_stages_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_params.rst
+++ b/doc/cli/drpcli_stages_params.rst
@@ -32,13 +32,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_remove.rst
+++ b/doc/cli/drpcli_stages_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_removeprofile.rst
+++ b/doc/cli/drpcli_stages_removeprofile.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_removetask.rst
+++ b/doc/cli/drpcli_stages_removetask.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_runaction.rst
+++ b/doc/cli/drpcli_stages_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_set.rst
+++ b/doc/cli/drpcli_stages_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_show.rst
+++ b/doc/cli/drpcli_stages_show.rst
@@ -33,13 +33,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_update.rst
+++ b/doc/cli/drpcli_stages_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_stages_wait.rst
+++ b/doc/cli/drpcli_stages_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets.rst
+++ b/doc/cli/drpcli_subnets.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_action.rst
+++ b/doc/cli/drpcli_subnets_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_actions.rst
+++ b/doc/cli/drpcli_subnets_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_create.rst
+++ b/doc/cli/drpcli_subnets_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_destroy.rst
+++ b/doc/cli/drpcli_subnets_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_exists.rst
+++ b/doc/cli/drpcli_subnets_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_get.rst
+++ b/doc/cli/drpcli_subnets_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_indexes.rst
+++ b/doc/cli/drpcli_subnets_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_leasetimes.rst
+++ b/doc/cli/drpcli_subnets_leasetimes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_list.rst
+++ b/doc/cli/drpcli_subnets_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_meta.rst
+++ b/doc/cli/drpcli_subnets_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_meta_add.rst
+++ b/doc/cli/drpcli_subnets_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_meta_get.rst
+++ b/doc/cli/drpcli_subnets_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_meta_remove.rst
+++ b/doc/cli/drpcli_subnets_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_meta_set.rst
+++ b/doc/cli/drpcli_subnets_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_nextserver.rst
+++ b/doc/cli/drpcli_subnets_nextserver.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_pickers.rst
+++ b/doc/cli/drpcli_subnets_pickers.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_range.rst
+++ b/doc/cli/drpcli_subnets_range.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_runaction.rst
+++ b/doc/cli/drpcli_subnets_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_set.rst
+++ b/doc/cli/drpcli_subnets_set.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_show.rst
+++ b/doc/cli/drpcli_subnets_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_update.rst
+++ b/doc/cli/drpcli_subnets_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_subnets_wait.rst
+++ b/doc/cli/drpcli_subnets_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_system.rst
+++ b/doc/cli/drpcli_system.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_system_action.rst
+++ b/doc/cli/drpcli_system_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_system_actions.rst
+++ b/doc/cli/drpcli_system_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_system_runaction.rst
+++ b/doc/cli/drpcli_system_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_system_upgrade.rst
+++ b/doc/cli/drpcli_system_upgrade.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks.rst
+++ b/doc/cli/drpcli_tasks.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_action.rst
+++ b/doc/cli/drpcli_tasks_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_actions.rst
+++ b/doc/cli/drpcli_tasks_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_create.rst
+++ b/doc/cli/drpcli_tasks_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_destroy.rst
+++ b/doc/cli/drpcli_tasks_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_exists.rst
+++ b/doc/cli/drpcli_tasks_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_indexes.rst
+++ b/doc/cli/drpcli_tasks_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_list.rst
+++ b/doc/cli/drpcli_tasks_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_meta.rst
+++ b/doc/cli/drpcli_tasks_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_meta_add.rst
+++ b/doc/cli/drpcli_tasks_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_meta_get.rst
+++ b/doc/cli/drpcli_tasks_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_meta_remove.rst
+++ b/doc/cli/drpcli_tasks_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_meta_set.rst
+++ b/doc/cli/drpcli_tasks_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_runaction.rst
+++ b/doc/cli/drpcli_tasks_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_show.rst
+++ b/doc/cli/drpcli_tasks_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_update.rst
+++ b/doc/cli/drpcli_tasks_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tasks_wait.rst
+++ b/doc/cli/drpcli_tasks_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates.rst
+++ b/doc/cli/drpcli_templates.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_action.rst
+++ b/doc/cli/drpcli_templates_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_actions.rst
+++ b/doc/cli/drpcli_templates_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_create.rst
+++ b/doc/cli/drpcli_templates_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_destroy.rst
+++ b/doc/cli/drpcli_templates_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_exists.rst
+++ b/doc/cli/drpcli_templates_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_indexes.rst
+++ b/doc/cli/drpcli_templates_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_list.rst
+++ b/doc/cli/drpcli_templates_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_meta.rst
+++ b/doc/cli/drpcli_templates_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_meta_add.rst
+++ b/doc/cli/drpcli_templates_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_meta_get.rst
+++ b/doc/cli/drpcli_templates_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_meta_remove.rst
+++ b/doc/cli/drpcli_templates_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_meta_set.rst
+++ b/doc/cli/drpcli_templates_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_runaction.rst
+++ b/doc/cli/drpcli_templates_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_show.rst
+++ b/doc/cli/drpcli_templates_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_update.rst
+++ b/doc/cli/drpcli_templates_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_upload.rst
+++ b/doc/cli/drpcli_templates_upload.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_templates_wait.rst
+++ b/doc/cli/drpcli_templates_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants.rst
+++ b/doc/cli/drpcli_tenants.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_create.rst
+++ b/doc/cli/drpcli_tenants_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_destroy.rst
+++ b/doc/cli/drpcli_tenants_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_exists.rst
+++ b/doc/cli/drpcli_tenants_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_indexes.rst
+++ b/doc/cli/drpcli_tenants_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_list.rst
+++ b/doc/cli/drpcli_tenants_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_meta.rst
+++ b/doc/cli/drpcli_tenants_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_meta_add.rst
+++ b/doc/cli/drpcli_tenants_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_meta_get.rst
+++ b/doc/cli/drpcli_tenants_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_meta_remove.rst
+++ b/doc/cli/drpcli_tenants_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_meta_set.rst
+++ b/doc/cli/drpcli_tenants_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_show.rst
+++ b/doc/cli/drpcli_tenants_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_update.rst
+++ b/doc/cli/drpcli_tenants_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_tenants_wait.rst
+++ b/doc/cli/drpcli_tenants_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users.rst
+++ b/doc/cli/drpcli_users.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_action.rst
+++ b/doc/cli/drpcli_users_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_actions.rst
+++ b/doc/cli/drpcli_users_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_create.rst
+++ b/doc/cli/drpcli_users_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_destroy.rst
+++ b/doc/cli/drpcli_users_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_exists.rst
+++ b/doc/cli/drpcli_users_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_indexes.rst
+++ b/doc/cli/drpcli_users_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_list.rst
+++ b/doc/cli/drpcli_users_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_meta.rst
+++ b/doc/cli/drpcli_users_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_meta_add.rst
+++ b/doc/cli/drpcli_users_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_meta_get.rst
+++ b/doc/cli/drpcli_users_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_meta_remove.rst
+++ b/doc/cli/drpcli_users_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_meta_set.rst
+++ b/doc/cli/drpcli_users_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_password.rst
+++ b/doc/cli/drpcli_users_password.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_passwordhash.rst
+++ b/doc/cli/drpcli_users_passwordhash.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_runaction.rst
+++ b/doc/cli/drpcli_users_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_show.rst
+++ b/doc/cli/drpcli_users_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_token.rst
+++ b/doc/cli/drpcli_users_token.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_update.rst
+++ b/doc/cli/drpcli_users_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_users_wait.rst
+++ b/doc/cli/drpcli_users_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_version.rst
+++ b/doc/cli/drpcli_version.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows.rst
+++ b/doc/cli/drpcli_workflows.rst
@@ -25,13 +25,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_action.rst
+++ b/doc/cli/drpcli_workflows_action.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_actions.rst
+++ b/doc/cli/drpcli_workflows_actions.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_create.rst
+++ b/doc/cli/drpcli_workflows_create.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_destroy.rst
+++ b/doc/cli/drpcli_workflows_destroy.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_exists.rst
+++ b/doc/cli/drpcli_workflows_exists.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_indexes.rst
+++ b/doc/cli/drpcli_workflows_indexes.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_list.rst
+++ b/doc/cli/drpcli_workflows_list.rst
@@ -72,13 +72,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_meta.rst
+++ b/doc/cli/drpcli_workflows_meta.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_meta_add.rst
+++ b/doc/cli/drpcli_workflows_meta_add.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_meta_get.rst
+++ b/doc/cli/drpcli_workflows_meta_get.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_meta_remove.rst
+++ b/doc/cli/drpcli_workflows_meta_remove.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_meta_set.rst
+++ b/doc/cli/drpcli_workflows_meta_set.rst
@@ -29,13 +29,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_runaction.rst
+++ b/doc/cli/drpcli_workflows_runaction.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_show.rst
+++ b/doc/cli/drpcli_workflows_show.rst
@@ -31,13 +31,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_update.rst
+++ b/doc/cli/drpcli_workflows_update.rst
@@ -30,13 +30,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/doc/cli/drpcli_workflows_wait.rst
+++ b/doc/cli/drpcli_workflows_wait.rst
@@ -34,13 +34,16 @@ Options inherited from parent commands
      -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
      -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
      -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
-     -F, --format string           The serialzation we expect for output.  Can be "json" or "yaml" (default "json")
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
      -x, --noToken                 Do not use token auth or token cache
      -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
      -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
      -T, --token string            token of the Digital Rebar Provision access
      -t, --trace string            The log level API requests should be logged at on the server side
      -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
      -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
 
 SEE ALSO

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/klauspost/cpuid v1.2.1 // indirect
 	github.com/klauspost/pgzip v1.2.1
 	github.com/krolaw/dhcp4 v0.0.0-20190531080455-7b64900047ae
+	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pborman/uuid v1.2.0
 	github.com/rackn/gohai v0.3.0
 	github.com/rackn/netwrangler v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -56,10 +56,14 @@ github.com/klauspost/pgzip v1.2.1 h1:oIPZROsWuPHpOdMVWLuJZXwgjhrW8r1yEX8UqMyeNHM
 github.com/klauspost/pgzip v1.2.1/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/krolaw/dhcp4 v0.0.0-20190531080455-7b64900047ae h1:eJIlhimWuFB4RmBV8UWt2CJhEPGunO0obfXHzzUxrOU=
 github.com/krolaw/dhcp4 v0.0.0-20190531080455-7b64900047ae/go.mod h1:0AqAH3ZogsCrvrtUpvc6EtVKbc3w6xwZhkvGLuqyi3o=
+github.com/mattn/go-runewidth v0.0.7 h1:Ei8KR0497xHyKJPAv59M1dkC+rOZCMBJ+t3fZ+twI54=
+github.com/mattn/go-runewidth v0.0.7/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OHLH3mGKHDcjJRFFRrJa6eAM5H+CtDdOsPc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
+github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/pborman/uuid v1.2.0 h1:J7Q5mO4ysT1dv8hyrUGHb9+ooztCXu1D8MY8DZYsu3g=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=


### PR DESCRIPTION
are now available.

RS_FORMAT (-F) = format to use (json,yaml,text,table)
RS_PRINT_FIELDS (-J) = comma separate list of fields to show
RS_NO_HEADER (-H) = remove the header fields
RS_TRUNCATE_LENGTH (-j) = limits the length of fields displayed