### PR TITLE
Tool for generating indexed blob of entire docs

### DIFF
--- a/tools/docs-indexer.sh
+++ b/tools/docs-indexer.sh
@@ -31,12 +31,13 @@ doc_files.each do |f|
   # Read each file as json
   blob = JSON.parse(open(f, "r").read)
   page = blob["current_page_name"]
-
+  title_raw = Nokogiri::HTML.parse(blob["title"]).text
+  title = title_raw.match(/^((\d+\.)+ )(.*)$/)[3]
   # Extract only the text from the html
   text = Nokogiri::HTML.parse(blob["body"]).text
 
   # Store in the indexes object
-  indexes[page] = text
+  indexes[page] = {title: title, text: text}
 end
 
 # Print out the indexes

--- a/tools/docs-indexer.sh
+++ b/tools/docs-indexer.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Check to make sure ruby is installed
+if ! [[ -f $(which ruby) ]] || ! [[ -f $(which gem) ]]; then
+  echo "Ruby must be installed for the docs indexer to function"
+  exit 1
+fi
+
+# If json built docs don't exist, generate them
+if ! [[ -d _build/json ]]; then
+  make json
+fi
+
+# Install nokogiri gem (for html parsing)
+gem list | grep nokogiri --s || gem install nokogiri
+
+# Run a ruby script to:
+#  - extract doc contents as text
+#  - pair the contents with the page name
+#  - return a single json blob with all of the contents
+ruby <<EOF
+require 'nokogiri'
+require 'json'
+
+# Find all json doc files
+doc_files = Dir["_build/json/doc/**/*.fjson"]
+
+indexes = {}
+
+doc_files.each do |f|
+  # Read each file as json
+  blob = JSON.parse(open(f, "r").read)
+  page = blob["current_page_name"]
+
+  # Extract only the text from the html
+  text = Nokogiri::HTML.parse(blob["body"]).text
+
+  # Store in the indexes object
+  indexes[page] = text
+end
+
+# Print out the indexes
+puts indexes.to_json
+EOF


### PR DESCRIPTION
Part of creating searchable documentation through the UX involved creating plaintext documentation with file indices. This is the tool that does that.

Depends on ruby, automatically runs `make json` if `_build/json` does not exist

Outputs to stdio as a giant json blob consisting of:

    {
      "path/to/docfile": "docfile contents in plaintext",
      ...
    }

At the moment that blob is around 2.2MB