### PR TITLE
catch Install flag correctly

### DIFF
--- a/doc/arch/provision.rst
+++ b/doc/arch/provision.rst
@@ -150,10 +150,23 @@ template.  RenderData has the following fields:
     repository that contains security updates to apply during OS
     install.
 
-  - **[Sprig functions]** are string, math, file and flow functions for golang
-    templates from the `Sprig Function Library <http://masterminds.github.io/sprig/>`_.
-    They can be added to pipeline evaluation to perform useful template
-    rendering operations.
+- **[Sprig functions]** are string, math, file and flow functions for golang
+  templates from the `Sprig Function Library <http://masterminds.github.io/sprig/>`_.
+  They can be added to pipeline evaluation to perform useful template
+  rendering operations.
+
+- **Provisioner** items are specific to the Provisioner
+
+  - **.ProvisionerAddress** returns the IP address to access
+    the Provisioner based upon the requesting IP address.
+
+  - **.ProvisionerURL**  returns a URL to access the file server part of the server using the
+    requesting IP address as a basis.
+
+  - **.ApiURL** returns a URL to access the api server part of the server using the
+    requesting IP address as a basis.
+
+  - **.Info.** models.Info structure
 
 - **Env**: The BootEnv that we are rendering templates for, if applicable.
   Unless the BootEnv has the OnlyUnknown flag set, RenderData will

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 # BUMP version on updates
-VERSION="v20.01.31-1"
+VERSION="v20.03.23-1"
 
 DEFAULT_DRP_VERSION=${DEFAULT_DRP_VERSION:-"stable"}
 

--- a/tools/install.sh
+++ b/tools/install.sh
@@ -899,16 +899,16 @@ Environment=RS_LOCAL_UI=tftpboot/files/ux
 Environment=RS_UI_URL=/ux
 EOF
                      fi
-                     if [[ $CREATE_SELF ]] ; then
+                     if [[ $CREATE_SELF == true ]] ; then
                        cat > /etc/systemd/system/dr-provision.service.d/create-self.conf <<EOF
 [Service]
-Environment=RS_CREATE_SELF=true
+Environment=RS_CREATE_SELF=$CREATE_SELF
 EOF
                      fi
-                     if [[ $START_RUNNER ]] ; then
+                     if [[ $START_RUNNER == true ]] ; then
                        cat > /etc/systemd/system/dr-provision.service.d/start-runner.conf <<EOF
 [Service]
-Environment=RS_START_RUNNER=true
+Environment=RS_START_RUNNER=$START_RUNNER
 EOF
                      fi
 


### PR DESCRIPTION
The installation for self bootstrap agent was always creating the agent even if it was not flagged.  This ensures correct behavior.

Also, add some supporting template expansion fields to the docs.