### PR TITLE
Two taskRunner improvement suggestions

### DIFF
--- a/agent/taskRunner.go
+++ b/agent/taskRunner.go
@@ -179,6 +179,7 @@ func (r *runner) perform(action *models.JobAction, taskDir string) error {
 		cmdArray = append(cmdArray, interp)
 	} else if strings.HasSuffix(taskFile, "ps1") {
 		cmdArray = append(cmdArray, "powershell.exe")
+		cmdArray = append(cmdArray, "-ExecutionPolicy Bypass")
 		cmdArray = append(cmdArray, "-File")
 	}
 	cmdArray = append(cmdArray, "./"+path.Base(taskFile))

--- a/agent/taskRunner.go
+++ b/agent/taskRunner.go
@@ -181,6 +181,9 @@ func (r *runner) perform(action *models.JobAction, taskDir string) error {
 		cmdArray = append(cmdArray, "powershell.exe")
 		cmdArray = append(cmdArray, "-ExecutionPolicy Bypass")
 		cmdArray = append(cmdArray, "-File")
+	} else if strings.HasSuffix(taskFile, ".cmd") || strings.HasSuffix(taskFile, ".bat") {
+		cmdArray = append(cmdArray, "cmd.exe")
+		cmdArray = append(cmdArray, "/c")
 	}
 	cmdArray = append(cmdArray, "./"+path.Base(taskFile))
 	home := os.Getenv("HOME")

--- a/cli/machines.go
+++ b/cli/machines.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"time"
@@ -23,7 +24,7 @@ func init() {
 	if DefaultStateLoc == "" {
 		switch runtime.GOOS {
 		case "windows":
-			DefaultStateLoc = `C:/Windows/System32/config/systemprofile/AppData/Local/rackn/drp-agent`
+			DefaultStateLoc = filepath.Join(os.Getenv("SYSTEMROOT"), `/System32/config/systemprofile/AppData/Local/rackn/drp-agent`)
 		default:
 			DefaultStateLoc = "/var/lib/drp-agent"
 		}


### PR DESCRIPTION
Made two improvements to the agent's taskRunner:
- Added an execution policy parameter to the PowerShell command line arguments to temporarily override the execution policy settings of the machine while running the script. That way the agent will be able to execute PowerShell scripts without running afoul of any policies set on the machine.
[Microsoft Docs: about_Execution_Policies](https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_execution_policies)
- Added support for Windows Batch files with the .cmd/.bat extensions.