### PR TITLE
Fixes to install.sh

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -278,9 +278,7 @@ esac
 # Wait until DRP is ready, or exit
 check_drp_ready() {
     COUNT=0
-    local _RSE
-    [[ -n "$RS_ENDPOINT" ]] && _RSE="-E https://127.0.0.1:8092"
-    while ! drpcli ${_RSE} info get 2>/dev/null >/dev/null ; do
+    while ! drpcli info get > /dev/null 2>&1 ; do
         echo "DRP is not up yet, waiting ($COUNT) ..."
         sleep 2
         # Pre-increment for compatibility with Bash 4.1+
@@ -1015,9 +1013,9 @@ EOF
          [[ -f ${BIN_DIR}/drp-install.sh ]] && rm -f ${BIN_DIR}/drp-install.sh
          if [[ $REMOVE_DATA == true ]] ; then
              printf "Removing data files and directories ... "
-             [[ -d "/usr/share/dr-provision" ]] && RM_DIR="/usr/share/dr-provision "
-             [[ -d "/etc/dr-provision" ]] && RM_DIR+="/etc/dr-provision "
-             [[ -d "${DRP_HOME_DIR}" ]] && RM_DIR+="${DRP_HOME_DIR}"
+             [[ -d "/usr/share/dr-provision" ]] && RM_DIR="/usr/share/dr-provision " || true
+             [[ -d "/etc/dr-provision" ]] && RM_DIR+="/etc/dr-provision " || true
+             [[ -d "${DRP_HOME_DIR}" ]] && RM_DIR+="${DRP_HOME_DIR}" || true
              echo "$RM_DIR"
              $_sudo rm -rf $RM_DIR
          fi


### PR DESCRIPTION
There were several bugs in the behavior in the `install.sh` script.  Some cleanups around usage() as well.
* add usage warning that `install` over writes existing installation
* remove gratuitous `touch` which causes zero length files
* fix `for` loop to `chown`, with `|| true` to prevent error exit
* add `export RS_ENDPOINT=https://127.0.0.1:8092` - on DRP endpoint managed systems, DRP endpoint install tests will fail or behave inconsistently since they are testing the managing DRP, not he service currently being installed
* correctly fix restore of `drpcli` backup binary (for systems under existing DRP endpoint control)
* fix directory checks before trying to remove them
