### PR TITLE
Two improvement suggestions for the taskRunner functions with regard to Windows

### DIFF
--- a/agent/taskRunner.go
+++ b/agent/taskRunner.go
@@ -179,6 +179,7 @@ func (r *runner) perform(action *models.JobAction, taskDir string) error {
 		cmdArray = append(cmdArray, interp)
 	} else if strings.HasSuffix(taskFile, "ps1") {
 		cmdArray = append(cmdArray, "powershell.exe")
+		cmdArray = append(cmdArray, "-ExecutionPolicy Bypass")
 		cmdArray = append(cmdArray, "-File")
 	}
 	cmdArray = append(cmdArray, "./"+path.Base(taskFile))

--- a/agent/taskRunner.go
+++ b/agent/taskRunner.go
@@ -181,6 +181,9 @@ func (r *runner) perform(action *models.JobAction, taskDir string) error {
 		cmdArray = append(cmdArray, "powershell.exe")
 		cmdArray = append(cmdArray, "-ExecutionPolicy Bypass")
 		cmdArray = append(cmdArray, "-File")
+	} else if strings.HasSuffix(taskFile, ".cmd") || strings.HasSuffix(taskFile, ".bat") {
+		cmdArray = append(cmdArray, "cmd.exe")
+		cmdArray = append(cmdArray, "/c")
 	}
 	cmdArray = append(cmdArray, "./"+path.Base(taskFile))
 	home := os.Getenv("HOME")

--- a/agent/taskRunner.go
+++ b/agent/taskRunner.go
@@ -179,7 +179,8 @@ func (r *runner) perform(action *models.JobAction, taskDir string) error {
 		cmdArray = append(cmdArray, interp)
 	} else if strings.HasSuffix(taskFile, "ps1") {
 		cmdArray = append(cmdArray, "powershell.exe")
-		cmdArray = append(cmdArray, "-ExecutionPolicy Bypass")
+		cmdArray = append(cmdArray, "-ExecutionPolicy")
+		cmdArray = append(cmdArray, "Bypass")
 		cmdArray = append(cmdArray, "-File")
 	} else if strings.HasSuffix(taskFile, ".cmd") || strings.HasSuffix(taskFile, ".bat") {
 		cmdArray = append(cmdArray, "cmd.exe")

--- a/agent/taskRunner.go
+++ b/agent/taskRunner.go
@@ -182,11 +182,11 @@ func (r *runner) perform(action *models.JobAction, taskDir string) error {
 		cmdArray = append(cmdArray, "-ExecutionPolicy")
 		cmdArray = append(cmdArray, "Bypass")
 		cmdArray = append(cmdArray, "-File")
-	} else if strings.HasSuffix(taskFile, ".cmd") || strings.HasSuffix(taskFile, ".bat") {
-		cmdArray = append(cmdArray, "cmd.exe")
+	} else if strings.HasSuffix(taskFile, "cmd") || strings.HasSuffix(taskFile, "bat") {
+		cmdArray = append(cmdArray, os.Getenv("ComSpec"))
 		cmdArray = append(cmdArray, "/c")
 	}
-	cmdArray = append(cmdArray, "./"+path.Base(taskFile))
+	cmdArray = append(cmdArray, filepath.FromSlash("./"+path.Base(taskFile)))
 	home := os.Getenv("HOME")
 	if home == "" {
 		home = r.agentDir


### PR DESCRIPTION
This pull request contains two suggestions to the taskRunner functions:
- It adds support for the `ExecutionPolicy` parameter to allow the drpcli agent to run PowerShell scripts, even if the machine's execution policy settings require that scripts be digitally signed. This approach does not change the machine's configuration and only applies to the specific script being executed as part of the task.
- This commit adds support for Windows batch scripts with the file extensions of `.bat` and `.cmd`.

This commit does make a change to the way the task file itself is being added the to CommandContext which affects all currently supported operating systems. The reason for this is that Linux and Windows use different folder separators in file paths. By using the `filepath.FromSlash` function, it will now use the correct separator compatible with the underlying operating system. _This was validated on both Linux and Windows_.