### PR TITLE
feat(timeouts):  Allow more granular control over API timeouts.

### DIFF
--- a/cli/plugin_providers.go
+++ b/cli/plugin_providers.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"fmt"
+	"os"
 	"path"
 
 	"github.com/digitalrebar/provision/v4/models"
@@ -49,8 +50,8 @@ then the (from [file]) part may be omitted, and [name] should be the path to the
 			defer fi.Close()
 			res := &models.PluginProviderUploadInfo{}
 			req := Session.Req().Post(fi).UrlFor(op.name, name)
-			if replaceWritable{
-				req = req.Params("replaceWritable","true")
+			if replaceWritable {
+				req = req.Params("replaceWritable", "true")
 			}
 			if err := req.Do(res); err != nil {
 				return err
@@ -60,5 +61,31 @@ then the (from [file]) part may be omitted, and [name] should be the path to the
 	}
 	upload.Flags().BoolVar(&replaceWritable, "replaceWritable", false, "Replace identically named writable objects")
 	op.addCommand(upload)
+	op.addCommand(&cobra.Command{
+		Use:     "download [item] to [dest]",
+		Aliases: []string{"show", "get"},
+		Short:   "Download the plugin_provider named [item] to [dest]",
+		Args: func(c *cobra.Command, args []string) error {
+			if len(args) == 1 || len(args) == 3 {
+				return nil
+			}
+			return fmt.Errorf("%v requires 1 or 2 arguments", c.UseLine())
+		},
+		RunE: func(c *cobra.Command, args []string) error {
+			dest := os.Stdout
+			if len(args) == 3 && args[2] != "-" {
+				var err error
+				dest, err = os.OpenFile(args[2], os.O_RDWR|os.O_CREATE, 0644)
+				if err != nil {
+					return fmt.Errorf("Error opening dest file %s: %v", args[2], err)
+				}
+				defer dest.Close()
+			}
+			if err := Session.GetBlob(dest, "plugin_providers", args[0], "binary"); err != nil {
+				return generateError(err, "Failed to fetch %v: %v", "plugin_providers", args[0])
+			}
+			return nil
+		},
+	})
 	op.command(app)
 }


### PR DESCRIPTION
This PR allows you to control both initial connect timeouts and
per-request total response timeouts using the context.Context mechanism.

It also adds support for downloading plugin_providers.