### PR TITLE
doc(provision): update advance release notes, tweak api docs

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -10,9 +10,30 @@
 Digital Rebar Provision API
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-In general, the Digital Rebar Provision API is documented via the Swagger spec and introspectable for machines via `/swagger.json` and for humans via `/swagger-ui`.  See :ref:`rs_swagger`.
-
 All API calls are available under `/api/v3` based on the Digital Rebar API convention.
+
+.. _rs_api_swagger:
+
+API Call Documentation (swagger.json)
+-------------------------------------
+
+Digital Rebar API documentation is dynamically generated an with each Digital Rebar endpoint in the form of a ``swagger.json`` file.
+
+The Swagger specification file is introspectable for clients via `[endpoint url]/swagger.json` and for humans via the Swagger UX built into all DRP endpoints at `[endpoint url]/swagger-ui`.
+
+For more details, see :ref:`rs_swagger`.
+
+.. _rs_api_patch:
+
+API PUT vs PATCH
+----------------
+
+RackN strongly recommends API consumers to use PATCH wherever possible instead of PUT.
+PATCH allows API calls to change specific object fields and may include tests to prevent race conditions.
+
+For example, the :ref:`rs_drpcli` and RackN UX use JSON PATCH (https://tools.ietf.org/html/rfc6902) instead of PUT extensively.  PATCH allows atomic field-level updates by including tests in the update.  This means that simulataneous upates do not create "last in" race conditions.  Instead, the update will fail in a predictable way that can be used in scripts.
+
+The DRPCLI facilitates use of PATCH for atomic operations by allowing scripts to pass in a reference (aka pre-modified) object.  If the ``-r`` reference object does not match then the update will be rejected.
 
 .. _rs_api_filters:
 
@@ -93,7 +114,12 @@ You can also interact with the API using ``curl``.  The general pattern is:
 
   ::
 
+    # option 1: basic auth user:password
     curl -X <method> -k -u <username>:<password> -H `Content-Type: application/json' -H 'Accept: application/json' https://<endpoint addr>:<port>/api/v3/<opject type>/<object ID>
+
+    # option 2: basic auth with token 
+    export RS_TOKEN=$(drpcli -P <password> users token <username>)
+    curl -X <method> -k --header 'Authorization: Basic $RS_TOKEN' -H `Content-Type: application/json' -H 'Accept: application/json' https://<endpoint addr>:<port>/api/v3/<opject type>/<object ID>
 
 In the remainder of this section, <object type> refers to the lower case, pluralized version of the type of object.  This is `bootenvs` for boot environments, `workflows` for workflows, `machines` for machines, and so on.
 <object id> refers to the unique identifier for this object, which is generally the `Name`, `ID` or `Uuid` field of an object.  You can also use any unique index in this field, in the form of `<index name>:<value>`.
@@ -110,6 +136,7 @@ The API follows the usual REST guidelines:
 * HEAD /spi/v3/<object type>/<object id> tests to see if the requested object exists.
 
 .. _rs_api_notes:
+
 
 API Exception & Deprecation Notes
 ---------------------------------

--- a/doc/cli/drpcli.rst
+++ b/doc/cli/drpcli.rst
@@ -1,5 +1,13 @@
-drpcli
-------
+.. Copyright (c) 2021 RackN Inc.
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. Digital Rebar Provision documentation under Digital Rebar master license
+.. index::
+  pair: Digital Rebar Provision; CLI
+
+.. _rs_drpcli:
+
+Digital Rebar CLI (drpcli)
+--------------------------
 
 A CLI application for interacting with the DigitalRebar Provision API
 

--- a/doc/operations/drpcli.rst
+++ b/doc/operations/drpcli.rst
@@ -7,7 +7,7 @@
 Using the ``drpcli`` tool
 +++++++++++++++++++++++++
 
-.. note:: **drpcli** normally spits out JSON formatted objects or an array of objects.  To help with some of the command line functions, we use the **jq** tool.  This is available for both Linux and Darwin.  You can specify output format to be YAML, with the ``--format=yaml`` flag.
+.. note:: **drpcli** normally outputs JSON formatted objects or an array of objects.  To help with some of the command line functions, we use the **jq** tool.  This is available for both Linux and Darwin.  You can specify output format to be YAML, with the ``--format=yaml`` flag.
 
 In this doc we will assume that ``drpcli`` is already somewhere in the path and have setup the environment variables to access Digital Rebar Provision.  See, :ref:`rs_cli`.
 
@@ -41,7 +41,7 @@ Would be equivalent to the HTTP REST API resource as follows:
 
   ::
 
-    https://127.0.0.1:8092/api/v3/templates/ereate
+    https://127.0.0.1:8092/api/v3/templates/create
 
 .. note:: See the :ref:`rs_autocomplete` for BASH shell auto completion.
 

--- a/doc/rel_notes/summaries/release_v47.rst
+++ b/doc/rel_notes/summaries/release_v47.rst
@@ -11,9 +11,9 @@
 Digital Rebar version 4.7 [in process]
 --------------------------------------
 
-Release Date: expected July 2021
+Release Date: early August 2021
 
-Release Themes: Usability, Universal Workflow UX, Cloud Usecase
+Release Themes: 
 
 In addition to bug fixes and performance improvements, the release includes several customer-driven features.
 
@@ -48,28 +48,106 @@ The following items are flagged as deprecated in v4.5 and are removed in v4.7.
 * old pattern cluster synchronization with cluster-add, cluster-step and cluster-sync.  Operators should migrate to the new `cluster-manager` patterns.
 
 
-Universal Workflow UX Helpers
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+.. _rs_release_v47_rocky:
 
-The components of Universal Workflow are all included the the v4.6 release.  v4.7 will include UX tools that help make the feature more accessible.
+Rocky and Alma Linux in Universal Workflow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Consolidated BootEnvs
-~~~~~~~~~~~~~~~~~~~~~
+With the transition to Centos Streams, we've added alternatives for two new Centos adjacent distros: Rocky and Alma linux.
+For operators concerned about long term stability for Centos, these should offer a reliable open alternative.
 
-Integrated Billing
-~~~~~~~~~~~~~~~~~~
+These are available as applications and pre-defined profiles in Universal Workflows.
 
-Hardware Support
-~~~~~~~~~~~~~~~~
+.. _rs_release_v47_ux_improvements:
 
-* LPAR
-* Super Micro
+Table Refactor for RackN Portal UX (tech preview)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+The v4.8 release will include significant improvements to the table and panel displays for the UX.  significant effort was made to ensure minimal relearning effort for existing operators.
+
+This update provides long requested features including:
+
+* resizable columns for all views
+* stable column sizing (will not change size as data is changed)
+* panels can be resized
+* panels remain open and can be changed by selecting different rows
+* improved filter usability (moves to top of page)
+* improved performance and scalability for >10,000 machine customers
+* dramatically reduced Digital Rebar API load based on better use of local cache
+
+This work is available as a preview from https://tip.rackn.io.  Advanced operators are asked to use this version for testing and feedback.
+
+As usual, the updated UX maintains compatability with all v4.x versions of Digital Rebar.
+
+.. _rs_release_v47_hardware:
+
+Firmware & Hardware Support
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The following hardware OEMs and generalized tooling was added.
+
+.. _rs_release_v47_firmware:
+
+Generalized Firmware Update Process
+-----------------------------------
+
+Firmware support for SuperMicro (see below) was provided in a generalized way will be used for other OEMs.
+
+At this time, no existing OEMs have been migrated to use this new process.
+
+.. _rs_release_v47_lpar:
+
+IBM LPAR (Logical Partitions)
+-----------------------------
+
+Allows Digital Rebar to manage LPAR VMs.  This brings control of the LPAR VM inline with physical infrastructure processes.
+
+See: https://www.ibm.com/docs/en/zos-basic-skills?topic=design-mainframe-hardware-logical-partitions-lpars
+
+.. _rs_release_v47_supermicro:
+
+SuperMicro
+-----------
+
+Redfish BMC, firmware and RAID configuration of SuperMicro hardware.
+
+.. _rs_release_v47_bootp:
+
+BOOTP Support
+~~~~~~~~~~~~~
+
+Before there was PXE, there was BOOTP for provisioning!  Digital Rebar now supports BOOTP;
+however this feature requires use of Reservations.
+
+.. _rs_release_v47_terraform:
+
+Terraform and Cloud-Wrapper Updates
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Cloud Wrapper templates were updated to enable better integration into universal workflow
+and simplify importing existing Terraform plans.
+
+1. to use cloud-init instead of relying on Ansible for join-up.
+2. to allow creating many machines from a single plan (uses cluster/profile)
+3. improve controls after Terraform created instances
+4. improve synchronization after Terraform destroys instances
+
+.. _rs_release_v47_bootenv:
+
+Implementation of Profile/Param Overrides for BootEnvs
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Addition of the ``bootenv-customize`` parameter in v4.6 allowed operators to overlay dynamic customizations
+on top of BootEnvs.  This feature was intended to reduce the number of BootEnvs maintained in the system.
+
+Digital Rebar v4.7 included a render helper to make this process easier to apply.  The ESXi BootEnv has
+been updated to use this feature.
+
+Universal Workflow BootEnvs will leverage this feature.
 
 .. _rs_release_v47_otheritems:
 
 Other Items of Note
 ~~~~~~~~~~~~~~~~~~~
 
-* UX
-* BOOTP Support
+* TBD

--- a/doc/rel_notes/summaries/release_v48.rst
+++ b/doc/rel_notes/summaries/release_v48.rst
@@ -8,12 +8,12 @@
 
 .. _rs_release_v48:
 
-Digital Rebar version 4.8 [planned]
------------------------------------
+Digital Rebar version 4.8 [in process]
+--------------------------------------
 
-Release Date: unknown
+Release Date: October 2021
 
-Release Themes: TBS
+Release Themes: Usability, Universal Workflow UX, Cloud Usecase
 
 In addition to bug fixes and performance improvements, the release includes several customer-driven features.
 
@@ -43,36 +43,52 @@ None known
 Removals
 ++++++++
 
-The following items are flagged as deprecated in v4.5 and were removed in v4.8.
-
-* old pattern cluster synchronization with cluster-add, cluster-step and cluster-sync.  Operators should migrate to the new cluster-gate-* patterns.
+None known
 
 
 FEATURE TBD
 ~~~~~~~~~~~
 
-Asynch Actions
-~~~~~~~~~~~~~
+.. _rs_release_v48_secrets:
 
-May slip to v4.8
+External Secrets
+~~~~~~~~~~~~~~~~
 
-Restricted Access ISOs
-~~~~~~~~~~~~~~~~~~~~~~
+Extend the Digital Rebar parameters to dynamically retrieve information from external sources.
 
-Planned, not committed
+.. _rs_release_v48_pipelines:
 
+UX for Infrastructure Pipelines / Universal Workflow
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Integrated Simple DNS
-~~~~~~~~~~~~~~~~~~~~~
+Enhance RackN Portal UX to provide additional user guidance for Universal Workflow components.
 
-Planned, not committed
+.. _rs_release_v48_workunits:
 
+WorkUnits / AsynchActions (Preview)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+Create a new operational mode for the Digital Rebar runner that allows tasks to be perforemed
+asynchronusly outside of Workflows.  This allows machines to be addressed 
+
+.. _rs_release_v48_ux:
+
+Table Refactor for RackN Portal UX
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Release in v4.8.  Preview in v4.7, See :ref:`_rs_release_v47_ux_improvements` for details.
+
+.. _rs_release_v48_vmware:
+
+VMware Cluster Building
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Beyond ESXi installation, Digital Rebar will coordinate cluster building activities for completed
+vCenter build out including VSAN, NSX-T using vmware lib and other tools.
 
 .. _rs_release_v48_otheritems:
 
 Other Items of Note
 ~~~~~~~~~~~~~~~~~~~
 
-* UX
-  * TBD
+* TBD

--- a/doc/rel_notes/summaries/release_v49.rst
+++ b/doc/rel_notes/summaries/release_v49.rst
@@ -1,0 +1,74 @@
+.. Copyright (c) 2010 RackN Inc.
+.. Licensed under the Apache License, Version 2.0 (the "License");
+.. Digital Rebar Provision documentation under Digital Rebar master license
+.. index::
+  pair: Digital Rebar Provision; Release v4.9
+  pair: Digital Rebar Provision; Release Notes
+
+.. _rs_release_v49:
+
+Digital Rebar version 4.9 [plannning]
+-------------------------------------
+
+Release Date: Early 2022
+
+Release Themes: TBD
+
+In addition to bug fixes and performance improvements, the release includes several customer-driven features.
+
+See :ref:`rs_release_summaries` for a complete list of all releases.
+
+.. _rs_release_v49_notices:
+
+Important Notices
+~~~~~~~~~~~~~~~~~
+
+.. _rs_release_v49_vulns:
+
+Vulnerabilities
++++++++++++++++
+
+None known
+
+.. _rs_release_v49_deprecations:
+
+Deprecations
+++++++++++++
+
+None known
+
+.. _rs_release_v49_removals:
+
+Removals
+++++++++
+
+None known
+
+FEATURES
+~~~~~~~~
+
+Integrated Billing
+~~~~~~~~~~~~~~~~~~
+
+May be pulled forward into v4.7 or v4.8
+
+
+Restricted Access ISOs
+~~~~~~~~~~~~~~~~~~~~~~
+
+Planned, not committed
+
+
+Integrated Simple DNS
+~~~~~~~~~~~~~~~~~~~~~
+
+Planned, not committed
+
+
+.. _rs_release_v49_otheritems:
+
+Other Items of Note
+~~~~~~~~~~~~~~~~~~~
+
+* UX
+  * TBD


### PR DESCRIPTION
Roadmap updates for v4.7+
Clarify API uses Swagger for docs.