### PR TITLE
perf(models): Stop generating excess garbage in models.New()

### DIFF
--- a/models/tenant.go
+++ b/models/tenant.go
@@ -51,7 +51,7 @@ func (t *Tenant) GetDescription() string {
 func (t *Tenant) Validate() {
 	t.AddError(ValidName("Invalid Name", t.Name))
 	for k := range t.Members {
-		if _, ok := modelPrefixes[k]; !ok {
+		if _, ok := baseModels[k]; !ok {
 			t.Errorf("Invalid ")
 		}
 	}


### PR DESCRIPTION
models.New was making one of everything on every call, despite being
obligated to only return one thing.  Use a bit of reflection and
init time caching to stop generating excess garbage.