### PR TITLE
fix: OnlyReservations flag not respected

### DIFF
--- a/models/subnet.go
+++ b/models/subnet.go
@@ -213,13 +213,13 @@ func (s *Subnet) Fill() {
 	if s.Strategy == "" {
 		s.Strategy = "MAC"
 	}
-	if s.Pickers == nil || len(s.Pickers) == 0 {
-		if s.OnlyReservations {
-			s.Pickers = []string{"none"}
-		} else {
-			s.Pickers = []string{"hint", "nextFree", "mostExpired"}
-		}
+	
+	if s.OnlyReservations {
+		s.Pickers = []string{"none"}
+	} else {
+		s.Pickers = []string{"hint", "nextFree", "mostExpired"}
 	}
+	
 	if s.ActiveLeaseTime == 0 {
 		s.ActiveLeaseTime = 60
 	}


### PR DESCRIPTION
Fixes issue digitalrebar/provision#176

This is based on the code that was opensource. Leases pick strategy (pickStrategies) is chosen based on the Subnet.Pickers values.  Subnet.Pickers values are set with Subnet.Fill() function, if s.Pickers are already set the OnlyReservations flag will not be respected. Something sets s.Pickers to ["hint", "nextFree", "mostExpired"] on subnet creation even with s.OnlyReservations true.
