### PR TITLE
Added the create catalog feature

### DIFF
--- a/cli/catalog.go
+++ b/cli/catalog.go
@@ -348,6 +348,34 @@ and wind up in a file with the same name as the item + the default file extensio
 	}
 	cmd.AddCommand(updateCmd)
 
+	// Start of create stuff
+	var pkgVer string
+	createCmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a custom catalog for Digital Rebar",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cat, err := fetchCatalog()
+			if err != nil {
+				return err
+			}
+			newMap := map[string]interface{}{}
+			for k, v := range cat.Sections["catalog_items"] {
+				item := &models.CatalogItem{}
+				if err := models.Remarshal(v, &item); err != nil {
+					continue
+				}
+				if item.Version == pkgVer {
+					newMap[k] = item
+				}
+			}
+			cat.Sections["catalog_items"] = newMap
+			return prettyPrint(cat)
+		},
+	}
+	createCmd.Flags().StringVarP(&pkgVer, "pkg-version", "", "", "pkg-version tip|stable (required)")
+	createCmd.MarkFlagRequired("pkg-version")
+	cmd.AddCommand(createCmd)
+
 	return cmd
 }
 


### PR DESCRIPTION
Initial adding of the create catalog feature. This allows a user to set
a catalog source and select a version "stable" or "tip" and a smaller
catalog will be generated using only that selected version.

Usage: drpcli catalog create --pkg-version stable > stable.json

This would pull the default catalog from repo.rackn.io and build a new
catalog of only "stable" marked packages.

Signed-off-by: Michael Rice <michael@michaelrice.org>