### PR TITLE
fix(doc): Enhance portfast, fix KB 46 RST

### DIFF
--- a/doc/kb/kb-00034.rst
+++ b/doc/kb/kb-00034.rst
@@ -36,22 +36,25 @@ see a baremetal PXE boot initial PXE boot works but then it's getting kicked to 
 Troubleshooting: You can manually grab the file with ``wget`` after it bails, so communications are working fine.
 It just appears it's not waiting long enough for DHCP and then fails to get the file before it gets an IP.
 
-.. note:: You can set these changes the global profile so it will apply everywhere.  It shouldn’t hurt
+.. note:: You can set these changes in the ``global`` profile so it will apply everywhere.  It shouldn’t hurt
           functioning systems (they will escape the loop early) and might fix this system.
 
 
 **Solution 1**: Do you run your switches with Portfast? or Spanning Tree delays?
 
-You add these to your kernel-console parameter to alter the retry and wait times.
+You add these to your ``kernel-options`` parameter to alter the retry and wait times.
   * ``provisioner.portdelay=<Number of seconds>`` - seconds to wait before bring up link
   * ``provisioner.postportdelay=<Number of seconds>`` - seconds to wait after bringing up link before dhcp
   * ``provisioner.wgetretrycount=<Number of retries before failure>`` - wget of squashfs occurs once a second for 10 times by default.
 
+If you need to specify more than one of the above three values, use a space separated list, for example:
+
+  * ``provisioner.wgetretrycount=3 provisioner.postportdelay=120``
 
 **Solution 2**: Is something is really "slower" than sledgehammer expects?
 
-You could try setting ``provisioner.wgetretrycount=60``.  ``kernel-console`` is a parameter that lets you
-changing the kernel parameters passed to bootenvs.  Sometimes it is used to tweak the kernel console that
+You could try setting ``provisioner.wgetretrycount=60``.  ``kernel-options`` is a parameter that lets you
+changing the kernel parameters passed to bootenvs.  Sometimes it is used to tweak the kernel options that
 the kernel is using, but it can be used for other values as well.
 
 

--- a/doc/kb/kb-00046.rst
+++ b/doc/kb/kb-00046.rst
@@ -34,13 +34,14 @@ shows what you would add to your task to add the ability for the task to query a
   ::
 
     ExtraClaims:
-    - scope: "profiles"
-      action: "get"
-      specific: "*"
+      - scope: "profiles"
+        action: "get"
+        specific: "*"
 
 See Also
 ========
-:ref:`rs_data_claim`s
+
+:ref:`rs_data_claim`
 
 
 Keywords


### PR DESCRIPTION
- enhance the portfast KB for multiple options specified (space separated, no commas)
- fix kb-00046 RST formatting