### PR TITLE
Added ARM64 jobs to .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: xenial
 language: go
+arch:
+  - amd64
+  - arm64
 addons:
   apt:
     packages:

--- a/cli/test-data/output/TestLoadIncrementer/plugin_providers.upload.incrementer.from/bin/linux/arm64/incrementer/stdout.expect
+++ b/cli/test-data/output/TestLoadIncrementer/plugin_providers.upload.incrementer.from/bin/linux/arm64/incrementer/stdout.expect
@@ -1,0 +1,3 @@
+RE:
+
+  "path": "incrementer",


### PR DESCRIPTION
Patch Details: Following files has been modified :

- Added arm64 architecture in travis.yml

- Created a folder named "arm64/incrementer/" and added a file named "stdout.expect" inside that folder
File Link- https://github.com/odidev/provision/blob/provision_arm64_support/cli/test-data/output/TestLoadIncrementer/plugin_providers.upload.incrementer.from/bin/linux/arm64/incrementer/stdout.expect