### PR TITLE
fix(race): Fix client panic on multiple Close()

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -139,6 +139,7 @@ func New(c *api.Client, m *models.Machine,
 		return nil, err
 	}
 	res.bootTime = bt
+	res.client.TokenRefresh("machines", m.UUID())
 	return res, nil
 }
 


### PR DESCRIPTION
The client can panic of Close() is called on it multiple times, which
can be the case if several independent routines are using the same api
CLient and they both close the Client as part of cleanup.  Fix the
issue be refactoring the code to use a Context for closing instead.

While we are at it, have the agent refresh its token on a regular
schedule.