### PR TITLE
WIP enhance(provision): Add FPM packaging (rpm, deb, snap)

### DIFF
--- a/pkgs/INSTALL-fpm
+++ b/pkgs/INSTALL-fpm
@@ -1,0 +1,14 @@
+###
+#  see FPM install directions at:
+###
+https://fpm.readthedocs.io/en/latest/installing.html
+
+###
+#  for CentOS 7 - had to do following NOT documented steps
+#  due to Ruby 2.3 not available in default repos
+###
+sudo yum install centos-release-scl
+sudo yum install rh-ruby23 rh-ruby23-ruby-devel gcc make rpm-build rubygems
+sudo scl enable rh-ruby23 bash
+sudo gem install fpm
+sudo gem install pleaserun

--- a/pkgs/Makefile
+++ b/pkgs/Makefile
@@ -1,0 +1,101 @@
+
+VERSION=v4.3.2
+CLIVER=v4.3.2
+VENDOR=rackn
+DESCRIPTION=Digital Rebar Provision platform - $(VERSION)
+MAINTAINER=support@rackn.com
+URL=https://rackn.com/
+LICENSE=RackN
+RPMSUM=Digital Rebar Provision platform
+ZIPFILE=drp-$(VERSION).zip
+PKGS=rpm deb snap
+# 'pacman' type fails to build 'services' target correctly
+# PKGS=rpm deb snap pacman
+
+FPM=--version "$(VERSION)" --vendor "$(VENDOR)" --maintainer "$(MAINTAINER)" --url '$(URL)' --description "$(DESCRIPTION)" --license "$(LICENSE)" --rpm-summary "$(RPMSUM)"
+
+.PHONY: package
+
+package: services dr-provision dr-client stage-outputs
+
+help:
+	@echo ""
+	@echo "Make main targets:"
+	@echo "	help                   # outputs this help statement"
+	@echo "	setup-fpm              # attempt to install/setup FPM"
+	@echo "	clean                  # remove packages and staged unzips"
+	@echo "	clean-all              # really clean everything"
+	@echo "	clean-pkgs             # remove staged packages that might exist"
+	@echo "	package	               # make dr-provsion, drpcli, and startup services packages"
+	@echo ""
+	@echo "Note: package builds: dr-provision dr-client services"
+	@echo "      and is equivalent to just 'make' with no targets"
+	@echo ""
+	@echo "Additional sub-targets:"
+	@echo "	dr-provision dr-client services"
+	@echo ""
+
+clean:
+	rm -rf bin/ usr/ *rpm *deb *snap *pkg.tar.xz
+
+clean-pkgs:
+	rm -rf pkgs/
+
+clean-all: clean clean-pkgs
+	rm -rf drp-$(VERSION).zip drpcli
+
+# CentOS 7.7 specific
+setup-fpm:
+	sudo yum install centos-release-scl
+	sudo yum install rh-ruby23 rh-ruby23-ruby-devel gcc make rpm-build rubygems
+	sudo scl enable rh-ruby23 bash
+	sudo gem install fpm
+	sudo gem install pleaserun
+
+setup:
+	test -f drpcli && echo "drpcli found ... skip download" || curl -fsSl https://rebar-catalog.s3-us-west-2.amazonaws.com/drpcli/$(CLIVER)/amd64/linux/drpcli -o drpcli
+	test -f ./drpcli && chmod 755 ./drpcli
+	test -f $(ZIPFILE) && echo "dr-provision zip found ... skip download" || ./drpcli catalog item download drp as drp-$(VERSION).zip --version $(VERSION)
+
+setup-drp: setup
+	bsdtar -xzvf $(ZIPFILE) bin/linux/amd64/dr-provision
+	mkdir -p usr/local/bin/
+	mv bin/linux/amd64/dr-provision usr/local/bin/
+
+setup-cli: setup
+	bsdtar -xzvf $(ZIPFILE) bin/linux/amd64/drpjoin bin/linux/amd64/drpcli bin/linux/amd64/drbundler
+	mkdir -p usr/local/bin/
+	mv bin/linux/amd64/drpjoin bin/linux/amd64/drpcli bin/linux/amd64/drbundler usr/local/bin/
+
+dr-provision: setup-drp build-dr-provision
+
+build-dr-provision:
+	for PKG in $(PKGS) ; do \
+		fpm --input-type dir --output-type $$PKG --name dr-provision --provides dr-provision $(FPM) usr/local/bin/; \
+	done
+	rm -rf usr/
+
+dr-client: setup-cli build-dr-client
+
+build-dr-client:
+	for PKG in $(PKGS) ; do \
+		fpm --input-type dir --output-type $$PKG --name drpcli --provides drpcli $(FPM) usr/local/bin/; \
+	done
+	rm -rf usr/
+
+services: build-services
+
+build-services:
+	for PKG in $(PKGS) ; do \
+		fpm --input-type pleaserun --output-type $$PKG --name dr-provision-services --provides dr-provision-services $(FPM) /usr/local/bin/dr-provision; \
+	done
+
+stage-outputs:
+	for PKG in $(PKGS) ; do                                              \
+    		mkdir -p pkgs/$$PKG;                                         \
+    		DIR=$$PKG;                                                   \
+		[[ $$PKG == "pacman" ]] && PKG="pkg.tar.xz";                 \
+		ls -1 *\.$$PKG > /dev/null 2>&1 && mv *\.$$PKG pkgs/$$DIR/;  \
+	done
+
+

--- a/pkgs/README.md
+++ b/pkgs/README.md
@@ -1,0 +1,32 @@
+
+This Makefile builds various distro packages of:
+
+  dr-provision
+  drpcli
+  service startup files
+
+The Makefile supports several targets for building packages.  Current
+package build support is limited to the FPM tool support.
+
+See FPM website(s) for more details:
+  https://fpm.readthedocs.io/en/latest/
+  https://github.com/jordansissel/fpm
+
+
+The following primary make targets are supported:
+
+  make                 # builds dr-provision, drpcli, services, stage-outputs
+  make clean           # removes intermediary built packages
+  make clean-pkgs      # nukes the pkgs/ staged directory
+  make clean-all       # returns to factory default
+  make dr-provision    # builds dr-provision packages
+  make drpcli          # builds seprate drpcli packages
+  make services        # builds start unit files for dr-provision
+  make stage-outputs   # moves intermediary packages to pkgs/<TYPE>/ dir
+
+If you run an individual target (eg 'dr-provision'), you also will want to
+run 'stage-outputs' optionally.
+
+A 'setup-fpm' target exists which attempts to setup the FPM packages and
+gems necessary for the resulting builds.  This has only been tested on
+CentOS 7 at this point.


### PR DESCRIPTION
Adds initial support to build RPM, DEB, and SNAP package types of `dr-provision`, `drpcli`, and associated service start up files for `dr-provision`.

This uses the `FPM` package management Ruby gem to build many supported package format types.  Testing of builds completed, and installations have been tested for RPM packaging type.  DEB and SNAP have not been tested yet.

Final output package artifact examples:
```
pkgs/deb:
drpcli_v4.3.2_amd64.deb  dr-provision-services_v4.3.2_amd64.deb  dr-provision_v4.3.2_amd64.deb

pkgs/rpm:
drpcli-v4.3.2-1.x86_64.rpm  dr-provision-services-v4.3.2-1.x86_64.rpm  dr-provision-v4.3.2-1.x86_64.rpm

pkgs/snap:
drpcli_v4.3.2_native.snap  dr-provision-services_v4.3.2_native.snap  dr-provision_v4.3.2_native.snap
```