### PR TITLE
fix(dhcpTest): Add a MAC address to our test DHCP packets.

### DIFF
--- a/cli/info.go
+++ b/cli/info.go
@@ -71,6 +71,7 @@ func addInfoCommands() (res *cobra.Command) {
 				Port           int
 			}
 			results := map[string]*status{}
+			chaddr,_ := net.ParseMAC("de:ad:be:ef:f0:01")
 			for _, service := range []string{"API", "Static", "TFTP", "DHCP", "BINL"} {
 				alive := false
 				switch service {
@@ -102,7 +103,7 @@ func addInfoCommands() (res *cobra.Command) {
 						xid := make([]byte, 4)
 						rand.Read(xid)
 						dest := &net.UDPAddr{IP: d.Address, Port: d.DhcpPort, Zone: ""}
-						packet := dhcp.RequestPacket(dhcp.Request, nil, net.IPv4(0, 0, 0, 0), xid, false, nil)
+						packet := dhcp.RequestPacket(dhcp.Request, chaddr, net.IPv4(0, 0, 0, 0), xid, false, nil)
 						conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
 						if err == nil {
 							defer conn.Close()
@@ -126,7 +127,7 @@ func addInfoCommands() (res *cobra.Command) {
 						xid := make([]byte, 4)
 						rand.Read(xid)
 						dest := &net.UDPAddr{IP: d.Address, Port: d.BinlPort, Zone: ""}
-						packet := dhcp.RequestPacket(dhcp.Request, nil, net.IPv4(0, 0, 0, 0), xid, false, nil)
+						packet := dhcp.RequestPacket(dhcp.Request, chaddr, net.IPv4(0, 0, 0, 0), xid, false, nil)
 						conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: 0})
 						if err == nil {
 							defer conn.Close()


### PR DESCRIPTION
The server-side code has gotten a little bit stricter about rejecting
invalid DHCP packets, including ones that do not have a chaddr set.

Add a fake one to our probing packets.