### PR TITLE
update drpmachines.py to skip empty machines

### DIFF
--- a/integrations/ansible/drpmachines.py
+++ b/integrations/ansible/drpmachines.py
@@ -120,12 +120,17 @@ def main():
     if raw.status_code == 200:
         for machine in raw.json():
             name = machine[u'Name']
+            if name == '' or name is None:
+                continue
+            if machine[u'Address'] == '' or machine[u'Address'] is None:
+                continue
             inventory["all"]["hosts"].extend([name])
             myvars = hostvars.copy()
             if host_address == "internal":
                 myvars["ansible_host"] = machine[u"Address"]
             else:
                 myvars["ansible_host"] = machine[u"Params"][host_address]
+            ansible_user = machine.get("Params").get("ansible_user", ansible_user)
             myvars["ansible_user"] = ansible_user
             myvars["rebar_uuid"] = machine[u"Uuid"]
             for k in machine[u'Params']:


### PR DESCRIPTION
This change will skip adding a machine to the inventory if the
machine name or the ip adddress is empty. This keeps context
runners out of the inventory, as well as other pseudo machines.

This change also introduces the ability to define a param named

    anisble_user

If set then that value will be used to override both root default,
and the shell env.

Signed-off-by: Michael Rice <michael@michaelrice.org>