### PR TITLE
fix(patch): More detailed patch errors

### DIFF
--- a/api/bootenv_test.go
+++ b/api/bootenv_test.go
@@ -462,7 +462,7 @@ Templates:
 			Type:  "PATCH",
 			Messages: []string{
 				"Patch error at line 0: Test op failed.",
-				"Patch line: {\"op\":\"test\",\"path\":\"/OS/Name\",\"from\":\"\",\"value\":\"ffred\"}",
+				"Patch: [\n  {\n    \"op\": \"test\",\n    \"path\": \"/OS/Name\",\n    \"from\": \"\",\n    \"value\": \"ffred\"\n  },\n  {\n    \"op\": \"replace\",\n    \"path\": \"/OS/Name\",\n    \"from\": \"\",\n    \"value\": \"qfred\"\n  }\n]",
 			},
 			Code: 409,
 		},


### PR DESCRIPTION
Patch errors from dr-provision now include the full patch, instead of
just the patch line.