### PR TITLE
feat(replaceWritable): Content packs can now override writable data

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,1 +1,0 @@
-LICENSE

--- a/api/content.go
+++ b/api/content.go
@@ -21,14 +21,22 @@ func (c *Client) GetContentItem(name string) (*models.Content, error) {
 	return res, c.Req().UrlFor("contents", name).Do(&res)
 }
 
-func (c *Client) CreateContent(content *models.Content) (*models.ContentSummary, error) {
+func (c *Client) CreateContent(content *models.Content, replaceWritable bool) (*models.ContentSummary, error) {
 	res := &models.ContentSummary{}
-	return res, c.Req().Post(content).UrlFor("contents").Do(res)
+	req := c.Req().Post(content).UrlFor("contents")
+	if replaceWritable {
+		req = req.Params("replaceWritable","true")
+	}
+	return res, req.Do(res)
 }
 
-func (c *Client) ReplaceContent(content *models.Content) (*models.ContentSummary, error) {
+func (c *Client) ReplaceContent(content *models.Content, replaceWritable bool) (*models.ContentSummary, error) {
 	res := &models.ContentSummary{}
-	return res, c.Req().Put(content).UrlFor("contents", content.Meta.Name).Do(res)
+	req := c.Req().Put(content).UrlFor("contents", content.Meta.Name)
+	if replaceWritable {
+		req = req.Params("replaceWritable","true")
+	}
+	return res, req.Do(res)
 }
 
 func (c *Client) DeleteContent(name string) error {

--- a/api/contents_test.go
+++ b/api/contents_test.go
@@ -48,7 +48,7 @@ func TestContentCrud(t *testing.T) {
 			op: func() (interface{}, error) {
 				barking := &models.Content{}
 				barking.Fill()
-				return session.CreateContent(barking)
+				return session.CreateContent(barking, false)
 			},
 		},
 		{
@@ -71,7 +71,7 @@ meta:
 				barking := &models.Content{}
 				barking.Fill()
 				barking.Meta.Name = "BarkingStore"
-				return session.CreateContent(barking)
+				return session.CreateContent(barking, false)
 			},
 		},
 		{
@@ -93,7 +93,7 @@ meta:
 					return nil, err
 				}
 				barking.Sections["profiles"] = map[string]interface{}{env.Key(): env}
-				return session.ReplaceContent(barking)
+				return session.ReplaceContent(barking, false)
 			},
 		},
 		{
@@ -123,7 +123,7 @@ meta:
 				}
 				env.(*models.BootEnv).Name = "ignoble"
 				barking.Sections["bootenvs"] = map[string]interface{}{env.Key(): env}
-				return session.ReplaceContent(barking)
+				return session.ReplaceContent(barking, false)
 			},
 		},
 		{

--- a/api/contents_test.go
+++ b/api/contents_test.go
@@ -41,7 +41,7 @@ func TestContentCrud(t *testing.T) {
 			expectRes: nil,
 			expectErr: &models.Error{
 				Model:    "contents",
-				Type:     "STORE_ERROR",
+				Type:     "POST",
 				Messages: []string{"Store at content- has no Name metadata"},
 				Code:     422,
 			},
@@ -82,7 +82,7 @@ meta:
 				Key:      "BarkingStore",
 				Type:     "PUT",
 				Messages: []string{"profiles:global in layer writable would override layer content-BarkingStore"},
-				Code:     500,
+				Code:     422,
 			},
 			op: func() (interface{}, error) {
 				barking := &models.Content{}

--- a/cli/plugin_providers.go
+++ b/cli/plugin_providers.go
@@ -20,7 +20,8 @@ func registerPluginProvider(app *cobra.Command) {
 		noCreate:   true,
 		noUpdate:   true,
 	}
-	op.addCommand(&cobra.Command{
+	replaceWritable := false
+	upload := &cobra.Command{
 		Use:   "upload [name] (from [file])",
 		Short: "Upload a program to act as a plugin_provider",
 		Long: `Uploads a program to act as a plugin_provider.
@@ -47,11 +48,17 @@ then the (from [file]) part may be omitted, and [name] should be the path to the
 			}
 			defer fi.Close()
 			res := &models.PluginProviderUploadInfo{}
-			if err := Session.Req().Post(fi).UrlFor(op.name, name).Do(res); err != nil {
+			req := Session.Req().Post(fi).UrlFor(op.name, name)
+			if replaceWritable{
+				req = req.Params("replaceWritable","true")
+			}
+			if err := req.Do(res); err != nil {
 				return err
 			}
 			return prettyPrint(res)
 		},
-	})
+	}
+	upload.Flags().BoolVar(&replaceWritable, "replaceWritable", false, "Replace identically named writable objects")
+	op.addCommand(upload)
 	op.command(app)
 }


### PR DESCRIPTION
The content pack and plugin upload API paths have added support for allowing the content that the objects provide
to replace identically named objects in the local writable store.  Multiple other layers providing identically named objects
is still disallowed.