### PR TITLE
fix(flags) Start standardizing on hyphenated flags.

### DIFF
--- a/cli/startup.go
+++ b/cli/startup.go
@@ -361,7 +361,7 @@ It also has several environment variables that control aspects of its operation:
 		"trace", "t", "",
 		"The log level API requests should be logged at on the server side")
 	app.PersistentFlags().StringVarP(&traceToken,
-		"traceToken", "Z", "",
+		"trace-token", "Z", "",
 		"A token that individual traced requests should report in the server logs")
 	app.PersistentFlags().StringVarP(&catalog,
 		"catalog", "c", defaultCatalog,
@@ -370,14 +370,31 @@ It also has several environment variables that control aspects of its operation:
 		"download-proxy", "D", defaultDownloadProxy,
 		"HTTP Proxy to use for downloading catalog and content")
 	app.PersistentFlags().BoolVarP(&noToken,
-		"noToken", "x", noToken,
+		"no-token", "x", noToken,
 		"Do not use token auth or token cache")
 	app.PersistentFlags().BoolVarP(&objectErrorsAreFatal,
-		"exitEarly", "X", false,
+		"exit-early", "X", false,
 		"Cause drpcli to exit if a command results in an object that has errors")
 	app.PersistentFlags().StringVarP(&urlProxy,
 		"url-proxy", "u", defaultUrlProxy,
 		"URL Proxy for passing actions through another DRP")
+	// Flags deprecated due to standardizing on all hyphenated form for persistent flags.
+	// TODO do the same thing for flags defined by commands
+	app.PersistentFlags().StringVar(&traceToken,
+		"traceToken", "",
+		"A token that individual traced requests should report in the server logs")
+	app.PersistentFlags().BoolVar(&noToken,
+		"noToken", noToken,
+		"Do not use token auth or token cache")
+	app.PersistentFlags().BoolVar(&objectErrorsAreFatal,
+		"exitEarly", false,
+		"Cause drpcli to exit if a command results in an object that has errors")
+	app.PersistentFlags().MarkHidden("traceToken")
+	app.PersistentFlags().MarkDeprecated("traceToken", "please use --trace-token")
+	app.PersistentFlags().MarkHidden("noToken")
+	app.PersistentFlags().MarkDeprecated("noToken", "please use --no-token")
+	app.PersistentFlags().MarkHidden("exitEarly")
+	app.PersistentFlags().MarkDeprecated("exitEarly", "please use --exit-early")
 	if runtime.GOOS != "windows" {
 		app.AddCommand(&cobra.Command{
 			Use:   "proxy [socket]",

--- a/cli/test-data/output/TestCorePieces/gohai.0c113ca6d57519b559ba5a426be3c6b6/stdout.expect
+++ b/cli/test-data/output/TestCorePieces/gohai.0c113ca6d57519b559ba5a426be3c6b6/stdout.expect
@@ -12,18 +12,18 @@ Global Flags:
   -d, --debug                   Whether the CLI should run in debug mode
   -D, --download-proxy string   HTTP Proxy to use for downloading catalog and content
   -E, --endpoint string         The Digital Rebar Provision API endpoint to talk to (default "https://127.0.0.1:10001")
-  -X, --exitEarly               Cause drpcli to exit if a command results in an object that has errors
+  -X, --exit-early              Cause drpcli to exit if a command results in an object that has errors
   -f, --force                   When needed, attempt to force the operation - used on some update/patch calls
   -F, --format string           The serialization we expect for output.  Can be "json" or "yaml" or "text" or "table" (default "json")
   -N, --no-color                Whether the CLI should output colorized strings
   -H, --no-header               Should header be shown in "text" or "table" mode
-  -x, --noToken                 Do not use token auth or token cache
+  -x, --no-token                Do not use token auth or token cache
   -P, --password string         password of the Digital Rebar Provision user (default "r0cketsk8ts")
   -J, --print-fields string     The fields of the object to display in "text" or "table" mode. Comma separated
   -r, --ref string              A reference object for update commands that can be a file name, yaml, or json blob
   -T, --token string            token of the Digital Rebar Provision access
   -t, --trace string            The log level API requests should be logged at on the server side
-  -Z, --traceToken string       A token that individual traced requests should report in the server logs
+  -Z, --trace-token string      A token that individual traced requests should report in the server logs
   -j, --truncate-length int     Truncate columns at this length (default 40)
   -u, --url-proxy string        URL Proxy for passing actions through another DRP
   -U, --username string         Name of the Digital Rebar Provision user to talk to (default "rocketskates")


### PR DESCRIPTION
Deprecate and hide the camelCased persistent flags.  This should also
be done for the per-command flags.