### PR TITLE
fix(token): Make the background token refresh goroutine error tolerant.

### DIFF
--- a/cli/contents.go
+++ b/cli/contents.go
@@ -424,7 +424,7 @@ func registerContent(app *cobra.Command) {
 	})
 
 	// Bundlize - takes a list of objects and makes them a bundle - deleting them optionaly.- interactive.
-	var delete = false
+	var remove = false
 	var reload = false
 	bundlize := &cobra.Command{
 		Use:   "bundlize [file] [meta fields] [objects]",
@@ -544,7 +544,7 @@ func registerContent(app *cobra.Command) {
 			s.Close()
 
 			// delete the objects
-			if delete {
+			if remove {
 				deleteOrder := []string{
 					"machines",
 					"leases",
@@ -574,7 +574,7 @@ func registerContent(app *cobra.Command) {
 					}
 				}
 				if reload {
-					if err := replaceContent(target, key, delete); err != nil {
+					if err := replaceContent(target, key, remove); err != nil {
 						return err
 					}
 				}
@@ -582,7 +582,7 @@ func registerContent(app *cobra.Command) {
 			return nil
 		},
 	}
-	bundlize.Flags().BoolVar(&delete, "delete", false, "Delete bundlized content")
+	bundlize.Flags().BoolVar(&remove, "delete", false, "Delete bundlized content")
 	bundlize.Flags().BoolVar(&reload, "reload", false, "Load the bundle as a content package (requires delete)")
 	bundlize.Flags().StringVar(&key, "key", "", "Location to save key for embedded secure parameters")
 	content.AddCommand(bundlize)

--- a/cli/machines.go
+++ b/cli/machines.go
@@ -410,14 +410,14 @@ the stage runner wait flag.
 			if runContext == "" {
 				runContext = os.Getenv("RS_CONTEXT")
 			}
-			agent, err := agent.New(Session, m, oneShot, exitOnFailure, ActuallyPowerThings && !skipPower, os.Stdout)
+			agt, err := agent.New(Session, m, oneShot, exitOnFailure, ActuallyPowerThings && !skipPower, os.Stdout)
 			if err != nil {
 				return err
 			}
 			if oneShot {
-				agent = agent.Timeout(time.Second)
+				agt = agt.Timeout(time.Second)
 			}
-			return agent.StateLoc(runStateLoc).Context(runContext).Run()
+			return agt.StateLoc(runStateLoc).Context(runContext).Run()
 		},
 	}
 	processJobs.Flags().BoolVar(&exitOnFailure, "exit-on-failure", false, "Exit on failure of a task")

--- a/store/common.go
+++ b/store/common.go
@@ -77,17 +77,17 @@ func Open(locator string) (Store, error) {
 		return nil, fmt.Errorf("Unknown ro value %s. Try true or false", roParam)
 	}
 	var res Store
-	path := uri.Opaque
-	if path == "" {
-		path = uri.Path
+	urlPath := uri.Opaque
+	if urlPath == "" {
+		urlPath = uri.Path
 	}
 	switch uri.Scheme {
 	case "stack":
 		res = &StackedStore{}
 	case "file":
-		res = &File{Path: path}
+		res = &File{Path: urlPath}
 	case "directory":
-		res = &Directory{Path: path}
+		res = &Directory{Path: urlPath}
 	case "memory":
 		res = &Memory{}
 	}


### PR DESCRIPTION
Instead of bailing and killing the program when token refresh fails for
any reason, back off and try again up to 5 times with decreasing intervals,
and give up while closing the client if the final refresh fails.  This
should lead to better behaviour on intermittent communication failures
while still forcing things to exit eventually.