### PR TITLE
install.sh learns how to upgrade and remove docker containers

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -571,6 +571,10 @@ install_container() {
             echo "Docker container run time information:"
             $_sudo docker ps --filter name=$CNT_NAME
             echo ""
+            echo ">>>  NOTICE:  If you intend to upgrade this container, record your 'install.sh' options  <<< "
+            echo ">>>           for the 'upgrade' command - you must reuse the same options to obtain the  <<< "
+            echo ">>>           same installed results in the upgraded container.  You have been warned!   <<< "
+            echo ""
             ;;
         *)  exit_cleanup 1 "Container type '$CNT_TYPE' not supported in installer."
             ;;

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -86,6 +86,7 @@ OPTIONS:
 
     install                 # Sets up an isolated or system 'production' enabled install
     upgrade                 # Sets the installer to upgrade an existing 'dr-provision'
+                            # container install kill/rm the DRP container, then upgrade and reattach volume
     remove                  # Removes the system enabled install.  Requires no other flags
                             # optional: '--remove-data' to wipe all installed data
 
@@ -161,6 +162,7 @@ CNT_REGISTRY=index.docker.io
 CNT_NETNS=host
 CNT_ENV=""
 CNT_RESTART="always"
+CNT_VOL_REMOVE=true
 SYSTEM_USER=root
 SYSTEM_GROUP=root
 
@@ -179,7 +181,8 @@ while (( $# > 0 )); do
         --fast-downloader)          FAST_DOWNLOADER=true                ;;
         --force)                    force=true                          ;;
         --remove-data)              REMOVE_DATA=true                    ;;
-        --upgrade)                  UPGRADE=true; force=true            ;;
+        --upgrade)                  UPGRADE=true; force=true
+                                    CNT_VOL_REMOVE=false                ;;
         --nocontent|--no-content)   NO_CONTENT=true                     ;;
         --no-sudo)                  _sudo=""                            ;;
         --keep-installer)           KEEP_INSTALLER=true                 ;;
@@ -510,7 +513,27 @@ FASTMSG
     echo
 } # end show_fast_isos()
 
-install_as_container() {
+remove_container() {
+    case $CNT_TYPE in
+        docker)
+            $_sudo docker kill $CNT_NAME > /dev/null && echo "Killed docker container '$CNT_NAME'"
+            $_sudo docker rm $CNT_NAME > /dev/null && echo "Removed docker container '$CNT_NAME'"
+            if [[ "$CNT_VOL_REMOVE" == "true" ]]; then
+                $_sudo docker volume rm $CNT_VOL > /dev/null && echo "Removed backing volume named '$CNT_VOL'"
+            else
+                echo ">>> Not removing container data volume '$CNT_VOL'"
+                if [[ "$MODE" == "remove" ]]; then
+                    echo "    To remove: '$_sudo docker volume rm $CNT_VOL'"
+                    echo "    or use '--remove-data' next time ... "
+                fi
+            fi
+            ;;
+        *)  exit_cleanup 1 "Container type '$CNT_TYPE' not supported in installer."
+            ;;
+    esac
+} # end remove_container()
+
+install_container() {
     if [[ -n "$CNT_ENV" ]]; then
         for ENV in $CNT_ENV; do
             OPTS="--env $ENV $OPTS"
@@ -520,15 +543,23 @@ install_as_container() {
     case $CNT_TYPE in
         docker)
             ! which docker > /dev/null 2>&1 && exit_cleanup 1 "Container install requested but no 'docker' in PATH ($PATH)."
-            docker volume create $CNT_VOL > /dev/null
-            VOL_MNT=$(docker volume inspect $CNT_VOL | grep Mountpoint | awk -F\" '{ print $4 }')
-            echo "Created docker volume named '$CNT_VOL' with mountpoint '$VOL_MNT'"
+            if [[ "$UPGRADE" != "true" ]]; then
+                $_sudo docker volume create $CNT_VOL > /dev/null
+                VOL_MNT=$($_sudo docker volume inspect $CNT_VOL | grep Mountpoint | awk -F\" '{ print $4 }')
+                echo "Created docker volume named '$CNT_VOL' with mountpoint '$VOL_MNT'"
+            else
+                if $_sudo docker volume inspect $CNT_VOL > /dev/null 2>&1; then
+                    echo "Attempting to reconnect volume '$CNT_VOL'"
+                else
+                    exit_cleanup 1 "No existing volume '$CNT_VOL' found to reconnect."
+                fi
+            fi
             if [[ -z "$CNT_NETNS" ]]; then
               echo "WARNING:  No network namespace set - you may have issues with DHCP and TFTP depending on your use case."
             else
               NETNS="--net $CNT_NETNS"
             fi
-            CMD="docker run $ENV_OPTS --restart "$CNT_RESTART" --volume $CNT_VOL:/provision/drp-data --name \"$CNT_NAME\" -itd $NETNS ${CNT_REGISTRY}/digitalrebar/provision:$DRP_VERSION"
+            CMD="$_sudo docker run $ENV_OPTS --restart "$CNT_RESTART" --volume $CNT_VOL:/provision/drp-data --name \"$CNT_NAME\" -itd $NETNS ${CNT_REGISTRY}/digitalrebar/provision:$DRP_VERSION"
             echo "Starting container with following run command:"
             echo "$CMD"
             eval $CMD
@@ -538,31 +569,37 @@ install_as_container() {
             echo "Volume is backed on host filesystem at: $VOL_MNT"
             echo ""
             echo "Docker container run time information:"
-            docker ps --filter name=$CNT_NAME
+            $_sudo docker ps --filter name=$CNT_NAME
             echo ""
             ;;
         *)  exit_cleanup 1 "Container type '$CNT_TYPE' not supported in installer."
             ;;
     esac
-} # end install_as_container()
+} # end install_container()
 
 # main
 
 MODE=$1
 
 if [[ $OS_FAMILY == "container" || $CONTAINER == "true" ]]; then
-    UPG_MSG="Please upgrade via Portal 'Catalog' menu, or 'drpcli system upgrade ... ' command."
     RMV_MSG="Remove not supported for container based installer at this time."
     GEN_MSG="Unsupported mode '$MODE'"
     case $MODE in
         install)
             echo "Installing Digital Rebar Provision as a container."
-            install_as_container
+            install_container
             exit_cleanup $?
             ;;
-        upgrade) exit_cleanup 1 "$UPG_MSG"        ;;
-        remove)  exit_cleanup 1 "$RMV_MSG"        ;;
-        *)       usage; exit_cleanup 1 "$GEN_MSG" ;;
+        upgrade)
+            echo "Upgrading Digital Rebar Provision as a container."
+            CNT_VOL_REMOVE=false
+            remove_container
+            install_container
+            exit_cleanup $?
+            ;;
+        remove)  [[ "$REMOVE_DATA" == "true" ]] && CNT_VOL_REMOVE="true" || CNT_VOL_REMOVE="false"
+                 remove_container; exit_cleanup $? ;;
+        *)       usage; exit_cleanup 1 "$GEN_MSG"  ;;
     esac
 fi
 
@@ -620,6 +657,7 @@ then
     MODE=install
     UPGRADE=true
     force=true
+    CNT_VOL_REMOVE=false
 fi
 
 case $MODE in

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -181,7 +181,7 @@ while (( $# > 0 )); do
         --fast-downloader)          FAST_DOWNLOADER=true                ;;
         --force)                    force=true                          ;;
         --remove-data)              REMOVE_DATA=true                    ;;
-        --upgrade)                  UPGRADE=true; force=true
+        --upgrade)                  UPGRADE=true; force=true            
                                     CNT_VOL_REMOVE=false                ;;
         --nocontent|--no-content)   NO_CONTENT=true                     ;;
         --no-sudo)                  _sudo=""                            ;;
@@ -543,7 +543,7 @@ install_container() {
     case $CNT_TYPE in
         docker)
             ! which docker > /dev/null 2>&1 && exit_cleanup 1 "Container install requested but no 'docker' in PATH ($PATH)."
-            if [[ "$UPGRADE" != "true" ]]; then
+            if [[ "$UPGRADE" == "false" ]]; then
                 $_sudo docker volume create $CNT_VOL > /dev/null
                 VOL_MNT=$($_sudo docker volume inspect $CNT_VOL | grep Mountpoint | awk -F\" '{ print $4 }')
                 echo "Created docker volume named '$CNT_VOL' with mountpoint '$VOL_MNT'"
@@ -592,6 +592,7 @@ if [[ $OS_FAMILY == "container" || $CONTAINER == "true" ]]; then
             ;;
         upgrade)
             echo "Upgrading Digital Rebar Provision as a container."
+            UPGRADE=true
             CNT_VOL_REMOVE=false
             remove_container
             install_container

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# BUMP version on updates
+VERSION="v20.01.31-1"
+
 DEFAULT_DRP_VERSION=${DEFAULT_DRP_VERSION:-"stable"}
 
 exit_cleanup() {
@@ -13,7 +16,7 @@ exit_cleanup() {
 
 usage() {
 cat <<EOFUSAGE
-  USAGE: $0 [ install | upgrade | remove ] [ <options: see below> ]
+  USAGE: $0 [ install | upgrade | remove | version ] [ <options: see below> ]
 
 WARNING: 'install' option will OVERWRITE existing installations
 
@@ -84,9 +87,10 @@ OPTIONS:
                             # Define Network Namespace to start container in. Defaults to "$CNT_NETNS"
                             # If set to empty string (""), then disable setting any network namespace
 
+    version                 # show install.sh script version and exit
     install                 # Sets up an isolated or system 'production' enabled install
-    upgrade                 # Sets the installer to upgrade an existing 'dr-provision'
-                            # container install kill/rm the DRP container, then upgrade and reattach volume
+    upgrade                 # Sets the installer to upgrade an existing 'dr-provision', for upgrade of
+                            # container; kill/rm the DRP container, then upgrade and reattach data volume
     remove                  # Removes the system enabled install.  Requires no other flags
                             # optional: '--remove-data' to wipe all installed data
 
@@ -122,6 +126,8 @@ PREREQUISITES:
     OPTIONAL: aria2c (if using experimental "fast downloader")
 
 WARNING: 'install' option will OVERWRITE existing installations
+
+INSTALLER VERSION:  $VERSION
 EOFUSAGE
 } # end usage()
 
@@ -1141,6 +1147,7 @@ EOF
              $_sudo rm -rf $RM_DIR
          fi
          ;;
+     version) echo "Installer Version: $VERSION" ;;
      *)
          echo "Unknown action \"$1\". Please use 'install', 'upgrade', or 'remove'";;
 esac


### PR DESCRIPTION
- `install.sh` can now upgrade an existing DRP installed docker container version
- can also remove the container, and honors the `--remove-data` flag semantics

NOTES:
If you are upgrading an existing docker container, and you have customized the start up options and configuration of your original container - you MUST USE the same `install` flags with the `upgrade` arguments.  There is no state preserved to be able to easily determine how the original install process was called. 