### PR TITLE
Doc: Fix 2 typos

### DIFF
--- a/doc/arch/data.rst
+++ b/doc/arch/data.rst
@@ -421,7 +421,7 @@ our package repository support.  This support consists of three parts:
    support.
 2. The .Repos, .MachineRepos, and .InstallRepos functions that are
    available at template expansion time.  These return a list of Repo
-   objects, and re described in more detail in the Template section.
+   objects, and are described in more detail in the Template section.
 3. The .Install and .Lines functions available on each Repo object.
 
 The package-repositories Param

--- a/doc/faq-troubleshooting.rst
+++ b/doc/faq-troubleshooting.rst
@@ -663,7 +663,7 @@ Render a Kickstart or Preseed
 
 Kickstart and Preseed files only created by request and are not stored on a filesystem that is viewable.  They are dynamically generated on the fly, and served from the virtual Filesystem space of the Digital Rebar HTTP server (on port 8091 by default).  However, it is possible to render a kickstart or preseed to evaluate how it is going to operate, or troubleshoot issues with your config files.
 
-When a machine is in provisioning status, you can view the dynamically generated preseed or kickstart from the TFTP server (or via the HTTP gateway).  Provisioning status means the Machine has been plaed in to an installable BootEnv via a Stage.  If (for exaxmple) placed in to ``centos-7-install`` Stage, the ``compute.ks`` can be rendered for the machine.  Or, if placed in to ``ubuntu-16.04-install`` Stage, the ``seed`` can be rendered for the machine.
+When a machine is in provisioning status, you can view the dynamically generated preseed or kickstart from the TFTP server (or via the HTTP gateway).  Provisioning status means the Machine has been placed into an installable BootEnv via a Stage.  If (for exaxmple) placed in to ``centos-7-install`` Stage, the ``compute.ks`` can be rendered for the machine.  Or, if placed in to ``ubuntu-16.04-install`` Stage, the ``seed`` can be rendered for the machine.
 
 Get the Machine ID, then use the following constructed URL:
   ::


### PR DESCRIPTION
I had some other typos I was going to fix in `doc/content-packages/drp-community-content `, but the .gitignore file ignores `/doc/content-packages/*.rst `for some reason. So git doesn't acknowledge my changes to the file, and then sphinx build reverts the changes back.

The doc contributing guidelines didn't specify a preferred branch to receive PRs