### PR TITLE
feat(override-bootenvs): Add basic bootenv override functions.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/klauspost/cpuid v1.2.1 // indirect
 	github.com/klauspost/pgzip v1.2.1
 	github.com/krolaw/dhcp4 v0.0.0-20190531080455-7b64900047ae
+	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/pborman/uuid v1.2.0
 	github.com/pkg/xattr v0.4.1

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421 h1:ZqeYNhU3OH
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLDQ0W1YjYsBW+p8U2u7vzgW2SQVmlNazg=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 h1:RWengNIwukTxcDr9M+97sNutRR1RKhG96O6jWumTTnw=
+github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826/go.mod h1:TaXosZuwdSHYgviHp1DAtfrULt5eUgsSMsZf+YrPgl8=
 github.com/olekukonko/tablewriter v0.0.4 h1:vHD/YYe1Wolo78koG299f7V/VAS08c6IpCLn+Ejf/w8=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
 github.com/pbnjay/strptime v0.0.0-20140226051138-5c05b0d668c9 h1:4lfz0keanz7/gAlvJ7lAe9zmE08HXxifBZJC0AdeGKo=

--- a/models/bootenv.go
+++ b/models/bootenv.go
@@ -172,6 +172,12 @@ func (o OsInfo) VersionEq(other string) bool {
 	return true
 }
 
+type BootEnvOverride struct {
+	Loaders   map[string]string
+	OS        OsInfo
+	Templates []TemplateInfo
+}
+
 // BootEnv encapsulates the machine-agnostic information needed by the
 // provisioner to set up a boot environment.
 //
@@ -459,4 +465,86 @@ func (b *BootEnv) CanHaveActions() bool {
 // some other network mechanism.
 func (b *BootEnv) NetBoot() bool {
 	return b.OnlyUnknown || b.Kernel != ""
+}
+
+// MergeOverrides makes a copy of b with the override values in overrides
+// applied in order, which whould be from leaset specific (in the global profile)
+// to the most specific (defined directly on a Machine).
+func (b *BootEnv) MergeOverrides(overrides ...BootEnvOverride) *BootEnv {
+	newEnv := Clone(b).(*BootEnv)
+	newEnv.Fill()
+	if _, ok := newEnv.OS.SupportedArchitectures["amd64"]; !ok && newEnv.Kernel != "" {
+		newEnv.OS.SupportedArchitectures["amd64"] = ArchInfo{
+			Kernel:     newEnv.Kernel,
+			Initrds:    newEnv.Initrds,
+			BootParams: newEnv.BootParams,
+			IsoFile:    newEnv.OS.IsoFile,
+			Sha256:     newEnv.OS.IsoSha256,
+			IsoUrl:     newEnv.OS.IsoUrl,
+		}
+	}
+
+	for i := len(overrides) - 1; i > -1; i-- {
+		override := overrides[i]
+		tMap := map[string]int{}
+		for j := range newEnv.Templates {
+			tMap[newEnv.Templates[j].Name] = j
+		}
+		for _, tmpl := range override.Templates {
+			if j, ok := tMap[tmpl.Name]; ok {
+				newEnv.Templates[j] = tmpl
+			} else {
+				newEnv.Templates = append(newEnv.Templates, tmpl)
+			}
+		}
+		if override.OS.Name != "" {
+			newEnv.OS.Name = override.OS.Name
+		}
+		if override.OS.Family != "" {
+			newEnv.OS.Family = override.OS.Family
+		}
+		if override.OS.Codename != "" {
+			newEnv.OS.Codename = override.OS.Codename
+		}
+		if override.OS.Version != "" {
+			newEnv.OS.Version = override.OS.Version
+		}
+		if newEnv.OS.SupportedArchitectures == nil {
+			newEnv.OS.SupportedArchitectures = map[string]ArchInfo{}
+		}
+		for k, loader := range override.Loaders {
+			newEnv.Loaders[k] = loader
+		}
+		for k, archInfo := range override.OS.SupportedArchitectures {
+			tgtArch, ok := newEnv.OS.SupportedArchitectures[k]
+			if !ok {
+				newEnv.OS.SupportedArchitectures[k] = archInfo
+				continue
+			}
+			if archInfo.IsoFile != "" {
+				tgtArch.IsoFile = archInfo.IsoFile
+			}
+			if archInfo.Sha256 != "" {
+				tgtArch.Sha256 = archInfo.Sha256
+			}
+			if archInfo.IsoUrl != "" {
+				tgtArch.IsoUrl = archInfo.IsoUrl
+			}
+			if archInfo.Kernel != "" {
+				tgtArch.Kernel = archInfo.Kernel
+			}
+			if len(archInfo.Initrds) > 0 {
+				tgtArch.Initrds = archInfo.Initrds
+			}
+			if archInfo.BootParams != "" {
+				tgtArch.BootParams = archInfo.BootParams
+			}
+			if archInfo.Loader != "" {
+				tgtArch.Loader = archInfo.Loader
+			}
+			newEnv.OS.SupportedArchitectures[k] = tgtArch
+		}
+	}
+	newEnv.Fill()
+	return newEnv
 }

--- a/models/utils.go
+++ b/models/utils.go
@@ -1,15 +1,15 @@
 package models
 
 import (
-	"bytes"
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"log"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/mohae/deepcopy"
 
 	"github.com/VictorLowther/jsonpatch2"
 	yaml "github.com/ghodss/yaml"
@@ -122,19 +122,7 @@ func Clone(m Model) Model {
 	if m == nil {
 		return nil
 	}
-	res, err := New(m.Prefix())
-	if err != nil {
-		log.Panicf("Failed to make a new %s: %v", m.Prefix(), err)
-	}
-	buf := bytes.Buffer{}
-	enc, dec := json.NewEncoder(&buf), json.NewDecoder(&buf)
-	if err := enc.Encode(m); err != nil {
-		log.Panicf("Failed to encode %s:%s: %v", m.Prefix(), m.Key(), err)
-	}
-	if err := dec.Decode(res); err != nil {
-		log.Panicf("Failed to decode %s:%s: %v", m.Prefix(), m.Key(), err)
-	}
-	return res
+	return deepcopy.Copy(m).(Model)
 }
 
 var (


### PR DESCRIPTION
We need a mechanism to allow for dynamic override of bootenvs to reign
in the bootenv explosions being caused by ESXi and others, and to
allow for user customizations of bootenvs that do not result in having
to copy everything that uses those bootenvs.

Along the way, switch to using deepcopy instead of JSON for model
cloning purposes.