### PR TITLE
feat(consensus): Update HA docs to include consensus docs.

### DIFF
--- a/cli/system.go
+++ b/cli/system.go
@@ -197,11 +197,11 @@ func addSystemCommands() (res *cobra.Command) {
 		},
 	})
 	consensus.AddCommand(&cobra.Command{
-		Use:   "enroll [endpointUrl] [endpointUser] [endpointPass]",
+		Use:   "enroll [endpointUrl] [endpointUser] [endpointPass] extraArgs",
 		Short: "Have the endpoint at [endpointUrl] join the cluster.",
 		Args: func(c *cobra.Command, args []string) error {
 			if len(args) < 3 {
-				return fmt.Errorf("Need exactly 3 arguments")
+				return fmt.Errorf("Need 3 or more arguments")
 			}
 			if len(args) > 3 {
 				if len(args[3:])%2 != 0 {
@@ -237,6 +237,21 @@ func addSystemCommands() (res *cobra.Command) {
 						intro.ConsensusAddr = v
 					case "Observer":
 						intro.Observer = strings.ToLower(v) == "true"
+					case "LoadBalanced":
+						if intro.ConsensusEnabled {
+							return fmt.Errorf("LoadBalanced can only be set during self-enrollment")
+						}
+						intro.LoadBalanced = strings.ToLower(v) == "true"
+					case "VirtAddr":
+						if intro.ConsensusEnabled {
+							return fmt.Errorf("VirtAddr can only be set during self-enrollment")
+						}
+						intro.VirtAddr = v
+					case "HaID":
+						if intro.ConsensusEnabled {
+							return fmt.Errorf("HaID can only be set during self-enrollment")
+						}
+						intro.HaID = v
 					default:
 						return fmt.Errorf("Unknown node HA setting %s", k)
 					}

--- a/doc/high-availability.rst
+++ b/doc/high-availability.rst
@@ -6,30 +6,22 @@
 
 .. _rs_high_availability:
 
-
 High Availability
-~~~~~~~~~~~~~~~~~
+#################
 
-High Availability is a new feature that will be present in dr-provision starting with version 4.3.0.
-To begin with, the working model will be Active/Passive with unidirectional data replication and
-manual failover.  Automated failover and failback may be added in future versions of dr-provision.
-Currently, high-availability should be considered a technical preview -- the details of how it is implemented
-and how to manage it are likely to change based on customer feedback.
-
+There are two strategies available for implementing high availability in dr-provision: automated failover using Raft for
+consensus and liveness checking, and manual failover via synchronous replication.  The former is new in 4.6.0, and
+is currently in beta testing.  The latter has been available since v4.3.0, and will continue to remain available for the
+forseeable future.
 
 Prerequisites
--------------
+~~~~~~~~~~~~~
 
-There are a few conditions that need to be met in order to set up an HA cluster of dr-provision machines:
+There are a few conditions that need to be met in order to set up an HA cluster of dr-provision nodes:
 
 #. A fast network between the nodes you want to run dr-provision on.  Data replication between HA nodes
    uses synchronous log replay and file transfer, so a fast network (at least gigabit Ethernet) is required to
    not induce too much lag into the system as a whole.
-
-#. A virtual IP address that can be moved from node to node.  dr-provision will handle adding and removing
-   the virtual IP from a specified interface and sending out gratuitous ARP packets on failover events.  If the
-   nodes forming the HA cluster are not in the same layer 2 broadcast domain or subnet, then you will need to
-   arrange for the appropriate route changes required.
 
 #. Enough storage space on each node to store a complete copy of all replicated data.  dr-provision will wind up
    replicating all file, ISO, job log, content bundle, plugin, and writable data to all nodes participating in the
@@ -39,25 +31,60 @@ There are a few conditions that need to be met in order to set up an HA cluster 
 #. A high-availability entitlement in your license.  High-availability is a licensed enterprise feature.  If you
    are not sure if your license includes high-availability support, contact support@rackn.com.
 
-Contraindications
------------------
+#. A virtual IP address that client and external traffic can be directed to.  If using dr-provision's internal
+   IL address management (i.e not using the --load-balanced command line option), dr-provision will handle adding and
+   removing the virtual IP from a specified interface and sending out gratuitous ARP packets on failover events, and
+   the nodes forming the HA cluster must be on the same layer 2 network.  If using an external load balancer,
+   then the virtual IP must point to the load balancer, and that address will be used by everything outside of the
+   cluster to communicate with whichever cluster node is the active one.
 
-The high-availability support code in dr-provision assumes a model where the machines are in the same layer 2
-broadcast domain to allow for moving the HA IP address via gratuitous AR), and that the writable storage that dr-provision
-uses is not shared (via NFS, iSCSI, drbd, or whatever) between servers running dr-provision.
+Synchronous Replication
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Synchronous Replication is the feature used to implement high availability with manual failover along with
+streaming realtime backups from dr-provision v4.3.0 thru v4.6.0.  It will continue to be present going forward
+as the realtime backup and protocol, but the shift towards consensus with automated failover will be the path
+going forward for high availability.
+
+When operating in synchronous replication mode, there must be at least 2 servers -- one active, and at least 1
+passive node.
+
+Consensus via Raft
+~~~~~~~~~~~~~~~~~~
+
+Consensus via Raft is the feature used to implement high availability with automated failover.  This mode requires that
+you have at least 3 servers in a cluster.  More servers in a cluster are also permitted, but there must be an odd number
+to prevent the cluster from deadlocking in the case of communication failures that isolate half of the cluster from the
+other half.  Consensus via raft also requires a stable IP address:port that can be used for the replication protocol.
+
+Contraindications
+~~~~~~~~~~~~~~~~~
+
+The high-availability support code in dr-provision assumes a model where either:
+
+* The machines are in the same layer 2 broadcast domain to allow for moving the HA IP address via gratuitous AR, or
+
+* An external load balancer is responsible for holding the virtual IP address and directing all traffic to the
+  current active node.
+
+* The writable storage that dr-provision uses is not shared (via NFS, iSCSI, drbd, or whatever) between servers running
+  dr-provision.
+
+* If running in automated failover, there must be at least 3 servers in the cluster, and there must be an odd number
+  of servers in the cluster.
+
+Of none of the above are true, then you cannot use dr-provision in high-availability mode.
 
 * If you are running on separate broadcast domains, you will need to either ensure that there is an alternate mechanism for
   ensuring that packets destined for the HA IP address get routed correctly, or accept that provisioning operations
-  will fail from the old network until the clients are informed of the new IP address.  In the latter case, you probably
-  do not want to use the integrated HA support directly, as it assumes that it has a virtual IP that will migrate from
-  one dr-provision instance to another.
+  will fail from the old network until the clients are informed of the new IP address.
 
 * If you are using a shared storage mechanism (NFS, DRBD, iSCSI, or some form of distributed filesystem), then you should
   not use our integrated HA support, as it will lead to data corruption.  You should also make sure you never run more than
   one instance of dr-provision on the same backing data at the same time, or the data will be corrupted.
 
 Configuration
--------------
+~~~~~~~~~~~~~
 
 Aside from settings listed later in this section, configuration flags and startup options for the dr-provision
 services participating in an HA cluster should be identical.  It is not required that the servers participating
@@ -66,7 +93,7 @@ If you try to add a server version to a cluster that is incompatible, it will fa
 you what to do to resolve the issue.
 
 High Availability Startup Options
-=================================
+---------------------------------
 
 --static-ip (or the environment variable RS_STATIC_IP)
   Not specifically a high-availability startup option, if it is configured it must be different
@@ -83,15 +110,21 @@ High Availability Startup Options
 
 --ha-address (or the environment variable RS_HA_ADDRESS)
   This is the IP address and netmask of the virtual IP that the active cluster member will use
-  for communication.  It must be in CIDR format (aa.bb.cc.dd/xx)
+  for communication.  It must be in CIDR format (aa.bb.cc.dd/xx) when not using an external load
+  balancer, and a raw IP address when using an external load balancer.
 
 --ha-interface (or the environment variable RS_HA_INTERFACE)
   This is the Ethernet interface that the ha address should be added to and removed from when
-  dr-provision transitions between active and passive.
+  dr-provision transitions between active and passive.  Only applicable when not using an external
+  load balancer.
 
 --ha-passive (or the environment variable RS_HA_PASSIVE)
   This must be true on the nodes that should start as passive nodes by default.  In practice, this means
   every node after the initial node.
+
+--ha-join (or the environment variable RS_HA_JOIN)
+  The URL of the active node that should be contacted when starting replication as a passive node in
+  a synchronous replication cluster.  If not present, this defaults to https://$RS_HA_ADDRESS:$RS_API_PORT/
 
 --ha-token (or the environment variable RS_HA_TOKEN)
   This is the authentication token that HA nodes use to authenticate and communicate with each other.
@@ -120,14 +153,159 @@ High Availability Startup Options
   Customize to taste to suit your preferred method of getting authority to add and remove addresses
   to interfaces.
 
-Bootstrapping
+--ha-consensus-addr (or the environment variable RS_HA_CONSENSUS_ADDR)
+  This is the address:port that this node will use for all consensus traffic.  It must be accessible
+  by all the nodes that will participate in the cluster, and it will both originate TCP connections and listen
+  for incoming traffic on this address:port combination.
+
+ha-state.json
+~~~~~~~~~~~~~
+
+As of version 4.6.0, the ha-state.json file will be the proxy Source of Truth for all high availability
+settings.  Settings in ha-state.json take precedence over any from the commandline or environment, and they
+will be automatically updated as conditions change as a result of HA-related API requests and general cluster
+status changes.  A sample ha-state.json looks like this::
+
+    {
+      "ActiveUri": "",
+      "ApiUrl": "",
+      "ConsensusAddr": "",
+      "ConsensusEnabled": false,
+      "ConsensusID": "ab0f7bec-5c48-45c3-8970-b3543ec2e9d4",
+      "ConsensusJoin": "",
+      "Enabled": false,
+      "HaID": "",
+      "LoadBalanced": false,
+      "Observer": false,
+      "Passive": false,
+      "Roots": [],
+      "Token": "",
+      "Valid": true,
+      "VirtAddr": "",
+      "VirtInterface": "",
+      "VirtInterfaceScript": ""
+    }
+
+ActiveUrl
+---------
+
+ActiveUrl is the URL that external services and clients should use to talk to the dr-provision cluster.
+It is automatically populated when a cluster is created wither via API or by booting with the appropriate
+command-line options and a missing or invalid ha-state.json.  This setting must be the same across all
+members participating in a cluster, and in a consensus cluster that is enforced by the consensus protocol.
+
+ApiUrl
+------
+
+ApiUrl is the URL used to contact the current node.  It is automatically populated on every start of the current node.
+It is specific to an individual node.
+
+ConsensusAddr
 -------------
+
+ConsensusAddr is the address:port that all consensus traffic will go over on this node.  It is initially populated
+by the --ha-consensus-addr commandline flag.  It is specific to an individual node.
+
+ConsensusEnabled
+----------------
+
+ConsensusEnabled indicates whether this node can participate in a consensus cluster.  It is automatically set
+to true when ConsensusAddr is not empty.  It must be true on all nodes of a consensus cluster, but can be
+different when using synchronous replication.
+
+ConsensusID
+-----------
+
+ConsensusID is set when loading an invalid ha-state.json for the first time, and must not be changed afterwards.
+It is what the node uses to uniquely identify itself to other cluster nodes, and it must be unique.
+
+ConsensusJoin
+-------------
+
+ConsensusJoin is the URL for the current consensus cluster leader, if any.  It is automatically updated by
+the consensus replication protocol, and should not be manually edited.
+
+Enabled
+-------
+
+Enabled is set when either form of high availability is enabled on this node.  It corresponds to the --ha-enabled
+command line option.
+
+HaID
+----
+
+HaID is the shared high-availability ID of the cluster.  This setting must be the same across all
+members participating in a cluster, and in a consensus cluster that is enforced by the consensus protocol.
+It corresponds to the --ha-id commandline option.
+
+LoadBalanced
+------------
+
+LoadBalanced indicates that the HA address is managed by an external load balancer instead of by dr-provision.
+This setting must be the same across all members participating in a cluster, and in a consensus cluster that is
+enforced by the consensus protocol.  It coresponds to the --ha-load-balanced command line option.
+
+Observer
+--------
+
+Observer indicates that this node can participate in a consensus cluster, but cannot become the active dr-provision
+node.  It is intended to be set when you are setting up a server to act as a consensus tiebreaker, realtime backup,
+repoting endpoint, or similar use.
+
+Passive
+-------
+
+Passive indicates that this node is not the active node in the cluster.  All nodes but the current active
+node must be Passive, and in a consensus cluster that is enforced by the consensus replication protocol.
+It corresponds to the --ha-passive commandline option.
+
+Roots
+-----
+
+Roots is the list of current trust roots for the consensus protocol.  All consensus traffic is secured via TLS
+1.3 mutual authentication, and the self-signed certificates in this list are uses as the trust roots for that
+mutual auth process.  Individual trust roots are valid for 3 months, and are rotated every month.
+
+Token
+-----
+
+Token is the authentication token that can be used for nodes participating in the same cluster to talk to
+each other's APIs. In both cluster types, Token will be rotated on a regular basis.
+
+Valid
+-----
+
+Valid indicates that the state stored in ha-state.json is valid.  If state is not valid, it is populated with
+matching parameters from the command line options, otherwise it takes precedence over command line options.
+
+VirtAddr
+--------
+
+VirtAddr is the address that all external traffix to the cluster should sue to communicate to the cluster.
+If LoadBalanced is true, it should be a raw IP address, otherwise it should be a CIDR address in address/prefix
+form.  It must be the same on all nodes in a cluster, and corresponds to the --ha-address command line option.
+
+VirtInterface
+-------------
+
+If LoadBalanced is false, VirtInterface is the name of the network interface that VirtAddr will be added or
+removed from.  It is specific to each node, and corresponds to the --ha-interface commandline option.
+
+VirtInterfaceScript
+-------------------
+
+If present, this is the name of the script that will be run whenever we need to add or remove VirtAddr
+to VirtInterface.It is specific to each node, and corresponds to the --ha-interface-script commandline option.
+
+
+Bootstrapping Synchronous Replication
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 This bootstrapping documentation will assume that you are working with dr-provision running as a native service
 managed by systemd on a Linux server.
 
 The Initially Active Node
-=========================
+-------------------------
 
 To start bootstrapping an HA cluster, start by installing what you want to be the default active dr-provision node.
 Once it is up and running, create a file named /etc/systemd/system/dr-provision.service.d/20-ha.conf with
@@ -167,7 +345,7 @@ Once that file is created, reload the config and restart dr-provision::
 When dr-provision comes back up, it will be running on the IP address you set aside as the HA IP address.
 
 The Initially Passive Nodes
-===========================
+---------------------------
 
 WARNING: Do not start a passive endpoint(s) in "normal mode."  When installing a passive endpoint, the active
 endpoint _must_ be available when the endpoint is started.
@@ -213,17 +391,83 @@ To promote a passive endpoint to active
 .. note:: Prior to v4.5.0, Signals were used to shift state.  SIGUSR2 was used to go from active to passive and
   SIGUSR1 was used to go from passive to active.
 
-Install Video
--------------
+Bootstrapping Consensus via Raft (v4.6.0 and later)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-This video was created at the time of v4.3 beta: https://youtu.be/xM0Zr3iL5jQ.  Please check for more recent updates.
+In 4.6 and later, you can bootstrap, add nodes to, and remove nodes from a consensus cluster using `drpcli` without
+needing to stop nodes for manual reconfiguration or mess with systemd config files.
 
+Self-enroll the initial active node
+-----------------------------------
+
+To start the initial active node, you can use the `drpcli system ha enroll` command to have it
+enroll itself.  The form of the command to run is as follows::
+
+    drpcli system ha enroll $RS_ENDPOINT username password \
+        ConsensusAddr address:port \
+        Observer true/false \
+        VirtInterface interface \
+        VirtInterfaceScript /path/to/script \
+        HaId ha-identifier \
+        LoadBalanced true/false \
+        VirtAddr virtualaddr
+
+The last 3 of those settings can only be specified during self-enroll, and even then they can only be specified
+if the system you are self-enrolling is not already in a synchronous replication cluster.  You also can only specify
+VirtInterface and VirtInterfaceScript if LoadBalanced is false.  If any errors are returned during that call,
+they should be addressed and the command retried.  Once the command finished without error, the chosen system
+will be in a single node Raft cluster that is ready to have other nodes added to the cluster.
+
+Adding additional nodes
+-----------------------
+
+To add additional nodes to an existing cluster, you also use
+`drpcli system ha enroll` against the current active node in that cluster::
+
+    drpcli system ha enroll https://ApiURL_of_target target_username target_password \
+        ConsensusAddr address:port \
+        Observer true/false \
+        VirtInterface interface \
+        VirtInterfaceScript /path/to/script
+
+This will get the global HA settings from the active node in the cluster, merge those settings with the
+per-node settings from the target node and the rest of the settings passed in on the command line, and direct
+the target node to join the cluster using the merged configuration.
+
+**NOTE** The current data on the target node will be backed up, and once the target node has joined the
+cluster it will mirror all data from the existing cluster.  All backed up data will be inaccessible from that point.
+
+Other consensus commands
+------------------------
+
+`drpcli system ha` has several other commands that you can use to examine the state of consensus on a node.
+
+* `drpcli system ha active` will get the Consensus ID of the node that is currently responsible for
+  all client communication in a consensus cluster.  It is possible for this value to be unset if the
+  active node has failed and the cluster is deciding on a new active node.
+
+* `drpcli system ha dump` will dump the user-visible parts of the backing finite state machine that
+  is responsible for keeping track of the state of the cluster.
+
+* `drpcli system ha failOverSafe` will return true if there is at least one node in the cluster that
+  is completly up-to-date with the active node, and it will return false otherwise.  You can pass
+  a time to wait (up to 5 seconds) for the cluster to be fail over safe as an optional argument.
+
+* `drpcli system ha id` returns the Consensus ID of the node you are takling to.
+
+* `drpcli system ha leader` returns the Consensus ID of the current leader of the Raft cluster.  This can
+  be different than the active ID if the cluster is in the middle of determining which cluster member is
+  best suited to handling external cluster traffic.
+
+* `drpcli system ha peers` returns a list of all known cluster members.
+
+* `drpcli system ha state` returns the current HA state of an individual node.
 
 Troubleshooting
----------------
+~~~~~~~~~~~~~~~
 
 Log Verification
-================
+----------------
 
 It is normal to see ``Error during replication: read tcp [passive IP]:45786->[cluster IP]:8092: i/o timeout`` on the
 passive endpoints logs when the active endpoint is killed or switches to passive mode.  This is an indication that the
@@ -231,12 +475,12 @@ active endpoint has stopped sending updates.
 
 
 Transfer Start-up Time
-======================
+----------------------
 
 It may take up to a minute for a passive endpoint to come online after it has received ``-USR1`` signals.
 
 Network Interface Locked
-========================
+------------------------
 
 It is possible for the HA interface to become locked if you have to stop and restart the service during configuration
 testing.  To clear the interface, use ```ip addr del [ha ip] dev [ha interface]```
@@ -245,7 +489,7 @@ This happens because Digital Rebar is attaching to (and detaching from) the clus
 then the association may not be correctly removed.
 
 WAL File Checksums
-==================
+------------------
 
 When operating correctly, all the WAL files should match on all endpoints.  You can check the signature of the wal files
 using `hexdump -C`
@@ -258,7 +502,9 @@ For example:
     hexdump -C base.0 |less
 
 Active Endpoint File ha-state is Passive:true
-=============================================
+---------------------------------------------
+
+This only applies for Synchronous Replication, and not Consensus.
 
 Digital Rebar uses the ``ha-state.json`` file in it's root directory (typically ``/var/lib/dr-provision``) to track
 transitions from active to passive state.


### PR DESCRIPTION
This expands the HA documentation to include information on the
new raft-based consensus protocol, along with instructions on
bootstrapping a consensus cluster from a standalone server.