### PR TITLE
fix(whoami): Account for vms running under hypervisors not being unique

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -32,7 +32,7 @@ require (
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/xattr v0.4.1
-	github.com/rackn/gohai v0.4.0
+	github.com/rackn/gohai v0.5.0
 	github.com/rackn/netwrangler v0.7.0
 	github.com/shirou/gopsutil v2.18.12+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Masterminds/sprig v2.20.0+incompatible h1:dJTKKuUkYW3RMFdQFXPU/s6hg10
 github.com/Masterminds/sprig v2.20.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d h1:G0m3OIz70MZUWq3EgK3CesDbo8upS2Vm9/P3FtgI+Jk=
 github.com/StackExchange/wmi v0.0.0-20190523213315-cbe66965904d/go.mod h1:3eOhrUMpNV+6aFIbp5/iudMxNCF27Vw2OZgy4xEx0Fg=
-github.com/VictorLowther/godmi v0.0.0-20190712193004-d244e3465e37 h1:PUbuWfvYnseI0EGyHLC7TligpL8T1vEQ9xz4rAssW98=
-github.com/VictorLowther/godmi v0.0.0-20190712193004-d244e3465e37/go.mod h1:JiYtLLi0v25VZLHRInc/p4CtOCFXUPKb9Q7vNQ6rqyk=
 github.com/VictorLowther/godmi v0.6.1 h1:cg88u82jFuLC72TC4tHAfNjMQyrwltO5U8BtoBA4lFo=
 github.com/VictorLowther/godmi v0.6.1/go.mod h1:O/JaTV/eBIggbtmYJ4Ld+Jqpn35C2OejkC5f0wNGt2o=
 github.com/VictorLowther/jsonpatch2 v1.0.0 h1:gQxztbUxxBK0EccdhRO44TgDy7jSFFIZAGO7vdQA2xA=
@@ -41,6 +39,7 @@ github.com/go-ole/go-ole v1.2.4 h1:nNBDSCOigTSiarFpYE9J/KtEA1IOW4CNeqT9TQDqCxI=
 github.com/go-ole/go-ole v1.2.4/go.mod h1:XCwSNxSkXRo4vlyPy93sltvi/qJq0jqQhjqQNIwKuxM=
 github.com/gofunky/semver v3.5.2+incompatible h1:bLtS5NNx0gLpaUJHGRtePWV6vs5Q2cNhatKFqKny5J8=
 github.com/gofunky/semver v3.5.2+incompatible/go.mod h1:7MXgDdC47tqmTJhxqX5CCuJaIx+c5igi9n0xPbKjG0U=
+github.com/google/go-cmp v0.4.0 h1:xsAVV57WRhGj6kEIi8ReJzQlHHqcBYCElAvkovg3B/4=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
@@ -110,10 +109,8 @@ github.com/pkg/xattr v0.4.1/go.mod h1:W2cGD0TBEus7MkUgv0tNZ9JutLtVO3cXu+IBRuHqnF
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rackn/gohai v0.0.0-20190619164647-92918a701117/go.mod h1:1NhfVxJ6qD4S5ondz2CobWFiYlODF8ex4pNgQrKYCxc=
-github.com/rackn/gohai v0.3.0 h1:oxAIEzqP07mK210dtV130I//8j4IryL6oQRUf7AZ5UY=
-github.com/rackn/gohai v0.3.0/go.mod h1:JGFSlNYmSPglk0ogBwtBandVf2mQPzVuFqjIbGDOZME=
-github.com/rackn/gohai v0.4.0 h1:WF7JgtJI2FJi1hw1vzY44yzJy+33Uz6Ijob99vghhmA=
-github.com/rackn/gohai v0.4.0/go.mod h1:L14W5Y4U9zycW/zJlbg75nVbrO6qWj80FWHjiCgxnag=
+github.com/rackn/gohai v0.5.0 h1:W56MFkYUpHkzl6RhffVjcuH9wJHLcBHMIKA4U+xnOm4=
+github.com/rackn/gohai v0.5.0/go.mod h1:L14W5Y4U9zycW/zJlbg75nVbrO6qWj80FWHjiCgxnag=
 github.com/rackn/netwrangler v0.7.0 h1:lMRzj+1xt45SnRiZ/7yJmqdBqVRTKB6xs29vCrfOHeQ=
 github.com/rackn/netwrangler v0.7.0/go.mod h1:1ZvFAprvzdbIZ/kMYh90tLMGsK4U31YqrAsKNIUEqls=
 github.com/russross/blackfriday v1.5.2 h1:HyvC0ARfnZBqnXwABFeSZHpKvJHJJfPz81GNueLj0oo=
@@ -154,6 +151,7 @@ golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e h1:N7DeIrjYszNmSW409R3frPPwg
 golang.org/x/sys v0.0.0-20191120155948-bd437916bb0e/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Sigh, in the face of cloned vms and such we cannot really rely on
certian parts of the DMI information being unique enough to count for
fingerprint purposes.  To alleviate that, don't calculate uniqueness
hashes based on DMI information when we are dealing with something we
know is running under a hypervisor, and fall back to doing uniqueness
checking based just on mac addresses