### PR TITLE
Added work-around to hard-coded drive letter for Windows drpcli

### DIFF
--- a/cli/machines.go
+++ b/cli/machines.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
@@ -23,7 +24,7 @@ func init() {
 	if DefaultStateLoc == "" {
 		switch runtime.GOOS {
 		case "windows":
-			DefaultStateLoc = `C:/Windows/System32/config/systemprofile/AppData/Local/rackn/drp-agent`
+			DefaultStateLoc = filepath.Join(os.Getenv("SYSTEMROOT"), `/System32/config/systemprofile/AppData/Local/rackn/drp-agent`)
 		default:
 			DefaultStateLoc = "/var/lib/drp-agent"
 		}


### PR DESCRIPTION
My attempt to resolve the hard-coded reference to the C: drive when installing the drpcli agent and providing the default state location. Using the path/filepath module since the Join function also fixes the slashes separating the folder names to whatever is appropriate for the underlying OS.
Instead of using a hard-coded reference to C:\Windows, I am  suggesting to replace it with whatever the value of the SYSTEMROOT environment variable is.