### PR TITLE
Start of new feature.  BootEnv templates can contain links

### DIFF
--- a/models/machine.go
+++ b/models/machine.go
@@ -12,6 +12,10 @@ import (
 // it is one we know how to normalize.
 func SupportedArch(s string) (string, bool) {
 	switch strings.ToLower(s) {
+	// rpi4 is a hack because it is really arm64, but reports as amd64.
+	// We build a lying bootenv for this purpose.
+	case "rpi4":
+		return "rpi4", true
 	case "amd64", "x86_64":
 		return "amd64", true
 	case "386", "486", "686", "i386", "i486", "i686":


### PR DESCRIPTION
to other files in the filesystem.  This allows for dynamic
names to static files.  This is needed for certain hardware
types.

Also, allow for the fake arch rpi4.  It is a lie, but lets
us handle certain badness that the rpi4 has.