### PR TITLE
doc(provision): release notes for v4.5

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -80,7 +80,7 @@ Our `Quick Start <http://provision.readthedocs.io/en/latest/doc/quickstart.html>
 
 Regular `Install <http://provision.readthedocs.io/en/latest/doc/install.html>`_ for more details on the install steps.  These include production options. (`Previous Version Docs <http://provision.readthedocs.io/en/latest/doc/quickstart.html>`_)
 
-Current Stable Line is the :ref:`rs_release_v44` and next Release is planned to be :ref:`rs_release_v45`.  See :ref:`rs_release_summaries` for a complete list.
+Current Stable Line is the :ref:`rs_release_v45` and next Release is planned to be :ref:`rs_release_v46`.  See :ref:`rs_release_summaries` for a complete list.
 
 Components & Extensions
 -----------------------

--- a/conf.py
+++ b/conf.py
@@ -69,9 +69,9 @@ master_doc = 'README'
 
 # General information about the project.
 project = u'Digital Rebar'
-copyright = u'2019, RackN team'
+copyright = u'2020, RackN Inc'
 license = u'Apache v2'
-author = u'RackN team'
+author = u'RackN Inc'
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the
@@ -155,7 +155,7 @@ html_theme = 'bizstyle'
 
 # The name for this set of Sphinx documents.  If None, it defaults to
 # "<project> v<release> documentation".
-html_title = "Digital Rebar Platform Docs"
+html_title = "Digital Rebar Docs"
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 html_short_title = "DRP"
@@ -257,7 +257,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, 'DigitalRebar_Provision.tex', u'Digital Rebar Platform Documentation',
+    (master_doc, 'DigitalRebar_Provision.tex', u'Digital Rebar Documentation',
      u'RackN team', 'manual'),
 ]
 
@@ -287,7 +287,7 @@ latex_documents = [
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'dr-provision', u'Digital Rebar Platform Documentation',
+    (master_doc, 'dr-provision', u'Digital Rebar Documentation',
      [author], 1)
 ]
 
@@ -301,8 +301,8 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'Digital Rebar Platform', u'Digital Rebar Platform Documentation',
-     author, 'Digital Rebar Platform', 'Golang API-Driven Provisioning Workflow.',
+    (master_doc, 'Digital Rebar', u'Digital Rebar Documentation',
+     author, 'Digital Rebar', 'Golang API-Driven Provisioning Workflow.',
      'Miscellaneous'),
 ]
 

--- a/doc/rel_notes/summaries/release_v40.rst
+++ b/doc/rel_notes/summaries/release_v40.rst
@@ -8,8 +8,8 @@
 
 .. _rs_release_v40:
 
-Digital Rebar version 4.0
--------------------------
+Digital Rebar version 4.0 [Summer 2019]
+---------------------------------------
 
 Release Date: August 8, 2019
 

--- a/doc/rel_notes/summaries/release_v41.rst
+++ b/doc/rel_notes/summaries/release_v41.rst
@@ -8,8 +8,8 @@
 
 .. _rs_release_v41:
 
-Digital Rebar version 4.1
--------------------------
+Digital Rebar version 4.1 [Fall 2019]
+-------------------------------------
 
 Release Date: missing
 

--- a/doc/rel_notes/summaries/release_v42.rst
+++ b/doc/rel_notes/summaries/release_v42.rst
@@ -8,8 +8,8 @@
 
 .. _rs_release_v42:
 
-Digital Rebar version 4.2
--------------------------
+Digital Rebar version 4.2 [Winter 2019]
+---------------------------------------
 
 Release Date: December 31, 2019
 

--- a/doc/rel_notes/summaries/release_v43.rst
+++ b/doc/rel_notes/summaries/release_v43.rst
@@ -8,8 +8,8 @@
 
 .. _rs_release_v43:
 
-Digital Rebar version 4.3
--------------------------
+Digital Rebar version 4.3 [Spring 2020]
+---------------------------------------
 
 Release Date: June 3, 2020
 

--- a/doc/rel_notes/summaries/release_v44.rst
+++ b/doc/rel_notes/summaries/release_v44.rst
@@ -7,8 +7,8 @@
 
 .. _rs_release_v44:
 
-Digital Rebar version 4.4
--------------------------
+Digital Rebar version 4.4 [Summer 2020]
+---------------------------------------
 
 Release Date: July 30, 2020
 

--- a/doc/rel_notes/summaries/release_v45.rst
+++ b/doc/rel_notes/summaries/release_v45.rst
@@ -8,12 +8,12 @@
 
 .. _rs_release_v45:
 
-Digital Rebar version 4.5
--------------------------
+Digital Rebar version 4.5 [Fall 2020]
+-------------------------------------
 
-Release Date: expected Fall 2020
+Release Date: September 25, 2020
 
-Release Themes: Multi-Site Manager, Universal Workflow
+Release Themes: Multi-Site Manager
 
 In addition to bug fixes and performance improvements, the release includes several customer-driven features.
 
@@ -27,45 +27,104 @@ Deprecations
 The following items are flagged as deprecated in v4.5 and will be removed in v4.6.
 
 * old pattern cluster synchronization with cluster-add, cluster-step and cluster-sync.  Operators should migrate to the new cluster-gate-* patterns.
+* terraform-provider-drp based on the DRP v3 API will not be supported
+
+
+.. _rs_release_v45_removals:
+
+Removals
+~~~~~~~~
+
+None at this time.
+
 
 .. _rs_release_v45_multisite:
 
-Multi-Site Manager
-~~~~~~~~~~~~~~~~~~
+Integrated Multi-Site Manager
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Two Major Features:
+_This is a licensed feature_
 
-* Ability to consolidate data from multiple endpoints into subscribed endpoints and proxy forward API requests
-* Ability to centrally manage and enforce configuration of remote endpoints
+This release integrated the Multi-Site Management features directly into DRP core instead of providing it as a plug-in.  While this change only has minor impacts on the API, it significantly improved the performance and resilience of the manager.
+
+Multi-Site Manager significantly enhances Digital Rebar from providing a single site integrated infrastructure as code (IaC) provision platform into a distributed infrastructure control plane.  The design maintains site autonomy AND builds a management federation.  By design, each site may have multiple managers to allow for regional and global layering.
+
+Major Features:
+
+* Ability to consolidate data from multiple endpoints into subscribed endpoints
+* Ability to change managed endpoint data via calls to the mirrored data in the manager API (uses DRP proxy forward)
+* Ability to centrally manage and enforce configuration of remote endpoints via Version Sets
+* Integrates with DRP HA features so that HA groups are managed as a single site.
+
+Important note: all managed endpoints must be licensed BEFORE they can be attached to the manager.  When using the UX to add endpoints, it will automatically check and update the relevant license.
 
 
 .. _rs_release_v45_universal_workflow:
 
 
-Sledgehammer Centos 8
-~~~~~~~~~~~~~~~~~~~~~
+Sledgehammer on Centos 8 (SL8)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-To take advantage of the latest kernel and distro features, customers want Sledgehammer migrated to Centos8 instead of Centos7
+To take advantage of the latest kernel and distro features, customers want Sledgehammer migrated to Centos 8 (aka SL8) instead of Centos 7 (aka SL7).  The change also includes python3.
 
-Make SL8 the main sledgehammer with python3 and a profile to support backwards SL7.
+As the heart of our discovery, imaging and hardware update features, Sledgehammer is a critical component for Digital Rebar operations.  Migrating to an updated Centos version allows operators to take advantage of features in the latest distro; however, the potential for Sledgehammer changes to impact existing workflows means that RackN takes a cautious approach to revisions.
+
+To leverage the new SL8, add the enabling SL8 profile in your workflow.
+
+Note: SL8 is expected to become default in DRP v4.6.  A profile will be provided the enable backwards SL7 support.
 
 
-Universal Workflow
-~~~~~~~~~~~~~~~~~~
-
-Planned, not committed
-
+.. _rs_release_v45_log_capture:
 
 Log Capture 
 ~~~~~~~~~~~~
 
-Planned, not committed
+Utility allows operators to collect log information from DRP as a portal unit for analysis by RackN.
 
-Allow customers to collect log information from DRP to analysis by RackN as a utility.  Should attempt (but won’t be able to) scrub/remove sensitive information.
+When working with customers and community environments, RackN often needs to review comprehensive system logs.  This utility makes it easier for operators to capture and package the correct logs.  This makes a greatly reduces the risk of incomplete captures and ultimately reduces the time to resolution for customers.
+
+This features has been integrated into the v4.5 DRPCLI and documented there.
+
+.. _rs_release_v45_performance:
+
+Startup and API Performance Tuning
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+RackN customers are running systems with thousands of machines and high transaction loads.  With Multi-Site creating aggregate views of these systems, performance at scale is a critical aspect of the v4.5 release with Multi-Site manager.
+
+Completed enhancements include:
+  * Significant refactoring was performed to improve DRP start times and loading of content packs to running systems.
+  * Stress testing of 1,000+ parallelized active agents was performed.
+  * Optimizations and testing of the RackN UX for high object counts and activity levels.
+  * Improved plugin initialization and safeties.
+
+.. _rs_release_v45_terraform:
+
+v4.5 Terraform Provider
+~~~~~~~~~~~~~~~~~~~~~~~
+
+The Terraform Provider (https://github.com/rackn/terraform-provider-drp) has been completely rewritten to work with Terraform v0.13+.  This new provider requires the v4.4 :ref:`rs_release_v44_pooling` feature.
+
+Terraform is one of several systems that need to request and release Digital Rebar machines in a more abstracted way.  While the Terraform provider is valuable as a stand alone benefit for Terraform users, RackN also uses it to validate the pooling API process and interfaction.
+
+Due to the new 3rd party registration feature, operators will be able to automatically download the updated provider from a RackN maintained registery.  This eliminates the requirement to track builds, download or create a local version of the provider.
+
+Note: While the provider is APLv2 open source, this feature leverages the licensed feature of pre-defined pools.
 
 .. _rs_release_v45_otheritems:
 
 Other Items of Note
 ~~~~~~~~~~~~~~~~~~~
 
-* TBD
+* `drpcli machines count` optimization bypassing sending data to get counts of machines
+* Fixes to `docker-context` plugin to improve start-up and reset operations
+* Tuning of the DHCP performance system
+* Improved integration with VMware ESXi provisioning
+* Significant updates and improvements to this documentation
+* Expand ansible-local-playbooks task to use templates
+* Updates to filebeat plugin
+* Improved stability for self-runner bootstrapping agent
+* Improved data collection and communication within HA clusters
+* Web UX
+  * Improved Params update from Machines List view including setting secure values
+  * Numerous rendering and edit page fixes

--- a/doc/rel_notes/summaries/release_v46.rst
+++ b/doc/rel_notes/summaries/release_v46.rst
@@ -1,0 +1,64 @@
+.. Copyright (c) 2020 RackN Inc.
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. Digital Rebar Provision documentation under Digital Rebar master license
+.. index::
+  pair: Digital Rebar Provision; Release v4.6
+  pair: Digital Rebar Provision; Release Notes
+
+
+.. _rs_release_v46:
+
+Digital Rebar version 4.6 [planned]
+-----------------------------------
+
+Release Date: expected Winter 2020
+
+Release Themes: Usability, Universal Workflow
+
+In addition to bug fixes and performance improvements, the release includes several customer-driven features.
+
+See :ref:`rs_release_summaries` for a complete list of all releases.
+
+.. _rs_release_v46_deprecations:
+
+Deprecations
+~~~~~~~~~~~~
+
+The following items are flagged as deprecated in v4.6 and will be removed in v4.7.
+
+* none planned.
+
+.. _rs_release_v46_removals:
+
+Removals
+~~~~~~~~
+
+The following items were flagged as deprecated in v4.5 and are removed in v4.6.
+
+* old pattern cluster synchronization with cluster-add, cluster-step and cluster-sync.  Operators should migrate to the new cluster-gate-* patterns.
+* terraform-provider-drp based on the DRP v3 API will not be supported
+
+Universal Workflow
+~~~~~~~~~~~~~~~~~~
+
+Planned, not committed
+
+
+Restricted Access ISOs
+~~~~~~~~~~~~~~~~~~~~~~
+
+Planned, not committed
+
+
+Integrated Simple DNS
+~~~~~~~~~~~~~~~~~~~~~
+
+Planned, not committed
+
+
+.. _rs_release_v46_otheritems:
+
+Other Items of Note
+~~~~~~~~~~~~~~~~~~~
+
+* TBD

--- a/doc/release.rst
+++ b/doc/release.rst
@@ -15,6 +15,7 @@ RackN creates a high level summary for each release that includes the major deli
 .. toctree::
    :maxdepth: 1
    :glob:
+   :reversed:
 
    rel_notes/summaries/*
 


### PR DESCRIPTION
Primarily, this is an update for the v4.5 release notes
It includes some cleanups on other pages and the addition of the v4.6 placeholder.