### PR TITLE
doc(multi-site-manager): add docs for proxy creates

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -52,6 +52,26 @@ The API includes specialized filter behavior for Params that allows deep searchi
 
 To filter Machines or Profiles by Param values, pass the Param name and value using the normal Field filter specification.  When the Field is not found, the backend will search model's Params keys and evalute the filter against the Param value.
 
+.. _rs_api_proxy:
+
+Leveraging Multi-Site Proxy Forwarding
+--------------------------------------
+
+In the :ref:`rs_manager_arch`, API calls to a DRP manager for remote objects are automatically forwarded to the correct attached endpoint.  This allows operators to make API calls to remote endpoints from a centralized manager without knowing the actual owner of the object.  The owning endpoint can be determined for any object by inspecting its `Endpoint` property.
+
+For most cases, no additional information or API notation is required to leverage this functionality. The exception is creating objects on attached endpoints.  The create (aka POST) case requires API callers to specify the target remote endpoint (the endpoint must be registered or the request will be rejected) to the manager.
+
+To make an explicit API proxy call, prefix the path of the request with the endpoint identity.  For example:
+
+  ::
+
+    /[target endpoint id]/api/v3/machines
+
+
+This pattern is also invoked by with the `-u` flag in the DRPCLI.
+
+NOTE: Multi-site is a licensed feature available in DRP v4.5+ and must be enabled for the endpoint.
+
 .. _rs_api_slim:
 
 Payload Reduction (slim)

--- a/doc/arch/manager.rst
+++ b/doc/arch/manager.rst
@@ -68,8 +68,9 @@ The two main functions of manager are discussed here.
 Single Pane of Glass
 ====================
 
-When making API requests, the manager will provide results from all the attached endpoints.  Additionally, all objects
-have a field, **Endpoint**, that is populated with the Endpoint Id (the High Availability Id) of the owning endpoint.
+When making API requests, the manager will provide results from all the attached endpoints.  Additionally, all objects have a field, **Endpoint**, that is populated with the Endpoint Id (the High Availability Id) of the owning endpoint.  API requests made to objects from attached endpoints are
+automatically forward to the correct endpoint.  See :ref:`rs_api_proxy` for more information about
+using this automatic API behavior explicity.
 
 Only the local objects are replicated up to the manager, objects provided by content packages and plugins are not
 replicated to the manager.  It is assumed that the manager will have all the content packages and plugins loaded to

--- a/doc/operations/manager.rst
+++ b/doc/operations/manager.rst
@@ -80,6 +80,12 @@ or content packages.  The **files** api can be used to update the catalog.
 
 The UX has a helper button for this action.
 
+Proxy Creating an Object on Managed Endpoint
+____________________________________________
+
+It is possible to create objects on managed endpoints by using proxy pass-through from the manager.  Details are available in :ref:`rs_api_proxy`.
+
+
 Manager Common Methods
 ----------------------
 


### PR DESCRIPTION
capturing the API call for the proxy create case. 
left breadcrumbs in other docs.