### PR TITLE
feat(drpcli): added abort log to support bundle

### DIFF
--- a/cli/support.go
+++ b/cli/support.go
@@ -96,6 +96,16 @@ func bundleCmds() *cobra.Command {
 				}
 			}
 
+			abtFile := drBase + "/abort.log"
+			_, err = os.Stat(abtFile)
+			if os.IsNotExist(err) {
+				return err
+			}
+			err = AddFileToZip(w, abtFile)
+			if err != nil {
+				return err
+			}
+
 			if w.Close() != nil {
 				return err
 			}


### PR DESCRIPTION
Added the abort log to the support bundle should it exist

Signed-off-by: Michael Rice <michael@michaelrice.org>