### PR TITLE
bug(provision): install.sh create-self ID does not match runner name

### DIFF
--- a/tools/install.sh
+++ b/tools/install.sh
@@ -3,7 +3,7 @@
 set -e
 
 # BUMP version on updates
-VERSION="v20.03.23-1"
+VERSION="v20.07.10-1"
 
 DEFAULT_DRP_VERSION=${DEFAULT_DRP_VERSION:-"stable"}
 
@@ -952,7 +952,7 @@ EOF
                                  if [[ $CREATE_SELF ]] ; then
                                      cp $(which drpcli) /tmp/jq
                                      chmod +x /tmp/jq
-                                     ID=$(drpcli info get | /tmp/jq .id -r)
+                                     ID=$(drpcli info get | /tmp/jq .id -r | sed -r 's/:/-/g')
                                      rm /tmp/jq
                                      drpcli machines workflow "Name:$ID" "$INITIAL_WORKFLOW" >/dev/null
                                  fi


### PR DESCRIPTION
In most testing, I've set the drp-ip.  If the ID is not set, then the drp-id and the self runner names do NOT match.
this coverts the ID to the correct name by replacing : with -