### PR TITLE
Update install.sh to allow for Raspberry pi install.

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -304,7 +304,7 @@ OS_NAME="$OS_TYPE-$OS_VER"
 
 case $OS_TYPE in
     centos|redhat|fedora) OS_FAMILY="rhel"      ;;
-    debian|ubuntu)        OS_FAMILY="debian"    ;;
+    debian|ubuntu|raspbian)        OS_FAMILY="debian"    ;;
     coreos)               OS_FAMILY="container" ;;
     *)                    OS_FAMILY="$OS_TYPE"  ;;
 esac


### PR DESCRIPTION
The problem
-
When trying to run the install.sh script, The script reports an error saying that the OS is unsupported. I'm installing this on Raspbian; which given a lot of the blog posts I see about digital rebar say it's compatible with a raspberry pi, is odd.

What this PR aims to achieve
-
This commit allows for Rasberry Pis to be used for the provisioning service. I found that Updating the install.sh and adding `raspbian` to line 307 seems to allow for a seamless install.

