### PR TITLE
Added doc path for arch/data

### DIFF
--- a/doc/arch.rst
+++ b/doc/arch.rst
@@ -15,6 +15,7 @@ dr-provision for developers and power users.
 .. toctree::
 
    arch/design
+   arch/data
    arch/models
    arch/auth
    arch/provision


### PR DESCRIPTION
Community pointed out missing link to doc. This patch adds the missing link.

Signed-off-by: Michael Rice <michael@michaelrice.org>