### PR TITLE
feat(pool): Add pooling support

### DIFF
--- a/agent/change_stage_test.go
+++ b/agent/change_stage_test.go
@@ -184,7 +184,10 @@ Tasks:
 	machineRes.Secret = ""
 	machineRes.Runnable = true
 	machineRes.Stage = "none"
-	machineRes.CurrentTask = -1
+	machineRes.CurrentTask = 0
+	machineRes.WorkflowComplete = true
+	machineRes.Pool = "default"
+	machineRes.PoolStatus = "Free"
 	rt(t, "Make initial machine", machineRes, nil,
 		func() (interface{}, error) {
 			err := session.CreateModel(machine1)
@@ -281,6 +284,7 @@ Tasks:
 	machineRes.Stage = "stageNoWait"
 	machineRes.Tasks = []string{"task1"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to stageNoWait", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -297,6 +301,7 @@ Tasks:
 	machineRes.Stage = "stageWait"
 	machineRes.Tasks = []string{"task1"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to stageWait", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -313,6 +318,7 @@ Tasks:
 	machineRes.Stage = "stageNoWait1"
 	machineRes.Tasks = []string{"task1"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to stageNoWait1", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -329,6 +335,7 @@ Tasks:
 	machineRes.Stage = "stageWait1"
 	machineRes.Tasks = []string{"task1"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to stageWait1", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -345,6 +352,7 @@ Tasks:
 	machineRes.Stage = "stageReboot"
 	machineRes.Tasks = []string{"task1"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to stageReboot", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -362,6 +370,7 @@ Tasks:
 	machineRes.Stage = "stageRealReboot"
 	machineRes.Tasks = []string{"task1"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to stageRealReboot", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -379,6 +388,7 @@ Tasks:
 	machineRes.Stage = "stageRealReboot1"
 	machineRes.Tasks = []string{"task1"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to stageRealReboot1", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -396,6 +406,7 @@ Tasks:
 	machineRes.Stage = "stageStop"
 	machineRes.Tasks = []string{"task1"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to stageStop", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -413,6 +424,7 @@ Tasks:
 	machineRes.Stage = "fred-install"
 	machineRes.Tasks = []string{"taskInstall"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to fred-install", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -430,6 +442,7 @@ Tasks:
 	machineRes.Stage = "greg-install"
 	machineRes.Tasks = []string{"taskInstall"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to greg-install", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)

--- a/agent/taskRunner_test.go
+++ b/agent/taskRunner_test.go
@@ -179,7 +179,10 @@ Tasks:
 	machineRes.Secret = ""
 	machineRes.Runnable = true
 	machineRes.Stage = "none"
-	machineRes.CurrentTask = -1
+	machineRes.CurrentTask = 0
+	machineRes.WorkflowComplete = true
+	machineRes.Pool = "default"
+	machineRes.PoolStatus = "Free"
 	rt(t, "Make initial machine", machineRes, nil,
 		func() (interface{}, error) {
 			err := session.CreateModel(machine1)
@@ -214,6 +217,7 @@ Tasks:
 	machineRes.Stage = "stage1"
 	machineRes.Tasks = []string{"task1", "task2"}
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Set machine 1 to stage1", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -256,6 +260,8 @@ Tasks:
 		}, nil)
 	machineRes = models.Clone(machine1).(*models.Machine)
 	machineRes.Tasks = []string{}
+	machineRes.CurrentTask = 0
+	machineRes.WorkflowComplete = true
 	rt(t, "Try to remove tasks from machine1", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -268,6 +274,8 @@ Tasks:
 		}, nil)
 	machineRes = models.Clone(machine1).(*models.Machine)
 	machineRes.Tasks = []string{"task2", "task1"}
+	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Try to change order of tasks on a machine", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)
@@ -416,6 +424,7 @@ Tasks:
 	}
 	machineRes = models.Clone(machine1).(*models.Machine)
 	machineRes.CurrentTask = -1
+	machineRes.WorkflowComplete = false
 	rt(t, "Increment machine1's CurrentTask pointer", machineRes, nil,
 		func() (interface{}, error) {
 			mc := models.Clone(machine1).(*models.Machine)

--- a/api/events_test.go
+++ b/api/events_test.go
@@ -103,7 +103,10 @@ Validated: true
 	machineRes.Secret = ""
 	machineRes.Runnable = true
 	machineRes.Stage = "none"
-	machineRes.CurrentTask = -1
+	machineRes.CurrentTask = 0
+	machineRes.Pool = "default"
+	machineRes.PoolStatus = "Free"
+	machineRes.WorkflowComplete = true
 	rt(t, "Make initial machine", machineRes, nil,
 		func() (interface{}, error) {
 			err := session.CreateModel(machine1)

--- a/api/objects_test.go
+++ b/api/objects_test.go
@@ -15,6 +15,7 @@ func TestObject(t *testing.T) {
 			"machines",
 			"params",
 			"plugins",
+			"pools",
 			"preferences",
 			"profiles",
 			"reservations",

--- a/cli/machines.go
+++ b/cli/machines.go
@@ -91,6 +91,72 @@ func registerMachine(app *cobra.Command) {
 			return prettyPrint(clone)
 		},
 	})
+	op.addCommand(&cobra.Command{
+		Use:   "releaseToPool [id]",
+		Short: fmt.Sprintf("Release this machine back to the pool"),
+		Long:  `Release this machine back to the pool`,
+		Args: func(c *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("%v requires 1 arguments", c.UseLine())
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			mid := args[0]
+			r := &[]models.PoolResult{}
+			p := map[string]interface{}{}
+			if err := Session.Req().Post(p).UrlFor("machines", mid, "releaseToPool").Do(r); err != nil {
+				return err
+			}
+			return prettyPrint(r)
+		},
+	})
+	op.addCommand(&cobra.Command{
+		Use:   "run [id]",
+		Short: fmt.Sprintf("Mark the machine as runnable"),
+		Long:  `Set the machine's Runnable flag to true`,
+		Args: func(c *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("%v requires 1 arguments", c.UseLine())
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			m, err := op.refOrFill(args[0])
+			if err != nil {
+				return generateError(err, "Failed to fetch %v: %v", op.singleName, args[0])
+			}
+			clone := models.Clone(m).(*models.Machine)
+			clone.Runnable = true
+			if err := Session.Req().PatchTo(m, clone).Do(&clone); err != nil {
+				return err
+			}
+			return prettyPrint(clone)
+		},
+	})
+	op.addCommand(&cobra.Command{
+		Use:   "pause [id]",
+		Short: fmt.Sprintf("Mark the machine as NOT runnable"),
+		Long:  `Set the machine's Runnable flag to false`,
+		Args: func(c *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("%v requires 1 arguments", c.UseLine())
+			}
+			return nil
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			m, err := op.refOrFill(args[0])
+			if err != nil {
+				return generateError(err, "Failed to fetch %v: %v", op.singleName, args[0])
+			}
+			clone := models.Clone(m).(*models.Machine)
+			clone.Runnable = false
+			if err := Session.Req().PatchTo(m, clone).Do(&clone); err != nil {
+				return err
+			}
+			return prettyPrint(clone)
+		},
+	})
 	jobs := &cobra.Command{
 		Use:   "jobs",
 		Short: "Access commands for manipulating the current job",

--- a/cli/pools.go
+++ b/cli/pools.go
@@ -1,0 +1,214 @@
+package cli
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/digitalrebar/provision/v4/models"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	addRegistrar(registerPool)
+}
+
+func registerPool(app *cobra.Command) {
+	op := &ops{
+		name:       "pools",
+		singleName: "pool",
+		example:    func() models.Model { return &models.Pool{} },
+	}
+
+	statusCmd := &cobra.Command{
+		Use:   "status [pool]",
+		Short: "Get Pool status",
+		Args: func(c *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("Must provide a pool")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			res := &models.PoolResults{}
+			if err := Session.Req().UrlFor("pools", id, "status").Do(&res); err != nil {
+				return fmt.Errorf("Failed to get pool status for %s: %v", id, err)
+			}
+			return prettyPrint(res)
+		},
+	}
+	op.addCommand(statusCmd)
+
+	activeCmd := &cobra.Command{
+		Use:   "active",
+		Short: "List active pools",
+		Args: func(c *cobra.Command, args []string) error {
+			if len(args) != 0 {
+				return fmt.Errorf("Does not take parameters")
+			}
+			return nil
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			res := []string{}
+			if err := Session.Req().UrlFor("pools-active").Do(&res); err != nil {
+				return fmt.Errorf("Failed to list active pools: %v", err)
+			}
+			return prettyPrint(res)
+		},
+	}
+	op.addCommand(activeCmd)
+
+	itemCmd := &cobra.Command{
+		Use:   "manage",
+		Short: "Manage machines in pools",
+	}
+	// Status
+	var allMachines bool
+	var minimum, count int
+	var addProfiles, removeProfiles, removeParameters string
+	var addParameters, newWorkflow, machineList, waitTimeout string
+	var sourcePool string
+
+	itemCmd.PersistentFlags().BoolVar(&allMachines, "all-machines", false, "Selects all available machines")
+	itemCmd.PersistentFlags().IntVar(&minimum, "minimum", 0, "Minimum number of machines to return - defaults to count")
+	itemCmd.PersistentFlags().IntVar(&count, "count", 0, "Count of machines to allocate")
+	itemCmd.PersistentFlags().StringVar(&machineList, "machine-list", "", "Comma separated list of machines UUID or Field:Value")
+	itemCmd.PersistentFlags().StringVar(&waitTimeout, "wait-timeout", "", "An amount of time to wait for completion in seconds or time string (e.g. 30m)")
+
+	itemCmd.PersistentFlags().StringVar(&newWorkflow, "new-workflow", "", "A workflow to set on the machines")
+	itemCmd.PersistentFlags().StringVar(&addProfiles, "add-profiles", "", "Comma separated list of profiles to add to the machine")
+	itemCmd.PersistentFlags().StringVar(&removeProfiles, "remove-profiles", "", "Comma separated list of profiles to remove from the machine")
+	itemCmd.PersistentFlags().StringVar(&removeParameters, "remove-parameters", "", "Comma separated list of parameters to remove from the machine")
+	itemCmd.PersistentFlags().StringVar(&addParameters, "add-parameters", "", "A JSON string of parameters to add to the machine")
+
+	longDesc := map[string]string{
+		"add":      `Add places machines from a pool into the selected pool.  The machines must be unallocated and in Free status.  By default, the default pool is used.`,
+		"remove":   `Remove places machines from the selected pool into the default pool.  The machines must be unallocated and in Free status.`,
+		"allocate": `Allocate reserves machines in the selected pool.  The machines must be unallocated and in Free status.`,
+		"release":  `Release frees machines in the selected pool.  The machines must be allocated and in InUse status.`,
+	}
+
+	for _, cmdName := range []string{"add", "remove", "allocate", "release"} {
+		cmdAct := &cobra.Command{
+			Use:   fmt.Sprintf("%s [id ][filter options a=f(v) style]", cmdName),
+			Short: fmt.Sprintf("%s machines to pool", cmdName),
+			Long:  longDesc[cmdName],
+			Args: func(c *cobra.Command, args []string) error {
+				if len(args) == 0 {
+					return fmt.Errorf("Must specify a pool id")
+				}
+				if allMachines && count > 0 {
+					return fmt.Errorf("Must choose count or all-machines, but not both")
+				}
+				if machineList != "" && (count > 0 || allMachines) {
+					return fmt.Errorf("machine-list must not be specified with count or all-machines")
+				}
+				if !allMachines && count == 0 && machineList == "" {
+					count = 1
+				}
+				if minimum > count {
+					return fmt.Errorf("count must be greater than minimum")
+				}
+				if minimum == 0 {
+					minimum = count
+				}
+				if len(args) == 1 {
+					return nil
+				}
+				if strings.Contains(args[1], "=") {
+					for i, a := range args {
+						if i == 0 {
+							continue
+						}
+						ar := strings.SplitN(a, "=", 2)
+						if len(ar) != 2 {
+							return fmt.Errorf("Filter argument requires an '=' separator: %s", a)
+						}
+					}
+				}
+				return nil
+			},
+			RunE: func(cmd *cobra.Command, args []string) error {
+				parms := map[string]interface{}{
+					"pool/all-machines": allMachines,
+					"pool/minimum":      minimum,
+					"pool/wait-timeout": waitTimeout,
+					"pool/count":        count,
+					"pool/workflow":     newWorkflow,
+				}
+				if addProfiles != "" {
+					l := []string{}
+					for _, pp := range strings.Split(addProfiles, ",") {
+						l = append(l, strings.TrimSpace(pp))
+					}
+					parms["pool/add-profiles"] = l
+				}
+				if removeProfiles != "" {
+					l := []string{}
+					for _, pp := range strings.Split(removeProfiles, ",") {
+						l = append(l, strings.TrimSpace(pp))
+					}
+					parms["pool/remove-profiles"] = l
+				}
+				if removeParameters != "" {
+					l := []string{}
+					for _, pp := range strings.Split(removeParameters, ",") {
+						l = append(l, strings.TrimSpace(pp))
+					}
+					parms["pool/remove-parameters"] = l
+				}
+				if addParameters != "" {
+					data := map[string]interface{}{}
+					if err := bufOrFileDecode(addParameters, &data); err != nil {
+						return fmt.Errorf("add-parameters is not a valid JSON or YAML string or file")
+					}
+					parms["pool/add-parameters"] = data
+				}
+				if machineList != "" {
+					l := []string{}
+					for _, pp := range strings.Split(machineList, ",") {
+						l = append(l, strings.TrimSpace(pp))
+					}
+					parms["pool/machine-list"] = l
+				}
+
+				id := args[0]
+				filters := []string{}
+				for i, v := range args {
+					if i == 0 {
+						continue
+					}
+					filters = append(filters, v)
+				}
+				if len(filters) > 0 {
+					parms["pool/filter"] = filters
+				}
+
+				cmdStr := fmt.Sprintf("%sMachines", cmd.Name())
+
+				pr := []*models.PoolResult{}
+				req := Session.Req().Post(parms).UrlFor("pools", id, cmdStr)
+				qsParams := []string{}
+				if force {
+					qsParams = append(qsParams, "force", "true")
+				}
+				if cmdStr == "addMachines" && sourcePool != "" {
+					qsParams = append(qsParams, "source-pool", sourcePool)
+				}
+				if len(qsParams) > 0 {
+					req = req.Params(qsParams...)
+				}
+				if err := req.Do(&pr); err != nil {
+					return err
+				}
+				return prettyPrint(pr)
+			},
+		}
+		if cmdName == "add" {
+			cmdAct.PersistentFlags().StringVar(&sourcePool, "source-pool", "", "The name of the pool to pull machines from")
+		}
+		itemCmd.AddCommand(cmdAct)
+	}
+	op.addCommand(itemCmd)
+	op.command(app)
+}

--- a/cli/test-data/output/TestCorePieces/machines.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/machines.indexes/stdout.expect
@@ -95,6 +95,24 @@
     "Unique": false,
     "Unordered": true
   },
+  "Pool": {
+    "Regex": true,
+    "Type": "string",
+    "Unique": false,
+    "Unordered": false
+  },
+  "PoolAllocated": {
+    "Regex": false,
+    "Type": "boolean",
+    "Unique": false,
+    "Unordered": true
+  },
+  "PoolStatus": {
+    "Regex": true,
+    "Type": "string",
+    "Unique": false,
+    "Unordered": false
+  },
   "Profiles": {
     "Regex": false,
     "Type": "list",
@@ -142,5 +160,11 @@
     "Type": "string",
     "Unique": false,
     "Unordered": false
+  },
+  "WorkflowComplete": {
+    "Regex": false,
+    "Type": "boolean",
+    "Unique": false,
+    "Unordered": true
   }
 }

--- a/cli/test-data/output/TestCorePieces/pools.indexes/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/pools.indexes/stdout.expect
@@ -1,0 +1,62 @@
+{
+  "Available": {
+    "Regex": false,
+    "Type": "boolean",
+    "Unique": false,
+    "Unordered": true
+  },
+  "Bundle": {
+    "Regex": true,
+    "Type": "string",
+    "Unique": false,
+    "Unordered": false
+  },
+  "Description": {
+    "Regex": true,
+    "Type": "string",
+    "Unique": false,
+    "Unordered": false
+  },
+  "Documentation": {
+    "Regex": true,
+    "Type": "string",
+    "Unique": false,
+    "Unordered": false
+  },
+  "Endpoint": {
+    "Regex": true,
+    "Type": "string",
+    "Unique": false,
+    "Unordered": false
+  },
+  "Id": {
+    "Regex": true,
+    "Type": "string",
+    "Unique": true,
+    "Unordered": false
+  },
+  "Key": {
+    "Regex": true,
+    "Type": "string",
+    "Unique": true,
+    "Unordered": false
+  },
+  "ParentPool": {
+    "Regex": true,
+    "Type": "string",
+    "Unique": false,
+    "Unordered": false
+  },
+  "ReadOnly": {
+    "Regex": false,
+    "Type": "boolean",
+    "Unique": false,
+    "Unordered": true
+  },
+  "Valid": {
+    "Regex": false,
+    "Type": "boolean",
+    "Unique": false,
+    "Unordered": true
+  }
+}

--- a/doc/arch.rst
+++ b/doc/arch.rst
@@ -25,4 +25,5 @@ dr-provision for developers and power users.
    arch/runner-state
    arch/content-package
    arch/cluster
+   arch/pooling
 

--- a/doc/arch/pooling.rst
+++ b/doc/arch/pooling.rst
@@ -1,0 +1,119 @@
+.. Copyright (c) 2020 RackN Inc.
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. Digital Rebar Provision documentation under Digital Rebar master license
+.. index::
+  pair: Digital Rebar Provision; Pooling Architecture
+
+.. _rs_pooling_arch:
+
+Pooling Architecture
+<<<<<<<<<<<<<<<<<<<<
+
+Digital Rebar Provision provides a mechanism to group machines into pools with defined actions on the transitions.  This
+functionality can be used to provide ``cloud-like`` operations on bare metal servers.
+
+This section will focus on the architecture of the pooling system.  The operational methods can be found at :ref:`rs_pooling_ops`.
+
+Pools provide three basic functions.
+
+* Machine grouping into pools
+* Machine allocation to track usage or consumption
+* Machine manipulation upon transitions in the pool
+
+Pools are dynamic and exist because machines are in pools.  Optionally, pool objects can be added to define additional
+control points and information.
+
+API calls can be made blocking or non-blocking.  Blocking calls will wait for a timeout or for all the machines to achieve
+workflow complete before returning.
+
+Pool Functions
+--------------
+
+Grouping by Pools
+=================
+
+Machines can be group into pools.  A machine can only be in one pool at a time.  All machines start in the default pool
+unless the pool variables are set upon machine creation.  The machines can be managed by API (CLI or UX) calls to move
+the machines between pools.
+
+Machines may be ``added`` or ``removed`` from pools.  Machines may be selected by specific machine values, e.g. UUID
+or Name, or filters.  The API methods allow for the requesting of a number of machines and how many are required to succeed.
+Machines are only moved if the minimum number of machines can be found.
+
+Pools are loosely hierarchical.  The ``default`` pool is the root pool.   Any pool with out an explicit parent will
+consider the ``default`` pool as its parent.  Pool parentage can be used when adding machines to and removing machines from
+a pool.  Unless explicitly declared in the API, the pool's parent will be used as the source or destination of the operation.
+
+Machine Allocation
+==================
+
+Machines can be allocated and released from inside a pool.  This allows for API calls to ask for machines without having
+to know the specific sets of machines. Machines may be selected by specific machine values, e.g. UUID or Name, or filters.
+The API methods allow for the requesting of a number of machines and how many are required to succeed.
+Machines are only moved if the minimum number of machines can be found.
+
+Allocating a machine reserves that machine and makes it not available for additional allocation.  Release a machine removes
+the reservation on the machine and makes it available for allocation within the pool again.
+
+Machine Transitions
+===================
+
+As machines transition into or out of the pools or allocated or released from with in a pool, these machines can be altered
+as the system operates on them.  The transitions can change workflow, add or remove parameters, and add or remove profiles.
+
+All transitions are supported, transitioning into a pool, allocating a machine, releasing a machine, and transitioning
+out of the pool.  A machine leaving a pool actually handles two transitions, the removal from the current pool actions
+and the entry into the new pool actions.
+
+These actions can be added on the API call for direct control.  The actions can also be added to the pool object that
+allows for simpler calls.
+
+
+Pool Implementation
+-------------------
+
+The following sections define the implementation details of Pooling.
+
+Machine Object
+==============
+
+To track the machine's status in the pool, three fields are on the machine object.
+
+* Pool - This string field declares what pool the machine is in.
+* PoolAllocated - This boolean field indicates if the machine has been allocated or not.
+* PoolStatus - This string field describes the machine's state in the pool.
+
+Additionally, the pool system needs to know when a workflow is complete.  There is also a boolean
+field ``WorkflowComplete`` that indicates if the current workflow is complete.
+
+Pool Status can have the following values:
+
+* Joining - Running a workflow defined when entering the pool, but not complete yet.
+* HoldJoin - Running a workflow defined when entering the pool that has a failed task and needs remediation before continuing.
+* Free - Waiting for allocation within the pool.
+* Building - Running a workflow defined when allocated, but not complete yet.
+* HoldBuild - Running a workflow defined when allocated that has a failed task and needs remediation before continuing.
+* InUse - Waiting for release but has completed all allocation actions
+* Destroying - Running a workflow defined when released, but not complete yet.
+* HoldDestroy - Running a workflow defined when released that has a failed task and needs remediation before continuing.
+* Leaving - Running a workflow defined when removed from the pool, but not complete yet.
+* HoldLeave - Running a workflow defined when removed that has a failed task and needs remediation before continuing.
+
+Pool Object
+===========
+
+The pool object is an optional construct for the system.  The pool object is needed when the parent field is needed.  The
+object is also needed when defining transition pieces.
+
+The pool object defines ``EnterActions``, ``ExitActions``, ``AllocateActions``, and ``ReleaseActions``.  These hold a
+structure that allow you to define:
+
+* Workflow - the workflow to use for this transition.
+* AddProfiles - A list of profiles to add to the machine - If already present, this is not an error.
+* RemoveProfiles - A list of profiles to remove from the machine. If not present on the machine, this is not an error.
+* AddParameters - A map of key/value pairs that get set as parameters on the machine.  If already present, this will replace the current value.
+* RemoveParameters - A list of parameters to remove from the machine.  If not present on the machine, this is not an error.
+
+There is a pending function that is *NOT* enabled for autofilling pools that are empty.  This will change in the coming
+releases.
+

--- a/doc/cli/drpcli.rst
+++ b/doc/cli/drpcli.rst
@@ -83,6 +83,8 @@ SEE ALSO
    CLI commands relating to plugin_providers
 -  `drpcli plugins <drpcli_plugins.html>`__ - Access CLI commands
    relating to plugins
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools
 -  `drpcli prefs <drpcli_prefs.html>`__ - List and set DigitalRebar
    Provision operational preferences
 -  `drpcli profiles <drpcli_profiles.html>`__ - Access CLI commands

--- a/doc/cli/drpcli_machines.rst
+++ b/doc/cli/drpcli_machines.rst
@@ -81,8 +81,13 @@ SEE ALSO
    for the machine
 -  `drpcli machines params <drpcli_machines_params.html>`__ - Gets/sets
    all parameters for the machine
+-  `drpcli machines pause <drpcli_machines_pause.html>`__ - Mark the
+   machine as NOT runnable
 -  `drpcli machines processjobs <drpcli_machines_processjobs.html>`__ -
    For the given machine, process pending jobs until done.
+-  `drpcli machines
+   releaseToPool <drpcli_machines_releaseToPool.html>`__ - Release this
+   machine back to the pool
 -  `drpcli machines remove <drpcli_machines_remove.html>`__ - Remove the
    param *key* from machines
 -  `drpcli machines
@@ -90,6 +95,8 @@ SEE ALSO
    profile from the machine’s list
 -  `drpcli machines removetask <drpcli_machines_removetask.html>`__ -
    Remove a task from the machine’s list
+-  `drpcli machines run <drpcli_machines_run.html>`__ - Mark the machine
+   as runnable
 -  `drpcli machines runaction <drpcli_machines_runaction.html>`__ - Run
    action on object from plugin
 -  `drpcli machines set <drpcli_machines_set.html>`__ - Set the machines

--- a/doc/cli/drpcli_machines_pause.rst
+++ b/doc/cli/drpcli_machines_pause.rst
@@ -1,0 +1,49 @@
+drpcli machines pause
+---------------------
+
+Mark the machine as NOT runnable
+
+Synopsis
+~~~~~~~~
+
+Set the machine’s Runnable flag to false
+
+::
+
+   drpcli machines pause [id] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for pause
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli machines <drpcli_machines.html>`__ - Access CLI commands
+   relating to machines

--- a/doc/cli/drpcli_machines_releaseToPool.rst
+++ b/doc/cli/drpcli_machines_releaseToPool.rst
@@ -1,0 +1,49 @@
+drpcli machines releaseToPool
+-----------------------------
+
+Release this machine back to the pool
+
+Synopsis
+~~~~~~~~
+
+Release this machine back to the pool
+
+::
+
+   drpcli machines releaseToPool [id] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for releaseToPool
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli machines <drpcli_machines.html>`__ - Access CLI commands
+   relating to machines

--- a/doc/cli/drpcli_machines_run.rst
+++ b/doc/cli/drpcli_machines_run.rst
@@ -1,0 +1,49 @@
+drpcli machines run
+-------------------
+
+Mark the machine as runnable
+
+Synopsis
+~~~~~~~~
+
+Set the machine’s Runnable flag to true
+
+::
+
+   drpcli machines run [id] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for run
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli machines <drpcli_machines.html>`__ - Access CLI commands
+   relating to machines

--- a/doc/cli/drpcli_pools.rst
+++ b/doc/cli/drpcli_pools.rst
@@ -1,0 +1,71 @@
+drpcli pools
+------------
+
+Access CLI commands relating to pools
+
+Synopsis
+~~~~~~~~
+
+Access CLI commands relating to pools
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for pools
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli <drpcli.html>`__ - A CLI application for interacting with the
+   DigitalRebar Provision API
+-  `drpcli pools action <drpcli_pools_action.html>`__ - Display the
+   action for this pool
+-  `drpcli pools actions <drpcli_pools_actions.html>`__ - Display
+   actions for this pool
+-  `drpcli pools active <drpcli_pools_active.html>`__ - List active
+   pools
+-  `drpcli pools create <drpcli_pools_create.html>`__ - Create a new
+   pool with the passed-in JSON or string key
+-  `drpcli pools destroy <drpcli_pools_destroy.html>`__ - Destroy pool
+   by id
+-  `drpcli pools exists <drpcli_pools_exists.html>`__ - See if a pools
+   exists by id
+-  `drpcli pools indexes <drpcli_pools_indexes.html>`__ - Get indexes
+   for pools
+-  `drpcli pools list <drpcli_pools_list.html>`__ - List all pools
+-  `drpcli pools manage <drpcli_pools_manage.html>`__ - Manage machines
+   in pools
+-  `drpcli pools runaction <drpcli_pools_runaction.html>`__ - Run action
+   on object from plugin
+-  `drpcli pools show <drpcli_pools_show.html>`__ - Show a single pools
+   by id
+-  `drpcli pools status <drpcli_pools_status.html>`__ - Get Pool status
+-  `drpcli pools update <drpcli_pools_update.html>`__ - Unsafely update
+   pool by id with the passed-in JSON
+-  `drpcli pools wait <drpcli_pools_wait.html>`__ - Wait for a pool’s
+   field to become a value within a number of seconds

--- a/doc/cli/drpcli_pools_action.rst
+++ b/doc/cli/drpcli_pools_action.rst
@@ -1,0 +1,50 @@
+drpcli pools action
+-------------------
+
+Display the action for this pool
+
+Synopsis
+~~~~~~~~
+
+Helper function to display the pool’s action.
+
+::
+
+   drpcli pools action [id] [action] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help            help for action
+         --plugin string   Plugin to filter action search
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_actions.rst
+++ b/doc/cli/drpcli_pools_actions.rst
@@ -1,0 +1,50 @@
+drpcli pools actions
+--------------------
+
+Display actions for this pool
+
+Synopsis
+~~~~~~~~
+
+Helper function to display the pool’s actions.
+
+::
+
+   drpcli pools actions [id] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help            help for actions
+         --plugin string   Plugin to filter action search
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_active.rst
+++ b/doc/cli/drpcli_pools_active.rst
@@ -1,0 +1,49 @@
+drpcli pools active
+-------------------
+
+List active pools
+
+Synopsis
+~~~~~~~~
+
+List active pools
+
+::
+
+   drpcli pools active [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for active
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_create.rst
+++ b/doc/cli/drpcli_pools_create.rst
@@ -1,0 +1,54 @@
+drpcli pools create
+-------------------
+
+Create a new pool with the passed-in JSON or string key
+
+Synopsis
+~~~~~~~~
+
+As a useful shortcut, ‘-’ can be passed to indicate that the JSON should
+be read from stdin.
+
+In either case, for the Machine, BootEnv, User, and Profile objects, a
+string may be provided to create a new empty object of that type. For
+User, BootEnv, Machine, and Profile, it will be the object’s name.
+
+::
+
+   drpcli pools create [json] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for create
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_destroy.rst
+++ b/doc/cli/drpcli_pools_destroy.rst
@@ -1,0 +1,49 @@
+drpcli pools destroy
+--------------------
+
+Destroy pool by id
+
+Synopsis
+~~~~~~~~
+
+This will destroy the pool.
+
+::
+
+   drpcli pools destroy [id] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for destroy
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_exists.rst
+++ b/doc/cli/drpcli_pools_exists.rst
@@ -1,0 +1,49 @@
+drpcli pools exists
+-------------------
+
+See if a pools exists by id
+
+Synopsis
+~~~~~~~~
+
+This will detect if a pool exists.
+
+::
+
+   drpcli pools exists [id] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for exists
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_indexes.rst
+++ b/doc/cli/drpcli_pools_indexes.rst
@@ -1,0 +1,49 @@
+drpcli pools indexes
+--------------------
+
+Get indexes for pools
+
+Synopsis
+~~~~~~~~
+
+Different object types can have indexes on various fields.
+
+::
+
+   drpcli pools indexes [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for indexes
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_list.rst
+++ b/doc/cli/drpcli_pools_list.rst
@@ -1,0 +1,91 @@
+drpcli pools list
+-----------------
+
+List all pools
+
+Synopsis
+~~~~~~~~
+
+This will list all pools by default. You can narrow down the items
+returned using index filters. Use the “indexes” command to get the
+indexes available for pools.
+
+To filter by indexes, you can use the following stanzas:
+
+-  *index* Eq *value* This will return items Equal to *value* according
+   to *index*
+-  *index* Ne *value* This will return items Not Equal to *value*
+   according to *index*
+-  *index* Lt *value* This will return items Less Than *value* according
+   to *index*
+-  *index* Lte *value* This will return items Less Than Or Equal to
+   *value* according to *index*
+-  *index* Gt *value* This will return items Greater Than *value*
+   according to *index*
+-  *index* Gte *value* This will return items Greater Than Or Equal to
+   *value* according to *index*
+-  *index* Re *re2 compatible regular expression* This will return items
+   in *index* that match the passed-in regular expression We use the
+   regular expression syntax described at
+   https://github.com/google/re2/wiki/Syntax
+-  *index* Between *lower* *upper* This will return items Greater Than
+   Or Equal to *lower* and Less Than Or Equal to *upper* according to
+   *index*
+-  *index* Except *lower* *upper* This will return items Less Than
+   *lower* or Greater Than *upper* according to *index*
+-  *index* In *comma,separated,list,of,values* This will return any
+   items In the set passed for the comma-separated list of values.
+-  *index* Nin *comma,separated,list,of,values* This will return any
+   items Not In the set passed for the comma-separated list of values.
+
+You can chain any number of filters together, and they will pipeline
+into each other as appropriate. After the above filters have been
+applied, you can further tweak how the results are returned using the
+following meta-filters:
+
+-  ‘reverse’ to return items in reverse order
+-  ‘limit’ *number* to only return the first *number* items
+-  ‘offset’ *number* to skip *number* items
+-  ‘sort’ *index* to sort items according to *index*
+
+::
+
+   drpcli pools list [filters...] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help         help for list
+         --limit int    Maximum number of items to return (default -1)
+         --offset int   Number of items to skip before starting to return data (default -1)
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_manage.rst
+++ b/doc/cli/drpcli_pools_manage.rst
@@ -1,0 +1,63 @@
+drpcli pools manage
+-------------------
+
+Manage machines in pools
+
+Synopsis
+~~~~~~~~
+
+Manage machines in pools
+
+Options
+~~~~~~~
+
+::
+
+         --add-parameters string      A JSON string of parameters to add to the machine
+         --add-profiles string        Comma separated list of profiles to add to the machine
+         --all-machines               Selects all available machines
+         --count int                  Count of machines to allocate
+     -h, --help                       help for manage
+         --machine-list string        Comma separated list of machines UUID or Field:Value
+         --minimum int                Minimum number of machines to return - defaults to count
+         --new-workflow string        A workflow to set on the machines
+         --remove-parameters string   Comma separated list of parameters to remove from the machine
+         --remove-profiles string     Comma separated list of profiles to remove from the machine
+         --wait-timeout string        An amount of time to wait for completion in seconds or time string (e.g. 30m)
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools
+-  `drpcli pools manage add <drpcli_pools_manage_add.html>`__ - add
+   machines to pool
+-  `drpcli pools manage allocate <drpcli_pools_manage_allocate.html>`__
+   - allocate machines to pool
+-  `drpcli pools manage release <drpcli_pools_manage_release.html>`__ -
+   release machines to pool
+-  `drpcli pools manage remove <drpcli_pools_manage_remove.html>`__ -
+   remove machines to pool

--- a/doc/cli/drpcli_pools_manage_add.rst
+++ b/doc/cli/drpcli_pools_manage_add.rst
@@ -1,0 +1,62 @@
+drpcli pools manage add
+-----------------------
+
+add machines to pool
+
+Synopsis
+~~~~~~~~
+
+Add places machines from a pool into the selected pool. The machines
+must be unallocated and in Free status. By default, the default pool is
+used.
+
+::
+
+   drpcli pools manage add [id ][filter options a=f(v) style] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help                 help for add
+         --source-pool string   The name of the pool to pull machines from
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+         --add-parameters string      A JSON string of parameters to add to the machine
+         --add-profiles string        Comma separated list of profiles to add to the machine
+         --all-machines               Selects all available machines
+     -c, --catalog string             The catalog file to use to get product information (default "https://repo.rackn.io")
+         --count int                  Count of machines to allocate
+     -d, --debug                      Whether the CLI should run in debug mode
+     -D, --download-proxy string      HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string            The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                      When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string              The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+         --machine-list string        Comma separated list of machines UUID or Field:Value
+         --minimum int                Minimum number of machines to return - defaults to count
+         --new-workflow string        A workflow to set on the machines
+     -H, --no-header                  Should header be shown in "text" or "table" mode
+     -x, --noToken                    Do not use token auth or token cache
+     -P, --password string            password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string        The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string                 A reference object for update commands that can be a file name, yaml, or json blob
+         --remove-parameters string   Comma separated list of parameters to remove from the machine
+         --remove-profiles string     Comma separated list of profiles to remove from the machine
+     -T, --token string               token of the Digital Rebar Provision access
+     -t, --trace string               The log level API requests should be logged at on the server side
+     -Z, --traceToken string          A token that individual traced requests should report in the server logs
+     -j, --truncate-length int        Truncate columns at this length (default 40)
+     -u, --url-proxy string           URL Proxy for passing actions through another DRP
+     -U, --username string            Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+         --wait-timeout string        An amount of time to wait for completion in seconds or time string (e.g. 30m)
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools manage <drpcli_pools_manage.html>`__ - Manage machines
+   in pools

--- a/doc/cli/drpcli_pools_manage_allocate.rst
+++ b/doc/cli/drpcli_pools_manage_allocate.rst
@@ -1,0 +1,60 @@
+drpcli pools manage allocate
+----------------------------
+
+allocate machines to pool
+
+Synopsis
+~~~~~~~~
+
+Allocate reserves machines in the selected pool. The machines must be
+unallocated and in Free status.
+
+::
+
+   drpcli pools manage allocate [id ][filter options a=f(v) style] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for allocate
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+         --add-parameters string      A JSON string of parameters to add to the machine
+         --add-profiles string        Comma separated list of profiles to add to the machine
+         --all-machines               Selects all available machines
+     -c, --catalog string             The catalog file to use to get product information (default "https://repo.rackn.io")
+         --count int                  Count of machines to allocate
+     -d, --debug                      Whether the CLI should run in debug mode
+     -D, --download-proxy string      HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string            The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                      When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string              The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+         --machine-list string        Comma separated list of machines UUID or Field:Value
+         --minimum int                Minimum number of machines to return - defaults to count
+         --new-workflow string        A workflow to set on the machines
+     -H, --no-header                  Should header be shown in "text" or "table" mode
+     -x, --noToken                    Do not use token auth or token cache
+     -P, --password string            password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string        The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string                 A reference object for update commands that can be a file name, yaml, or json blob
+         --remove-parameters string   Comma separated list of parameters to remove from the machine
+         --remove-profiles string     Comma separated list of profiles to remove from the machine
+     -T, --token string               token of the Digital Rebar Provision access
+     -t, --trace string               The log level API requests should be logged at on the server side
+     -Z, --traceToken string          A token that individual traced requests should report in the server logs
+     -j, --truncate-length int        Truncate columns at this length (default 40)
+     -u, --url-proxy string           URL Proxy for passing actions through another DRP
+     -U, --username string            Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+         --wait-timeout string        An amount of time to wait for completion in seconds or time string (e.g. 30m)
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools manage <drpcli_pools_manage.html>`__ - Manage machines
+   in pools

--- a/doc/cli/drpcli_pools_manage_release.rst
+++ b/doc/cli/drpcli_pools_manage_release.rst
@@ -1,0 +1,60 @@
+drpcli pools manage release
+---------------------------
+
+release machines to pool
+
+Synopsis
+~~~~~~~~
+
+Release frees machines in the selected pool. The machines must be
+allocated and in InUse status.
+
+::
+
+   drpcli pools manage release [id ][filter options a=f(v) style] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for release
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+         --add-parameters string      A JSON string of parameters to add to the machine
+         --add-profiles string        Comma separated list of profiles to add to the machine
+         --all-machines               Selects all available machines
+     -c, --catalog string             The catalog file to use to get product information (default "https://repo.rackn.io")
+         --count int                  Count of machines to allocate
+     -d, --debug                      Whether the CLI should run in debug mode
+     -D, --download-proxy string      HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string            The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                      When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string              The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+         --machine-list string        Comma separated list of machines UUID or Field:Value
+         --minimum int                Minimum number of machines to return - defaults to count
+         --new-workflow string        A workflow to set on the machines
+     -H, --no-header                  Should header be shown in "text" or "table" mode
+     -x, --noToken                    Do not use token auth or token cache
+     -P, --password string            password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string        The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string                 A reference object for update commands that can be a file name, yaml, or json blob
+         --remove-parameters string   Comma separated list of parameters to remove from the machine
+         --remove-profiles string     Comma separated list of profiles to remove from the machine
+     -T, --token string               token of the Digital Rebar Provision access
+     -t, --trace string               The log level API requests should be logged at on the server side
+     -Z, --traceToken string          A token that individual traced requests should report in the server logs
+     -j, --truncate-length int        Truncate columns at this length (default 40)
+     -u, --url-proxy string           URL Proxy for passing actions through another DRP
+     -U, --username string            Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+         --wait-timeout string        An amount of time to wait for completion in seconds or time string (e.g. 30m)
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools manage <drpcli_pools_manage.html>`__ - Manage machines
+   in pools

--- a/doc/cli/drpcli_pools_manage_remove.rst
+++ b/doc/cli/drpcli_pools_manage_remove.rst
@@ -1,0 +1,60 @@
+drpcli pools manage remove
+--------------------------
+
+remove machines to pool
+
+Synopsis
+~~~~~~~~
+
+Remove places machines from the selected pool into the default pool. The
+machines must be unallocated and in Free status.
+
+::
+
+   drpcli pools manage remove [id ][filter options a=f(v) style] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for remove
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+         --add-parameters string      A JSON string of parameters to add to the machine
+         --add-profiles string        Comma separated list of profiles to add to the machine
+         --all-machines               Selects all available machines
+     -c, --catalog string             The catalog file to use to get product information (default "https://repo.rackn.io")
+         --count int                  Count of machines to allocate
+     -d, --debug                      Whether the CLI should run in debug mode
+     -D, --download-proxy string      HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string            The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                      When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string              The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+         --machine-list string        Comma separated list of machines UUID or Field:Value
+         --minimum int                Minimum number of machines to return - defaults to count
+         --new-workflow string        A workflow to set on the machines
+     -H, --no-header                  Should header be shown in "text" or "table" mode
+     -x, --noToken                    Do not use token auth or token cache
+     -P, --password string            password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string        The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string                 A reference object for update commands that can be a file name, yaml, or json blob
+         --remove-parameters string   Comma separated list of parameters to remove from the machine
+         --remove-profiles string     Comma separated list of profiles to remove from the machine
+     -T, --token string               token of the Digital Rebar Provision access
+     -t, --trace string               The log level API requests should be logged at on the server side
+     -Z, --traceToken string          A token that individual traced requests should report in the server logs
+     -j, --truncate-length int        Truncate columns at this length (default 40)
+     -u, --url-proxy string           URL Proxy for passing actions through another DRP
+     -U, --username string            Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+         --wait-timeout string        An amount of time to wait for completion in seconds or time string (e.g. 30m)
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools manage <drpcli_pools_manage.html>`__ - Manage machines
+   in pools

--- a/doc/cli/drpcli_pools_runaction.rst
+++ b/doc/cli/drpcli_pools_runaction.rst
@@ -1,0 +1,50 @@
+drpcli pools runaction
+----------------------
+
+Run action on object from plugin
+
+Synopsis
+~~~~~~~~
+
+Run action on object from plugin
+
+::
+
+   drpcli pools runaction [id] [command] [- | JSON or YAML Map of objects | pairs of string objects] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help            help for runaction
+         --plugin string   Plugin to filter action search
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_show.rst
+++ b/doc/cli/drpcli_pools_show.rst
@@ -1,0 +1,50 @@
+drpcli pools show
+-----------------
+
+Show a single pools by id
+
+Synopsis
+~~~~~~~~
+
+This will show a pool by ID. You may also show a single item using a
+unique index. In that case, format id as *index*:*value*
+
+::
+
+   drpcli pools show [id] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for show
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_status.rst
+++ b/doc/cli/drpcli_pools_status.rst
@@ -1,0 +1,49 @@
+drpcli pools status
+-------------------
+
+Get Pool status
+
+Synopsis
+~~~~~~~~
+
+Get Pool status
+
+::
+
+   drpcli pools status [pool] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for status
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_update.rst
+++ b/doc/cli/drpcli_pools_update.rst
@@ -1,0 +1,50 @@
+drpcli pools update
+-------------------
+
+Unsafely update pool by id with the passed-in JSON
+
+Synopsis
+~~~~~~~~
+
+As a useful shortcut, ‘-’ can be passed to indicate that the JSON should
+be read from stdin
+
+::
+
+   drpcli pools update [id] [json] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for update
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/cli/drpcli_pools_wait.rst
+++ b/doc/cli/drpcli_pools_wait.rst
@@ -1,0 +1,54 @@
+drpcli pools wait
+-----------------
+
+Wait for a pool’s field to become a value within a number of seconds
+
+Synopsis
+~~~~~~~~
+
+This function waits for the value to become the new value.
+
+Timeout is optional, defaults to 1 day, and is measured in seconds.
+
+Returns the following strings: complete - field is equal to value
+interrupt - user interrupted the command timeout - timeout has exceeded
+
+::
+
+   drpcli pools wait [id] [field] [value] [timeout] [flags]
+
+Options
+~~~~~~~
+
+::
+
+     -h, --help   help for wait
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+     -c, --catalog string          The catalog file to use to get product information (default "https://repo.rackn.io")
+     -d, --debug                   Whether the CLI should run in debug mode
+     -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
+     -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:8092")
+     -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
+     -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
+     -H, --no-header               Should header be shown in "text" or "table" mode
+     -x, --noToken                 Do not use token auth or token cache
+     -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
+     -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
+     -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
+     -T, --token string            token of the Digital Rebar Provision access
+     -t, --trace string            The log level API requests should be logged at on the server side
+     -Z, --traceToken string       A token that individual traced requests should report in the server logs
+     -j, --truncate-length int     Truncate columns at this length (default 40)
+     -u, --url-proxy string        URL Proxy for passing actions through another DRP
+     -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")
+
+SEE ALSO
+~~~~~~~~
+
+-  `drpcli pools <drpcli_pools.html>`__ - Access CLI commands relating
+   to pools

--- a/doc/operation.rst
+++ b/doc/operation.rst
@@ -24,6 +24,7 @@ Some of these operations are in the :ref:`rs_ui`, but not all.  This will focus 
    operations/airgap
    operations/contexts
    operations/imagedeploy
+   operations/pooling
    operations/esxi-getting-started
    operations/security
    operations/scaling

--- a/doc/operations/pooling.rst
+++ b/doc/operations/pooling.rst
@@ -1,0 +1,143 @@
+.. Copyright (c) 2020 RackN Inc.
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. Digital Rebar Platform documentation under Digital Rebar master license
+.. index::
+  pair: Digital Rebar Platform; Pooling Operations
+
+.. _rs_pooling_ops:
+
+Pooling Operations
+==================
+
+This section will address usage of the pooling system.  The architecture and implementation of the pooling system is
+described at :ref:`rs_pooling_arch`.
+
+Pool Actions
+------------
+
+The Pool objects follow the Digital Rebar Provision standard API model.  One can list, show, update, and destroy pools.
+Additionally, pools can have actions from plugins.  Pools do not have parameters like a Machine or Plugin.
+
+::
+
+  drpcli pools list  # API call - GET /api/v3/pools
+  drpcli pools show mypool # API call - GET /api/v3/pools/mypool
+  drpcli pools update mypool '{ "Description": "mypool desc" }' # API call - PUT or PATCH /api/v3/pools/mypool with Data
+  drpcli pools destroy mypool # API call - DELETE /api/v3/pools/mypool
+
+
+NOTE: These commands only operate on Pool objects.  Pools can exist without objects just by machines being assigned
+to them.
+
+There is an additional command to get the status of the machines inside a pool.  This works pool objects and non-pool
+object pools.  The active pools are pools with machines in them without or with a pool object.
+
+::
+
+  drpcli pools active # API call - GET /api/v3/pools-active - NOTE The change.
+  drpcli pools status mypool   # API call - GET /api/v3/pools/mypool/status
+
+These allow you to manage machine membership for pool objects and non-pool objects.
+
+::
+
+  drpcli pools manage add mypool # API call - POST /api/v3/pools/mypool/addMachines with Data
+  drpcli pools manage remove mypool # API call - POST /api/v3/pools/mypool/removeMachines with Data
+  drpcli pools manage allocate mypool # API call - POST /api/v3/pools/mypool/allocateMachines with Data
+  drpcli pools manage release mypool # API call - POST /api/v3/pools/mypool/releaseMachines with Data
+
+The CLI takes additional parameters that let you add additional controls.
+
+* --add-parameters - A JSON string parameters to add to the system.  This is a map like the Parameters section of a Machine.
+* --remove-parameters - A comma separated list of parameters to remove from the machine.
+* --add-profiles - A comma separated list of profiles to add to the machine.
+* --remove-profiles - A comma separated list of profiles to remove from the machine.
+* --new-workflow - A workflow to assign to the machine when the action is done.
+* --count - the number of machines to operate on
+* --all-machines - Override count and use all machines in the pool or source pool.
+* --machine-list - a comma separated list of filters.  E.g Name:mymachine or just a UUID
+* --minimum - The minimum number of machines that must be found for success.  Using count and minimum can allow for partial success.
+* --wait-timeout - the number of seconds (or time string, e.g. 10h) to wait for all the machines to achieve the next status.
+* --source-pool - the pool to add machines from.  Defaults to the parent of the pool or default if unspecified. (only for add)
+
+Filters can be added to the drpcli command line to reduce the scope.  For example, ipmi/enabled=true would restrict operations
+to machines that have ipmi/enabled set to `true`.  The normal and full set of machine filters are available.  Multiple
+filters are ANDed together.
+
+For the API, these are POSTed as the following json blob.  Source pool is a query parameter.
+
+::
+
+  {
+    "pool/add-parameters": {
+      "param1": "string",
+      "param2": true
+    },
+    "pool/remove-parameters": [ "param3", "param4" ],
+    "pool/add-profiles": [ "profile1", "profile2" ],
+    "pool/remove-profiles": [ "profile3", "profile4" ],
+    "pool/workflow": "nextworkflow",
+    "pool/count": 30,
+    "pool/all-machines": false,
+    "pool/machine-list": ["UUID1", "Name:mymachine"],
+    "pool/minimum": 1,
+    "pool/wait-timeout": "30m",
+    "pool/filter": [ "ipmi/enable=true" ]
+  }
+
+
+
+
+Pool Objects
+------------
+
+Here is an example of a pool object with actions defined.  This assumes that you have already created the required
+profiles and workflows.
+
+
+::
+
+  ---
+  Id: my-machines
+  Description: Pool that install linux and cleans the machine
+  EnterActions:
+    Workflow: clean-machine
+    AddProfiles:
+    - pool-test-1
+    AddParameters:
+      auto-param-1: true
+    RemoveProfiles:
+    - pool-test-2
+    RemoveParameters:
+    - auto-param-2
+  AllocateActions:
+    Workflow: install-linux
+    AddProfiles:
+    - pool-test-2
+    AddParameters:
+      auto-param-2: false
+    RemoveProfiles:
+      - pool-test-1
+    RemoveParameters:
+      - auto-param-1
+  ReleaseActions:
+    Workflow: discover
+    AddProfiles:
+    - pool-test-1
+    AddParameters:
+      auto-param-1: false
+    RemoveProfiles:
+    - pool-test-2
+    RemoveParameters:
+    - auto-param-2
+  ExitActions:
+    Workflow: clean-machine
+    AddProfiles:
+    - pool-test-2
+    AddParameters:
+      auto-param-2: true
+    RemoveProfiles:
+    - pool-test-1
+    RemoveParameters:
+    - auto-param-1
+

--- a/models/machine.go
+++ b/models/machine.go
@@ -201,6 +201,17 @@ type Machine struct {
 	// is used to uniquely identify a Machine using a score based on how many total items in the Fingerprint
 	// match.
 	Fingerprint MachineFingerprint
+	// Pool contains the pool the machine is in.
+	// Unset machines will join the default Pool
+	Pool string
+	// PoolAllocated defines if the machine is allocated in this pool
+	// This is a calculated field.
+	PoolAllocated bool
+	// PoolStatus contains the status of this machine in the Pool.
+	//    Values are defined in Pool.PoolStatuses
+	PoolStatus PoolStatus
+	// WorkflowCopmlete indicates if the workflow is complete
+	WorkflowComplete bool
 }
 
 func (n *Machine) IsLocked() bool {

--- a/models/pool.go
+++ b/models/pool.go
@@ -1,0 +1,177 @@
+package models
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+)
+
+// PoolStatuses define the valid status for Machines in the pool
+var PoolStatuses []string = []string{
+	"Joining",
+	"HoldJoin",
+	"Free",
+	"Building",
+	"HoldBuild",
+	"InUse",
+	"Destroying",
+	"HoldDestroy",
+	"Leaving",
+	"HoldLeave",
+}
+
+type PoolStatus string
+
+const PS_JOINING = "Joining"
+const PS_HOLD_JOIN = "HoldJoin"
+const PS_FREE = "Free"
+const PS_BUILDING = "Building"
+const PS_HOLD_BUILD = "HoldBuild"
+const PS_IN_USE = "InUse"
+const PS_DESTROYING = "Destroying"
+const PS_HOLD_DESTROY = "HoldDestroy"
+const PS_LEAVING = "Leaving"
+const PS_HOLD_LEAVE = "HoldLeave"
+
+/*
+ * Pool defines the basics of the pool.  This is a static object
+ * that can be shared through content packs and version sets.
+ *
+ * Membership is dynamic and truth is from the machines' state.
+ *
+ * The transition actions are used on machines moving through the
+ * pool (into and out of, allocated and released).
+ *   EnterActions
+ *   ExitActions
+ *   AllocateActions
+ *   ReleaseActions
+ *
+ * Params are used to provide default values.
+ *
+ * AutoFill Parameters are:
+ *   UseAutoFill      bool
+ *   MinFree          int32
+ *   MaxFree          int32
+ *   CreateParameters map[string]interface{}
+ *   AcquirePool      string
+ */
+type Pool struct {
+	Validation
+	Access
+	Meta
+	Owned
+	Bundled
+
+	Id            string
+	Description   string `json:",omitempty"`
+	Documentation string `json:",omitempty"`
+	ParentPool    string `json:",omitempty"`
+
+	EnterActions    *PoolTransitionActions `json:",omitempty"`
+	ExitActions     *PoolTransitionActions `json:",omitempty"`
+	AllocateActions *PoolTransitionActions `json:",omitempty"`
+	ReleaseActions  *PoolTransitionActions `json:",omitempty"`
+
+	AutoFill *PoolAutoFill `json:",omitempty"`
+}
+
+// PoolTransitionActions define the default actions that should happen to a machine upon
+// movement through the pool.
+type PoolTransitionActions struct {
+	Workflow         string                 `json:",omitempty"`
+	AddProfiles      []string               `json:",omitempty"`
+	AddParameters    map[string]interface{} `json:",omitempty"`
+	RemoveProfiles   []string               `json:",omitempty"`
+	RemoveParameters []string               `json:",omitempty"`
+}
+
+// PoolAutoFill are rules for dynamic pool sizing
+type PoolAutoFill struct {
+	UseAutoFill      bool                   `json:"UseAutoFill,omitempty"`
+	MinFree          int32                  `json:"MinFree,omitempty"`
+	MaxFree          int32                  `json:"MaxFree,omitempty"`
+	CreateParameters map[string]interface{} `json:"CreateParameters,omitempty"`
+	AcquirePool      string                 `json:"AcquirePool,omitempty"`
+	ReturnPool       string                 `json:"ReturnPool,omitempty"`
+}
+
+// PoolResults is dynamically built provide membership and status.
+type PoolResults map[PoolStatus][]*PoolResult
+
+// PoolResult is the common return structure most operations
+type PoolResult struct {
+	Name      string
+	Uuid      string
+	Allocated bool
+	Status    PoolStatus
+}
+
+func (p *Pool) Key() string {
+	return p.Id
+}
+
+func (p *Pool) KeyName() string {
+	return "Id"
+}
+
+func (p *Pool) AuthKey() string {
+	return p.Key()
+}
+
+func (p *Pool) GetDescription() string {
+	return p.Description
+}
+
+func (p *Pool) GetDocumentation() string {
+	return p.Documentation
+}
+
+func (p *Pool) Prefix() string {
+	return "pools"
+}
+
+// Clone the pool
+func (p *Pool) Clone() *Pool {
+	p2 := &Pool{}
+	buf := bytes.Buffer{}
+	enc, dec := json.NewEncoder(&buf), json.NewDecoder(&buf)
+	if err := enc.Encode(p); err != nil {
+		log.Panicf("Failed to encode pools:%s: %v", p.Id, err)
+	}
+	if err := dec.Decode(p2); err != nil {
+		log.Panicf("Failed to decode pools:%s: %v", p.Id, err)
+	}
+	return p2
+}
+
+func (p *Pool) Fill() {
+	if p.Meta == nil {
+		p.Meta = Meta{}
+	}
+	if p.Errors == nil {
+		p.Errors = []string{}
+	}
+}
+
+func (p *Pool) CanHaveActions() bool {
+	return true
+}
+
+func (p *Pool) SliceOf() interface{} {
+	s := []*Pool{}
+	return &s
+}
+
+func (p *Pool) ToModels(obj interface{}) []Model {
+	items := obj.(*[]*Pool)
+	res := make([]Model, len(*items))
+	for i, item := range *items {
+		res[i] = Model(item)
+	}
+	return res
+}
+
+// SetName sets the name. In this case, it sets Id.
+func (p *Pool) SetName(name string) {
+	p.Id = name
+}

--- a/models/utils.go
+++ b/models/utils.go
@@ -85,6 +85,7 @@ func All() []Model {
 		&User{},
 		&Workflow{},
 		&Tenant{},
+		&Pool{},
 	}
 }
 


### PR DESCRIPTION
This commit adds the pooling objects and cli to the core
product.

The CLI and DOCs describe the operational and architectural usage.

Pools are optionally defined groups of machines that track
transition into and out the pools along with allocation and release.

Pools can define actions (add/remove parameters, add/remove profiles,
and change workflow) for entry and exit of pools and allocation and
release within the pool

Pool operations can be done on specific machines or filters that let
the user operate with cloud-like methods.