### PR TITLE
feat(fingerprint): machine fingerprint models and Gohai updates

### DIFF
--- a/cli/machines.go
+++ b/cli/machines.go
@@ -380,6 +380,21 @@ the stage runner wait flag.
 			return prettyPrint(res)
 		},
 	}
+	op.addCommand(&cobra.Command{
+		Use:   "whoami",
+		Short: "Figure out what machine UUID most closely matches the current system",
+		Args:  cobra.NoArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			whoami := &models.Whoami{}
+			if err := whoami.Fill(); err != nil {
+				return err
+			}
+			if err := Session.Req().Post(whoami).UrlFor("whoami").Do(&whoami); err != nil {
+				return err
+			}
+			return prettyPrint(whoami)
+		},
+	})
 	tokenFetch.Flags().StringVar(&tokenDuration, "ttl", "1h", "The time that the retrieved token should be valid.")
 	op.addCommand(tokenFetch)
 	op.addCommand(inspectCommands())

--- a/cli/startup.go
+++ b/cli/startup.go
@@ -345,6 +345,19 @@ func NewApp() *cobra.Command {
 			return gohai()
 		},
 	})
+
+	app.AddCommand(&cobra.Command{
+		Use:   "fingerprint",
+		Short: "Get the machine fingerprint used to determine what machine we are running on",
+		Args:  cobra.NoArgs,
+		RunE: func(c *cobra.Command, args []string) error {
+			w := &models.Whoami{}
+			if err := w.Fill(); err != nil {
+				return err
+			}
+			return prettyPrint(w)
+		},
+	})
 	app.AddCommand(agentHandler)
 
 	return app

--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/xattr v0.4.1
-	github.com/rackn/gohai v0.3.0
+	github.com/rackn/gohai v0.4.0
 	github.com/rackn/netwrangler v0.7.0
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUW
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
 github.com/VictorLowther/godmi v0.0.0-20190712193004-d244e3465e37 h1:PUbuWfvYnseI0EGyHLC7TligpL8T1vEQ9xz4rAssW98=
 github.com/VictorLowther/godmi v0.0.0-20190712193004-d244e3465e37/go.mod h1:JiYtLLi0v25VZLHRInc/p4CtOCFXUPKb9Q7vNQ6rqyk=
+github.com/VictorLowther/godmi v0.6.1 h1:cg88u82jFuLC72TC4tHAfNjMQyrwltO5U8BtoBA4lFo=
+github.com/VictorLowther/godmi v0.6.1/go.mod h1:O/JaTV/eBIggbtmYJ4Ld+Jqpn35C2OejkC5f0wNGt2o=
 github.com/VictorLowther/jsonpatch2 v1.0.0 h1:gQxztbUxxBK0EccdhRO44TgDy7jSFFIZAGO7vdQA2xA=
 github.com/VictorLowther/jsonpatch2 v1.0.0/go.mod h1:MagdKGtUJ6bwyDgLk502ME/LDMKy9Rqh9iOf41iG5ds=
 github.com/alecthomas/participle v0.3.0 h1:e8vhrYR1nDjzDxyDwpLO27TWOYWilaT+glkwbPadj50=
@@ -18,6 +20,8 @@ github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e h1:vUmf0yezR0y7jJ5pceLHthLaYf4bA5T14B6q39S4q2Q=
+github.com/digitalocean/go-smbios v0.0.0-20180907143718-390a4f403a8e/go.mod h1:YTIHhz/QFSYnu/EhlF2SpU2Uk+32abacUYA5ZPljz1A=
 github.com/digitalrebar/logger v0.3.0 h1:7/XP3BQiWfl1Lqmm7tvkvdwjPilDUUPC/iWbeWO9G6g=
 github.com/digitalrebar/logger v0.3.0/go.mod h1:zH2t4FBhzVxZJTg+eaPzNCRL50nlcRLxWurfTsl5jWE=
 github.com/digitalrebar/tftp v2.1.0+incompatible h1:CzBcnsUaMtdLSOf3dSycinnfpajAAro7l8oo/ILyzOI=
@@ -37,6 +41,7 @@ github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/gofunky/semver v3.5.2+incompatible h1:bLtS5NNx0gLpaUJHGRtePWV6vs5Q2cNhatKFqKny5J8=
 github.com/gofunky/semver v3.5.2+incompatible/go.mod h1:7MXgDdC47tqmTJhxqX5CCuJaIx+c5igi9n0xPbKjG0U=
+github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -107,6 +112,8 @@ github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZN
 github.com/rackn/gohai v0.0.0-20190619164647-92918a701117/go.mod h1:1NhfVxJ6qD4S5ondz2CobWFiYlODF8ex4pNgQrKYCxc=
 github.com/rackn/gohai v0.3.0 h1:oxAIEzqP07mK210dtV130I//8j4IryL6oQRUf7AZ5UY=
 github.com/rackn/gohai v0.3.0/go.mod h1:JGFSlNYmSPglk0ogBwtBandVf2mQPzVuFqjIbGDOZME=
+github.com/rackn/gohai v0.4.0 h1:WF7JgtJI2FJi1hw1vzY44yzJy+33Uz6Ijob99vghhmA=
+github.com/rackn/gohai v0.4.0/go.mod h1:L14W5Y4U9zycW/zJlbg75nVbrO6qWj80FWHjiCgxnag=
 github.com/rackn/netwrangler v0.7.0 h1:lMRzj+1xt45SnRiZ/7yJmqdBqVRTKB6xs29vCrfOHeQ=
 github.com/rackn/netwrangler v0.7.0/go.mod h1:1ZvFAprvzdbIZ/kMYh90tLMGsK4U31YqrAsKNIUEqls=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
@@ -147,6 +154,7 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwg
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=

--- a/models/role.go
+++ b/models/role.go
@@ -37,7 +37,7 @@ var (
 	addedActions = map[string]string{
 		"users":     "token, password",
 		"jobs":      "log",
-		"machines":  "getSecure, updateSecure, updateTaskList, token",
+		"machines":  "getSecure, updateSecure, updateTaskList, token, whoami",
 		"plugins":   "getSecure, updateSecure",
 		"profiles":  "getSecure, updateSecure",
 		"stages":    "getSecure, updateSecure",

--- a/models/whoami.go
+++ b/models/whoami.go
@@ -1,0 +1,164 @@
+package models
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/rackn/gohai/plugins/dmi"
+	ghnet "github.com/rackn/gohai/plugins/net"
+
+	"github.com/pborman/uuid"
+)
+
+// Whoami contains the elements used toi fingerprint a machine, along with
+// the results of the fingerprint comparison request
+type Whoami struct {
+	Result struct {
+		Score int       `json:",omitempty"`
+		Uuid  uuid.UUID `json:",omitempty"`
+		Token string    `json:",omitempty"`
+	}
+	Fingerprint MachineFingerprint
+	MacAddrs    []string
+	OnDiskUUID  string
+}
+
+// Fill fills out the MacAddrs list and the MachineFingerprint from
+// the DMI information on the machine.
+func (w *Whoami) Fill() error {
+	(&w.Fingerprint).Fill()
+	w.MacAddrs = []string{}
+	hasher := sha256.New()
+	dmiinfo, err := dmi.Gather()
+	if err != nil {
+		return err
+	}
+	if dmiinfo.System.SerialNumber != "" {
+		fmt.Fprint(hasher, dmiinfo.System.Manufacturer, dmiinfo.System.ProductName, dmiinfo.System.SerialNumber)
+		w.Fingerprint.SSNHash = hasher.Sum(nil)
+		hasher.Reset()
+	}
+	if len(dmiinfo.Chassis) > 0 && dmiinfo.Chassis[0].SerialNumber != "" {
+		fmt.Fprint(hasher, dmiinfo.System.Manufacturer, dmiinfo.System.ProductName, dmiinfo.Chassis[0].SerialNumber)
+		w.Fingerprint.CSNHash = hasher.Sum(nil)
+		hasher.Reset()
+	}
+	w.Fingerprint.SystemUUID = dmiinfo.System.UUID
+	for _, mem := range dmiinfo.Memory.Devices {
+		if mem.SerialNumber == "" {
+			continue
+		}
+		fmt.Fprint(hasher, mem.Manufacturer, mem.PartNumber, mem.SerialNumber)
+		w.Fingerprint.MemoryIds = append(w.Fingerprint.MemoryIds, hasher.Sum(nil))
+		hasher.Reset()
+	}
+	sort.Slice(w.Fingerprint.MemoryIds, func(i, j int) bool {
+		return bytes.Compare(w.Fingerprint.MemoryIds[i], w.Fingerprint.MemoryIds[j]) == -1
+	})
+	netinfo, err := ghnet.Gather()
+	if err != nil {
+		return err
+	}
+	for _, intf := range netinfo.Interfaces {
+		if !intf.Sys.IsPhysical {
+			continue
+		}
+		w.MacAddrs = append(w.MacAddrs, intf.HardwareAddr.String())
+	}
+	sort.Strings(w.MacAddrs)
+	return nil
+}
+
+// FromMachine extracts the Fingerprint and HardwareAddrs fields from a Machine
+// and populates Whoami with it.
+func (w *Whoami) FromMachine(m *Machine) {
+	w.MacAddrs = append([]string{}, m.HardwareAddrs...)
+	w.Fingerprint = m.Fingerprint
+}
+
+// ToMachine saves the Fingerprint and the MacAddrs fields onto the passed Machine.
+func (w *Whoami) ToMachine(m *Machine) {
+	m.HardwareAddrs = append([]string{}, w.MacAddrs...)
+	m.Fingerprint = w.Fingerprint
+}
+
+// Score calculates how closely the passed in Whoami matches a candidate Machine.
+// In the current implementation, Score awards points based on the following
+// criteria:
+//
+// * 25 points if the Machine has an SSNHash that matches the one in the Whoami
+//
+// * 25 points if the Machine has a CSNHash that matches the one in the Whoami
+//
+// * 50 points if the Machine has a SystemUUID that matches the one in the Whoami
+//
+// * 0 to 100 points varying depending on how many memory DIMMs from the machine
+//   fingerprint are present in Whoami.
+//
+// * 0 to 100 points varying depending on how many HardwareAddrs from the Machine
+//   are present in Whoami.
+//
+// * 1000 points if the machine UUID matches OnDiskUUID
+//
+// If the score is less than 100 at the end of the scoring process, it is rounded down
+// to zero.  The intent is to be resilient in the face of hardware changes:
+//
+// * SSNHash, CSNHash, and SystemUUID come from the motherboard.
+//
+// * MemoryIds are generated deterministically from the DIMMs installed in the system
+//
+// * MacAddrs comes from the physical Ethernet devices in the system.
+func (w *Whoami) Score(m *Machine) (score int) {
+	if len(m.Fingerprint.SSNHash) > 0 {
+		if bytes.Equal(w.Fingerprint.SSNHash, m.Fingerprint.SSNHash) {
+			score += 25
+		}
+	}
+	if len(m.Fingerprint.CSNHash) > 0 {
+		if bytes.Equal(w.Fingerprint.CSNHash, m.Fingerprint.CSNHash) {
+			score += 25
+		}
+	}
+	if m.Fingerprint.SystemUUID != "" {
+		if w.Fingerprint.SystemUUID == m.Fingerprint.SystemUUID {
+			score += 50
+		}
+	}
+	var matched int
+	var j int
+	if len(m.Fingerprint.MemoryIds) > 0 {
+		for _, probe := range m.Fingerprint.MemoryIds {
+			for j = range w.Fingerprint.MemoryIds {
+				cmp := bytes.Compare(w.Fingerprint.MemoryIds[j], probe)
+				if cmp == 0 {
+					matched++
+					break
+				}
+			}
+		}
+		score += (100 * matched) / len(m.Fingerprint.MemoryIds)
+	}
+	if len(m.HardwareAddrs) > 0 {
+		matched = 0
+		for _, probe := range m.HardwareAddrs {
+			for j = range w.MacAddrs {
+				cmp := strings.Compare(w.MacAddrs[j], probe)
+				if cmp == 0 {
+					matched++
+					break
+				}
+			}
+		}
+		score += (100 * matched) / len(m.HardwareAddrs)
+	}
+	if m.UUID() == w.OnDiskUUID {
+		score += 1000
+	}
+	if score < 100 {
+		score = 0
+	}
+	return
+}


### PR DESCRIPTION
Add the required models and machine code changes to allow for detcting
what Machine record most closely matches the current running machine.

Currently, this is based on a combination of matching certian classes of
DMI information, memory serial numbers, and MAC address matching.

This will eventually allow dr-provision to be resilient in the face
of hardware changes when running tasks.